### PR TITLE
Add prepared statements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ version = VERSION
 group = 'covesoftware'
 
 
-build.finalizedBy(publishToMavenLocal) 
+build.finalizedBy(publishToMavenLocal)
 publishing {
         publications {
             maven(MavenPublication) {
@@ -27,22 +27,22 @@ repositories {
     mavenLocal()
     mavenCentral()
     jcenter()
- 
+
 }
- 
+
 task downloadDeps {
     project.mkdir("${buildDir}/downloaded")
     def f = new File("${buildDir}/downloaded/Cobra.jar")
     if(!f.exists()){
         new URL("https://github.com/lobobrowser/Cobra/releases/download/1.0.2/Cobra.jar").withInputStream{ i -> f.withOutputStream{ it << i }}
-    }    
+    }
 }
 
 compileJava.dependsOn downloadDeps
 
-dependencies {    
+dependencies {
     implementation 'com.oracle.ojdbc:ojdbc8:19.3.0.0'
-    implementation 'postgresql:postgresql:42.2.14'
+    implementation 'org.postgresql:postgresql:42.2.23'
     implementation 'asm:asm:3.3'
     implementation 'cglib:cglib:2.1_3'
     implementation 'commons-logging:commons-logging:1.0.4'
@@ -55,14 +55,18 @@ dependencies {
     implementation 'jfree:jfreechart:1.0.13'
     implementation 'org.python:jython:2.7.2'
     implementation 'org.jooq:jooq:3.11.2'
-    implementation 'org.lobobrowser:LoboBrowser:1.0.0'            
-    //implementation 'lobobrowser:Cobra:1.0.2@jar' //NOTE fix once lobo gets this up on a artifact repository 
+    implementation 'org.lobobrowser:LoboBrowser:1.0.0'
+    //implementation 'lobobrowser:Cobra:1.0.2@jar' //NOTE fix once lobo gets this up on a artifact repository
     implementation fileTree( dir: "${buildDir}/downloaded/", include: "*.jar" )
-    // this was org.nfunk; there appears to have been a change in management        
+    // this was org.nfunk; there appears to have been a change in management
     implementation( 'org.scijava:jep:2.4.1' ) {
         exclude group: "jama", module: "jama"
-        
+
     }
+
+    compileOnly fileTree(dir: "$projectDir/cwmsDbApi")
+    compileOnly fileTree(dir: "$projectDir/cwmsSystemJars")
+
     implementation "gov.nist.math:jama:1.0.2"
     implementation 'io.dropwizard.metrics:metrics-core:4.1.0-rc2'
     implementation 'org.passay:passay:1.3.1'
@@ -73,8 +77,8 @@ dependencies {
 
     implementation fileTree(dir:'cwmsDbApi/', include:'*.jar');
     implementation files("${System.getProperty('java.home')}/../lib/tools.jar")
-    
-    izpack 'org.codehaus.izpack:izpack-standalone-compiler:4.3.5'    
+
+    izpack 'org.codehaus.izpack:izpack-standalone-compiler:4.3.5'
 
     testRuntimeOnly 'org.junit:junit:4.8.1'
 }
@@ -84,14 +88,14 @@ import org.apache.tools.ant.filters.ReplaceTokens
 /*https://stackoverflow.com/questions/30038540/replace-token-in-file-before-building-but-keep-token-in-sources
 (Anwser by Aaron)
 
-This does slow down the build somewhat, but it was the cleanest 
+This does slow down the build somewhat, but it was the cleanest
 quick way I could find to replace the behavoir.
-There were a log of suggestion to replace modifiing the 
+There were a log of suggestion to replace modifiing the
 java with creating a properties file that gets changed.
  */
 task processSource(type: Sync ){
     from sourceSets.main.java
-    inputs.property 'RCNUM', RCNUM    
+    inputs.property 'RCNUM', RCNUM
     inputs.property 'DATE', DATE
     filter(ReplaceTokens, tokens: ['RCNUM': RCNUM, 'DATE': DATE])
     into "$buildDir/src"
@@ -103,8 +107,8 @@ compileJava {
 
 import org.apache.tools.ant.filters.*;
 task stage( type: Copy ){
-    dependsOn jar 
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE   
+    dependsOn jar
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     from('install'){
         into ""
         exclude "lrgs/**", "bin/**"
@@ -112,24 +116,24 @@ task stage( type: Copy ){
 
     from('install'){
         into ""
-        include "bin/**bat"                
+        include "bin/**bat"
     }
 
     from('install/bin'){
-        into "bin/"        
-        exclude ".*\\.bat"        
-        eachFile { details -> details.file.setExecutable(true) }        
+        into "bin/"
+        exclude ".*\\.bat"
+        eachFile { details -> details.file.setExecutable(true) }
         filter( FixCrLfFilter.class, eol:FixCrLfFilter.CrLf.newInstance("lf") )
     }
-         
+
     from('install/lrgs'){
         into ""
     }
 
     from("${buildDir}/libs/"){
-        include '*.jar' 
-        into "bin"      
-        rename("opendcs.*",'opendcs.jar')  
+        include '*.jar'
+        into "bin"
+        rename("opendcs.*",'opendcs.jar')
     }
 
     from(configurations.runtimeClasspath){
@@ -149,7 +153,7 @@ task stage( type: Copy ){
         include "**/*.xml"
         into 'imports/comp-cwms'
     }
-        
+
     from("${projectDir}/doc"){
         include "*.pdf", "algorithms.txt"
         into "doc"
@@ -159,19 +163,19 @@ task stage( type: Copy ){
 
     from("${projectDir}/schema")  {
         into 'schema'
-    }  
+    }
     from("${projectDir}/python") {
         into 'python'
     }
 
     from("${projectDir}/cwmsDbAPI"){
         into 'cwmsDbAPI'
-    }   
+    }
 
     from("izpack")
     into("${buildDir}/stage")
 
-    
+
 
     doLast{
         mkdir "$buildDir/stage/lib"
@@ -181,7 +185,7 @@ task stage( type: Copy ){
         mkdir "$buildDir/stage/edit-db/platform"
         mkdir "$buildDir/stage/edit-db/routing"
         mkdir "$buildDir/stage/edit-db/site"
-        
+
     }
 }
 
@@ -201,10 +205,10 @@ task opentsdb(type: com.bmuschko.gradle.izpack.CreateInstallerTask) {
     dependsOn stage
     doFirst{
         delete "${buildDir}/stage/dep/NWIS.jar"
-        
+
 
     }
-    
+
         baseDir = file("$buildDir/stage")
         installFile = file("$buildDir/stage/opendcs-6-7.xml")
         outputFile = file("$buildDir/opendcs-ot-${VERSION}.jar")
@@ -212,7 +216,7 @@ task opentsdb(type: com.bmuschko.gradle.izpack.CreateInstallerTask) {
         compressionLevel = 9
         appProperties = ['app.group': "$group", 'app.name': 'opendcs', 'app.title': 'OpenDCS',
                         'app.version': VERSION, 'app.subpath': "OpenDCS-$VERSION"]
-    
+
 }
 
 
@@ -221,6 +225,6 @@ task cwmstar( type: Tar){
 
     archiveFileName = "${buildDir}/opendcs-cwms-${VERSION}.tgz"
     compression = Compression.GZIP
-    
+
 
 }

--- a/build.xml
+++ b/build.xml
@@ -62,7 +62,7 @@ can find your git source tree and your directory with the downloaded jars.
 		<filterchain><striplinebreaks/></filterchain>
 	</loadfile>
 	<echo message="RCNUM=${RCNUM}"/>
-	
+
 	<path id="lib.path">
 		<fileset dir="${izpack.dir}/lib" includes="*.jar"/>
 	</path>
@@ -161,7 +161,7 @@ can find your git source tree and your directory with the downloaded jars.
             </filterset>
         </copy>
 		<javac debug="true" destdir="${build.classes}"
-			target="1.6" source="1.6"
+			target="1.8" source="1.8"
 			includeantruntime="true"
 			includes="lrgs/gui/LrgsBuild.java">
 			<src path="${build.classes}"/>
@@ -169,7 +169,7 @@ can find your git source tree and your directory with the downloaded jars.
 		</javac>
 
 		<javac debug="true" destdir="${build.classes}"
-			target="1.6" source="1.6"
+			target="1.8" source="1.8"
 			includeantruntime="true"
 			includes="decodes/**,ilex/**,lrgs/**,lritdcs/**,opendcs/**,covesw/**">
 			<src path="${src.dir}"/>
@@ -196,7 +196,7 @@ can find your git source tree and your directory with the downloaded jars.
 			</fileset>
 		</copy>
 
-		<jar jarfile="${dist.jar}" 
+		<jar jarfile="${dist.jar}"
 		     basedir="${build.classes}"
 			 update="true"/>
 	</target>
@@ -253,7 +253,7 @@ can find your git source tree and your directory with the downloaded jars.
 			</tarfileset>
 		</tar>
 
-		<copy todir="stage/bin">			
+		<copy todir="stage/bin">
 			<fileset dir="${project.dir}/install/bin"/>
 			<fileset dir="build/lib">
 				<include name="opendcs.jar"/>
@@ -474,7 +474,7 @@ can find your git source tree and your directory with the downloaded jars.
 	</path>
 
 	<target name="dcpmon" depends="jar">
-		
+
 		<mkdir dir="stage/dcpmon-build"/>
 		<mkdir dir="stage/dcpmon-build/war-distro"/>
 		<copy todir="stage/dcpmon-build/war-distro">
@@ -493,14 +493,14 @@ can find your git source tree and your directory with the downloaded jars.
 		</javac>
 		<copy todir="stage/dcpmon-build" file="${dcpmon.dir}/install/makeDcpmon.sh"/>
 		<copy todir="stage/dcpmon-build" file="${dcpmon.dir}/install/README"/>
-		<tar tarfile="stage/dcpmon-build-6-8-${RCNUM}.tgz" 
+		<tar tarfile="stage/dcpmon-build-6-8-${RCNUM}.tgz"
 			basedir="stage"
 			includes="dcpmon-build/**"
 			compression="gzip"/>
 	</target>
 
 	<target name="hydrojson" depends="jar">
-		
+
 		<mkdir dir="stage/hydrojson-build"/>
 		<mkdir dir="stage/hydrojson-build/war-distro"/>
 		<copy todir="stage/hydrojson-build/war-distro">
@@ -519,7 +519,7 @@ can find your git source tree and your directory with the downloaded jars.
 		</javac>
 		<copy todir="stage/hydrojson-build" file="${hydrojson.dir}/install/makehydrojson.sh"/>
 		<copy todir="stage/hydrojson-build" file="${hydrojson.dir}/install/README"/>
-		<tar tarfile="stage/hydrojson-build-6-8-${RCNUM}.tgz" 
+		<tar tarfile="stage/hydrojson-build-6-8-${RCNUM}.tgz"
 			basedir="stage"
 			includes="hydrojson-build/**"
 			compression="gzip"/>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'opendcs'

--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
@@ -1,16 +1,16 @@
 /*
 *
 * $Id: CwmsTimeSeriesDb.java,v 1.57 2020/05/02 12:44:06 mmaloney Exp $
-* 
+*
 *  This is open-source software written by Sutron Corporation, under
 *  contract to the federal government. You are free to copy and use this
 *  source code for your own purposes, except that no part of the information
 *  contained in this file may be claimed to be proprietary.
 *
-*  Except for specific contractual terms between ILEX and the federal 
+*  Except for specific contractual terms between ILEX and the federal
 *  government, this source code is provided completely without warranty.
 *  For more information contact: info@ilexeng.com
-*  
+*
 *  $Log: CwmsTimeSeriesDb.java,v $
 *  Revision 1.57  2020/05/02 12:44:06  mmaloney
 *  Add stack trace on connection failure.
@@ -276,8 +276,8 @@
 *  DbKey Implementation
 *
 *  Revision 1.144  2013/02/20 15:07:24  gchen
-*  Enhance a new feature to allow to use the maxComputationRetries property 
-*  to limit the number of retries for those failed computations. There will 
+*  Enhance a new feature to allow to use the maxComputationRetries property
+*  to limit the number of retries for those failed computations. There will
 *  be unlimited retries if maxComputationRetires=0.
 *
 *  Revision 1.143  2012/11/13 15:14:49  mmaloney
@@ -674,6 +674,8 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.GregorianCalendar;
 import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -738,18 +740,18 @@ public class CwmsTimeSeriesDb
 	private String[] currentlyUsedVersions = { "" };
 	GregorianCalendar saveTsCal = new GregorianCalendar(
 		TimeZone.getTimeZone("UTC"));
-	
+
 	CwmsGroupHelper cwmsGroupHelper = null;
-	
+
 	public boolean requireCcpTables = true;
-	
+
 	private String dbUri = null;
-	
+
 	private BaseParam baseParam = new BaseParam();
 	private PreparedStatement getMinStmt = null, getTaskListStmt;
 	String getMinStmtQuery = null, getTaskListStmtQuery = null;
-	
-	
+
+
 	/**
 	 * No args constructor required because this is instantiated from
 	 * the class name.
@@ -757,7 +759,7 @@ public class CwmsTimeSeriesDb
 	public CwmsTimeSeriesDb()
 	{
 		super();
-		
+
 		Site.explicitList = true;
 
 		// CWMS uses ts_code as a unique identifier of a time-series
@@ -768,15 +770,15 @@ public class CwmsTimeSeriesDb
 		maxCompRetryTimeFrmt = "%d*1/24";
 		module = "CwmsTimeSeriesDb";
 	}
-	
+
 	public static CwmsConnectionInfo getDbConnection(String dbUri, String username, String password, String dbOfficeId)
 		throws BadConnectException
 	{
 		if (dbOfficeId == null)
 			dbOfficeId = DecodesSettings.instance().CwmsOfficeId;
-		
+
 		CwmsConnectionInfo ret = new CwmsConnectionInfo();
-		
+
 		// Make a call to the new connection pool.
 //		System.setProperty("oracle.jdbc.autoCommitSpecCompliant", "false");
 //System.err.println("Connecting to '" + dbUri + "' as '" + username + "' with pw '" + password + "' and office '" + dbOfficeId + "'");
@@ -801,7 +803,7 @@ public class CwmsTimeSeriesDb
 				ex.printStackTrace(System.err);
 			throw new BadConnectException(msg);
 		}
-		
+
 		// MJM 2018-2/21 Force autoCommit on.
 		try{ ret.getConnection().setAutoCommit(true); }
 		catch(SQLException ex)
@@ -811,13 +813,13 @@ public class CwmsTimeSeriesDb
 
 		// After connection set the context for VPD to work.
 		ret.setDbOfficeCode(officeId2code(ret.getConnection(), dbOfficeId));
-		
+
 		ArrayList<StringPair> officePrivileges = null;
 		String dbOfficePrivilege = null;
 		try
 		{
 			officePrivileges = determinePrivilegedOfficeIds(ret.getConnection());
-			// MJM 2018-12-05 now determine the highest privilege level that this user has in 
+			// MJM 2018-12-05 now determine the highest privilege level that this user has in
 			// the specified office ID:
 Logger.instance().debug3("Office Privileges for user '" + username + "'");
 			for(StringPair op : officePrivileges)
@@ -838,7 +840,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 					continue;
 				}
 				Logger.instance().debug3("Privilege: " + op.first + ":" + op.second);
-				
+
 				String priv = op.second.toLowerCase();
 				if (TextUtil.strEqualIgnoreCase(op.first, dbOfficeId) && priv.startsWith("ccp"))
 				{
@@ -877,12 +879,12 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 			try { CwmsDbConnectionPool.close(ret.getConnection()); } catch(Exception ex2) {}
 			throw new BadConnectException(msg);
 		}
-		
+
 		return ret;
 	}
 
 	/**
-	 * Connect this app to the database and return appID. 
+	 * Connect this app to the database and return appID.
 	 * The credentials property set contains username, password,
 	 * etc, for connecting to database.
 	 * @param appName must match an application in the database.
@@ -894,14 +896,14 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		throws BadConnectException
 	{
 		String dbUri = this.dbUri != null ? this.dbUri : DecodesSettings.instance().editDatabaseLocation;
-		
+
 		String username = credentials.getProperty("username");
 		String password = credentials.getProperty("password");
 
 		CwmsGuiLogin cgl = CwmsGuiLogin.instance();
 		if (DecodesInterface.isGUI())
 		{
-			try 
+			try
 			{
 				if (!cgl.isLoginSuccess())
 				{
@@ -918,12 +920,12 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 					"Cannot display login dialog: " + ex);
 			}
 		}
-	
+
 		// MJM 2018-12-05 The new HEC/RMA connection facility requires that office ID
 		// be known before getting a connection from the pool. Therefore I cannot set
 		// it dynamically from the database or from user selection.
 		dbOfficeId = DecodesSettings.instance().CwmsOfficeId;
-		
+
 		// CWMS is Always GMT.
 		DecodesSettings.instance().sqlTimeZone = "GMT";
 
@@ -945,7 +947,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 			if (getConnection() != null)
 				closeConnection();
 		}
-		
+
 		// CWMS OPENDCS-16 for DB version >= 68, use old OracleSequenceKeyGenerator,
 		// which assumes a separate sequence for each table. Do not use CWMS_SEQ for anything.
 		int decodesDbVersion = getDecodesDatabaseVersion();
@@ -974,13 +976,13 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 				warning("Error executing '" + q + "':" + ex);
 			}
 		}
-		
-		Logger.instance().info(module + 
+
+		Logger.instance().info(module +
 			" Connected to DECODES CWMS Database " + dbUri + " as user " + username
 			+ " with officeID=" + dbOfficeId + " (dbOfficeCode=" + dbOfficeCode + ")");
 
 		cgl.setLoginSuccess(true);
-		
+
 		try
 		{
 			hec.data.Units.getAvailableUnits();
@@ -1002,8 +1004,8 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 
 		return appId;
 	}
-	
-	
+
+
 	/**
 	 * Fills in the internal list of privileged office IDs.
 	 * @return array of string pairs: officeId,Privilege
@@ -1012,12 +1014,12 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 	public static ArrayList<StringPair> determinePrivilegedOfficeIds(Connection conn)
 		throws SQLException
 	{
-		
+
 		CwmsDbSec dbSec = CwmsDbServiceLookup.buildCwmsDb(CwmsDbSec.class, conn);
 		ResultSet rs = dbSec.getAssignedPrivGroups(conn, null);
-		
+
 		ArrayList<StringPair> ret = new ArrayList<StringPair>();
-//		
+//
 //		CwmsSecJdbc cwmsSec = new CwmsSecJdbc(conn);
 		// 4/8/13 phone call with Pete Morris - call with Null. and the columns returned are:
 		// username, user_db_office_id, db_office_id, user_group_type, user_group_owner, user_group_id,
@@ -1052,13 +1054,13 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 //				+ "is_member='" + is_member + "' "
 //				+ "user_group_desc='" + user_group_desc + "'"
 				);
-			
+
 			// We look for groups "CCP Proc", "CCP Mgr", and "CCP Reviewer".
 			// Ignore anything else.
 			String gid = user_group_id.trim();
 			if (!TextUtil.startsWithIgnoreCase(gid, "CCP"))
 				continue;
-			
+
 			// See if we have an existing privilege for this office ID.
 			int existingIdx = 0;
 			String existingPriv = null;
@@ -1100,7 +1102,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 	public void setParmSDI(DbCompParm parm, DbKey siteId, String dtcode)
 		throws DbIoException, NoSuchObjectException
 	{
-		debug3("setParmSDI siteId=" + siteId + 
+		debug3("setParmSDI siteId=" + siteId +
 			", dtcode=" + dtcode);
 		ResultSet rs = null;
 
@@ -1117,11 +1119,11 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		}
 		try
 		{
-			String q = 
+			String q =
 				"SELECT TS_CODE, LOCATION_ID FROM CWMS_V_TS_ID "
 				+ "WHERE LOCATION_CODE = " + siteId
 				+ " AND TS_ACTIVE_FLAG = 'T'"
-				+ " AND upper(PARAMETER_ID) = " 
+				+ " AND upper(PARAMETER_ID) = "
 						+ sqlString(dtcode.toUpperCase())
 				+ " AND INTERVAL_ID = " + sqlString(parm.getInterval())
 				+ " AND VERSION_ID = " + sqlString(parm.getVersion())
@@ -1151,7 +1153,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		}
 		finally
 		{
-			if (rs != null) 
+			if (rs != null)
 				try { rs.close(); }
 				catch(Exception ex) {}
 		}
@@ -1190,7 +1192,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 
 		return tsid;
 	}
-	
+
 	/**
 	 * CWMS TSDB stores ParamType.Duration.Version in the tab selector.
 	 */
@@ -1201,7 +1203,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 
 	/**
 	 * For CWMS we show all 5 path components for the site.
-	 * 
+	 *
 	 * {@inheritDoc}
 	 */
 	@Override
@@ -1214,7 +1216,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		header[2] = "Interval";
 		header[3] = "Duration";
 		header[4] = "Version";
-		
+
 		ArrayList<String[]> ret = new ArrayList<String[]>();
 		ret.add(header);
 
@@ -1241,12 +1243,12 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		}
 		return ret;
 	}
-	
+
 	/**
 	 * Validate the passed information to make sure it represents a valid
 	 * parameter within this database. If not, throw ConstraintException.
 	 */
-	public void validateParm(DbKey siteId, String dtcode, String interval, 
+	public void validateParm(DbKey siteId, String dtcode, String interval,
 		String tabSel, int modelId)
 		throws ConstraintException, DbIoException
 	{
@@ -1276,6 +1278,123 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 	public String getRevisionLabel() { return ""; }
 
 	/**
+	 * Releases triggers associated with the new data in the passed collection.
+	 * The implementation may use information contained in the collection's
+	 * opaque handle.
+	 * @param dc the data collection to be released.
+	 */
+
+	@Override
+	public void releaseNewData(DataCollection dc)
+		throws DbIoException
+	{
+		RecordRangeHandle rrh = dc.getTasklistHandle();
+		if (rrh == null)
+			return;
+
+		int maxRetries = DecodesSettings.instance().maxComputationRetries;
+		boolean doRetryFailed = DecodesSettings.instance().retryFailedComputations;
+
+
+		try(
+			PreparedStatement deleteNormal = conn.prepareStatement("delete from CP_COMP_TASKLIST where RECORD_NUM = ?");
+			PreparedStatement deleteFailedAfterMaxRetries = conn.prepareStatement(
+					  "delete from CP_COMP_TASKLIST "
+					+ "where RECORD_NUM = ? " // failRecList
+					+ "and (( current_timestamp - DATE_TIME_LOADED) > " // curTimeName
+					+ "INTERVAL '? hour')" ); //String.format(maxCompRetryTimeFrmt, maxRetries) + ")"); //
+			PreparedStatement updateFailedRetry = conn.prepareStatement(
+				"update CP_COMP_TASKLIST set FAIL_TIME = ? where RECORD_NUM = ? and "
+			+	"((current_timestamp - DATE_TIME_LOADED) <= INTERVAL '? hour')");
+			PreparedStatement updateFailTime = conn.prepareStatement("UPDATE CP_COMP_TASKLIST SET FAIL_TIME = current_timestamp where record_num = ?");
+
+
+		){
+			while(rrh.size() > 0)
+			{
+				String []records = rrh.getRecNumList(250).split(",");
+				for( String rec: records ){
+					if( "".equalsIgnoreCase(rec) ) continue;
+					deleteNormal.setLong(1, Long.parseLong(rec.trim()));
+					deleteNormal.addBatch();
+				}
+
+				deleteNormal.executeBatch();
+			}
+
+			while(rrh.getFailedRecnums().size() > 0)
+			{
+				String failRecNumList = rrh.getFailedRecNumList(250);
+				String records[] = failRecNumList.split(",");
+				//Array failRecs = conn.createArrayOf("integer", failRecNumList.split(","));
+				// Add the retry limit for failed computations
+				if (doRetryFailed && maxRetries > 0)
+				{
+					debug3("updating failed records based on retry count");
+					for( String rec: records ){
+						if( "".equalsIgnoreCase(rec) ) continue;
+						deleteFailedAfterMaxRetries.setLong(1,Long.parseLong(rec.trim()));
+						//deleteFailedAfterMaxRetries.setString(2,curTimeName);
+						deleteFailedAfterMaxRetries.setInt(2,maxRetries);
+						deleteFailedAfterMaxRetries.addBatch();
+					}
+					deleteFailedAfterMaxRetries.executeBatch();
+					info("deleted failed recs past retry in (" + failRecNumList +")" );
+					for( String rec: records){
+						if( "".equalsIgnoreCase(rec) ) continue;
+						//updateFailedRetry.setString(1,curTimeName);
+						updateFailedRetry.setLong(1,Long.parseLong(rec.trim()));
+						updateFailedRetry.setInt(2, maxRetries);
+						updateFailedRetry.addBatch();
+
+					}
+					updateFailedRetry.executeBatch();
+					info("updated fail time on (" + failRecNumList + "))" );
+				}
+				else
+				{
+					// DB V5 handles failed computations by setting a FAIL_TIME
+					// on the task list record. Previous version just delete record.
+					if( tsdbVersion >= 4 && doRetryFailed ) {
+						debug3("updating failed records");
+						for( String rec: records ){
+							//updateFailTime.setString(1, curTimeName);
+							updateFailTime.setLong(1, Long.parseLong(rec.trim()));
+							//updateFailTime.setArray(2, failRecs);
+							updateFailTime.execute();
+						}
+						updateFailTime.executeBatch();
+						info("updated fail time on (" + failRecNumList + "))" );
+					} else {
+						for( String rec: records ){
+							if( "".equalsIgnoreCase(rec) ) continue;
+							deleteNormal.setLong(1, Long.parseLong(rec.trim()));
+							deleteNormal.addBatch();
+						}
+
+						deleteNormal.executeBatch();
+						info("deleted failed records: (" +failRecNumList +" )" );
+					}
+					commit();
+				}
+			}
+
+		} catch( SQLException err ){
+					//warning(err.getLocalizedMessage());
+					StringWriter sw = new StringWriter();
+					PrintWriter pw = new PrintWriter(sw);
+					err.printStackTrace(pw);
+					warning("removing items from task list failed:");
+					warning(sw.toString());
+					throw new DbIoException(err.getLocalizedMessage());
+		}
+
+
+
+	}
+
+
+	/**
 	 * TSDB version 5 & above use a join with CP_COMP_DEPENDS to determine
 	 * not only what the new data is, but what computations depend on it.
 	 * The dependent computation IDs are stored inside each CTimeSeries.
@@ -1284,6 +1403,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 	public DataCollection getNewData(DbKey applicationId)
 		throws DbIoException
 	{
+		debug3("CWMS GET NEW DATA");
 		// Reload the TSID cache every hour.
 		if (System.currentTimeMillis() - lastTsidCacheRead > 3600000L)
 		{
@@ -1311,27 +1431,33 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 					DecodesSettings.instance().retryFailedComputations
 					? " and (a.FAIL_TIME is null OR SYSDATE - a.FAIL_TIME >= 1/24)"
 					: "";
-	
+
 				getMinStmtQuery = "select min(a.record_num) from cp_comp_tasklist a "
-					+ "where a.LOADING_APPLICATION_ID = " + applicationId
+					+ "where a.LOADING_APPLICATION_ID = ? "// + applicationId
 					+ failTimeClause;
 				getMinStmt = conn.prepareStatement(getMinStmtQuery);
-	
+
+
 				// 2nd query gets tasklist recs within record_num range.
-				getTaskListStmtQuery = 
+				getTaskListStmtQuery =
 					"select a.RECORD_NUM, a.SITE_DATATYPE_ID, ROUND(a.VALUE,8), a.START_DATE_TIME, "
 					+ "a.DELETE_FLAG, a.UNIT_ID, a.VERSION_DATE, a.QUALITY_CODE, a.MODEL_RUN_ID "
 					+ "from CP_COMP_TASKLIST a "
-					+ "where a.LOADING_APPLICATION_ID = " + applicationId
+					+ "where a.LOADING_APPLICATION_ID = ?" // + applicationId
 					+ " and ROWNUM < 20000"
 					+ failTimeClause
 					+ " ORDER BY a.site_datatype_id, a.start_date_time";
 				getTaskListStmt = conn.prepareStatement(getTaskListStmtQuery);
+
 			}
 
-			debug3("Executing prepared stmt '" + getMinStmtQuery + "'");
+			// this may seems silly, but it allows Oracle to cache the query and it's plan for all instances
+			getMinStmt.setLong(1,applicationId.getValue());
+			getTaskListStmt.setLong(1,applicationId.getValue());
+
+			debug3("Executing prepared stmt2 '" + getMinStmtQuery + "'");
 			ResultSet rs = getMinStmt.executeQuery();
-			
+
 			if (rs == null || !rs.next())
 			{
 				debug1("No new data for appId=" + applicationId);
@@ -1367,7 +1493,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 //				// The 32-bit integer wrapped around. Set to max possible int.
 //				maxRecNum = Integer.MAX_VALUE;
 //			}
-//			
+//
 //			getTaskListStmt.setInt(2, maxRecNum);
 
 			debug3("Executing '" + getTaskListStmtQuery + "'");
@@ -1401,14 +1527,14 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 						}
 					}
 				}
-				else 
+				else
 					deleted = TextUtil.str2boolean(df);
-					
+
 				String unitsAbbr = rs.getString(6);
 				Date versionDate = getFullDate(rs, 7);
 				BigDecimal qc = rs.getBigDecimal(8);
 				long qualityCode = qc == null ? 0 : qc.longValue();
-				
+
 				TasklistRec rec = new TasklistRec(recordNum, sdi, value,
 					valueWasNull, timeStamp, deleted,
 					unitsAbbr, versionDate, qualityCode);
@@ -1416,13 +1542,13 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 			}
 
 			RecordRangeHandle rrhandle = new RecordRangeHandle(applicationId);
-			
+
 			// Process the real-time records collected above.
 			for(TasklistRec rec : tasklistRecs)
 				processTasklistEntry(rec, dataCollection, rrhandle, badRecs, applicationId);
-			
+
 			dataCollection.setTasklistHandle(rrhandle);
-			
+
 			// Delete the bad tasklist recs, 250 at a time.
 			if (badRecs.size() > 0)
 				Logger.instance().debug1("getNewDataSince deleting " + badRecs.size()
@@ -1445,17 +1571,17 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 				for(int i=0; i<x; i++)
 					badRecs.remove(0);
 			}
-			
+
 			// Show each tasklist entry in the log if we're at debug level 3
 			if (Logger.instance().getMinLogPriority() <= Logger.E_DEBUG3)
 			{
 				List<CTimeSeries> allts = dataCollection.getAllTimeSeries();
 				debug3("getNewData, returning " + allts.size() + " TimeSeries.");
 				for(CTimeSeries ts : allts)
-					debug3("ts " + ts.getTimeSeriesIdentifier().getUniqueString() + " " 
+					debug3("ts " + ts.getTimeSeriesIdentifier().getUniqueString() + " "
 						+ ts.size() + " values.");
 			}
-			
+
 			return dataCollection;
 		}
 		catch(SQLException ex)
@@ -1484,9 +1610,9 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 			TimeSeriesDAI timeSeriesDAO = this.makeTimeSeriesDAO();
 			try
 			{
-				TimeSeriesIdentifier tsid = 
+				TimeSeriesIdentifier tsid =
 					timeSeriesDAO.getTimeSeriesIdentifier(rec.getSdi());
-				String tabsel = tsid.getPart("paramtype") + "." + 
+				String tabsel = tsid.getPart("paramtype") + "." +
 					tsid.getPart("duration") + "." + tsid.getPart("version");
 				cts = new CTimeSeries(rec.getSdi(), tsid.getInterval(),
 					tabsel);
@@ -1496,7 +1622,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 				if (fillDependentCompIds(cts, applicationId) == 0)
 				{
 					warning("Deleting tasklist rec for '"
-						+ tsid.getUniqueString() 
+						+ tsid.getUniqueString()
 						+ "' because no dependent comps.");
 					if (badRecs != null)
 						badRecs.add(rec.getRecordNum());
@@ -1566,7 +1692,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		TimedVariable tv = new TimedVariable(rec.getValue());
 		tv.setTime(rec.getTimeStamp());
 		tv.setFlags(CwmsFlags.cwmsQuality2flag(rec.getQualityCode()));
-		
+
 		if (!rec.isDeleted() && !rec.isValueWasNull())
 		{
 			VarFlags.setWasAdded(tv);
@@ -1587,7 +1713,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 				+ " cwms qualcode=0x" + Long.toHexString(rec.getQualityCode()));
 		}
 	}
-	
+
 	public boolean isCwms() { return true; }
 
 	@Override
@@ -1618,7 +1744,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 				+ uniqueString + "', parm=" + parm);
 			TimeSeriesDAI timeSeriesDAO = makeTimeSeriesDAO();
 
-			try 
+			try
 			{
 				tsidRet = timeSeriesDAO.getTimeSeriesIdentifier(uniqueString);
 				debug3("CwmsTimeSeriesDb.transformTsid "
@@ -1647,7 +1773,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		}
 		else
 			tsidRet = tsid;
-		
+
 		if (fillInParm)
 		{
 			parm.setSiteDataTypeId(tsidRet.getKey());
@@ -1676,7 +1802,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		if (!(tsidRet instanceof CwmsTsId))
 			return false;
 		CwmsTsId ctsid = (CwmsTsId) tsidRet;
-		
+
 		SiteName sn = parm.getSiteName();
 		if (sn != null)
 		{
@@ -1690,7 +1816,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 				SiteDAI siteDAO = makeSiteDAO();
 				try
 				{
-					
+
 					DbKey siteId = siteDAO.lookupSiteID(sn);
 					tsidRet.setSite(siteDAO.getSiteById(siteId));
 				}
@@ -1780,7 +1906,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 			{
 				String morphed = morph(ctsid.getPart("version"), s);
 				if (morphed == null)
-					debug2("Unable to morph param '" + ctsid.getPart("version") 
+					debug2("Unable to morph param '" + ctsid.getPart("version")
 						+ "' with version spec '" + s + "'");
 				else
 				{
@@ -1794,7 +1920,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		}
 		return transformed;
 	}
-	
+
 	/**
 	 * For version 6.3, morph the tsid part by the computation param part.
 	 * @param tsidComponent The component from the TSID
@@ -1810,7 +1936,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		// tsid: A       parm: D-*     result: null
 		// tsid: A-B-C   parm: *-D     result: A-D
 		// tsid: A-B     parm: *-      result: A
-		
+
 		// Check for a partial location specification (OpenDCS 6.3)
 		String tps[] = tsidComponent.split("-");
 		String pps[] = parmComponent.split("-");
@@ -1841,17 +1967,17 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 				sb.append("-");
 		}
 		return sb.toString();
-		
+
 		/*
-		 * Note: the table_selector in cp_comp_ts_parm will be empty for a component that is 
+		 * Note: the table_selector in cp_comp_ts_parm will be empty for a component that is
 		 * completely undefined. The syntax is ParamType.Duration.Version[.SiteSpec.ParmSpec],
 		 * So "Total.1Hour." means that Version is undefined and shows as <var> in the gui.
 		 * This is different from "Total.1Hour.Something-*". Meaning that the first part of
 		 * the subversion can be anything.
 		 */
 	}
-	
-	
+
+
 	public String getDbOfficeId()
 	{
 		return dbOfficeId;
@@ -1878,7 +2004,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		}
 		return retStr;
 	}
-	
+
 	@Override
 	public ArrayList<String> listParamTypes()
 		throws DbIoException
@@ -1910,9 +2036,9 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		if (!ret.contains("Total"))
 			ret.add("Total");
 		return ret;
-		
+
 	}
-	
+
 	@Override
 	public String[] getValidPartChoices(String part)
 	{
@@ -1920,7 +2046,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 			return currentlyUsedVersions;
 		return super.getValidPartChoices(part);
 	}
-	
+
 //	public void printCat()
 //	{
 //		try
@@ -1938,19 +2064,19 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 //			System.err.println("Error: " + ex);
 //			ex.printStackTrace(System.err);
 //		}
-//		
+//
 //	}
-	
+
 	@Override
 	public TimeSeriesIdentifier makeEmptyTsId()
 	{
 		return new CwmsTsId();
 	}
-	
-	
+
+
 	/**
 	 * Reset the VPD context variable with user specified office Id
-	 * @throws DbIoException 
+	 * @throws DbIoException
 	 */
 	public static void setCtxDbOfficeId(Connection conn, String dbOfficeId,
 		DbKey dbOfficeCode, String dbOfficePrivilege)
@@ -1960,15 +2086,15 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		String errMsg = null;
 		PreparedStatement storeProcStmt = null;
 		CallableStatement testStmt = null;
-		
+
 		try
 		{
 			String q = null;
-			int privLevel = 
+			int privLevel =
 				dbOfficeId == null ? 0 :
 				dbOfficePrivilege.toUpperCase().contains("MGR") ? 1 :
 				dbOfficePrivilege.toUpperCase().contains("PROC") ? 2 : 3;
-			q = 
+			q =
 				"begin cwms_ccp_vpd.set_ccp_session_ctx(" +
 				":1 /* office code */, :2 /* priv level*/, :3 /* officeId */); end;";
 			storeProcStmt  = conn.prepareCall(q);
@@ -1981,7 +2107,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 				+ ", dbOfficeId='" + dbOfficeId + "'");
 			storeProcStmt.execute();
 //			conn.commit();
-			
+
 			q = "{ ? = call cwms_ccp_vpd.get_pred_session_office_code_v(?, ?) }";
 			testStmt = conn.prepareCall(q);
 			testStmt.registerOutParameter(1, Types.VARCHAR);
@@ -1992,7 +2118,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 			testStmt.execute();
 			String pred = testStmt.getString(1);
 			Logger.instance().info("Predicate for table PLATFORMCONFIG is '" + pred + "'");
-			
+
 		}
 		catch (SQLException ex)
 		{
@@ -2016,7 +2142,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 			}
 		}
 	}
-	
+
 	/**
 	 * Use database-specific flag definitions to determine whether the
 	 * passed variable should be considered 'questionable'.
@@ -2027,7 +2153,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 	{
 		return (v.getFlags() & CwmsFlags.VALIDITY_MASK) == CwmsFlags.VALIDITY_QUESTIONABLE;
 	}
-	
+
 	/**
 	 * Use database-specific flag definitions to set the passed variable
 	 * as 'questionable'.
@@ -2074,7 +2200,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 //			Logger.instance().info("cwmsVersionOverride==2");
 //			return CWMS_V_2_1;
 //		}
-//		
+//
 //		String q = "select count(*) from all_synonyms where owner='PUBLIC' " +
 //			"and SYNONYM_NAME = 'CWMS_ENV'";
 //		ResultSet rs = null;
@@ -2113,7 +2239,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 //			}
 //		}
 //	}
-	
+
 	/**
 	 * Converts a CWMS String Office ID to the numeric office Code.
 	 * @param con the Connection
@@ -2124,7 +2250,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 	{
 		String q = "select cwms_util.get_office_code('" +
 				officeId + "') from dual";
-			
+
 		ResultSet rs = null;
 		Statement stmt = null;
 		try
@@ -2139,7 +2265,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
         }
 		catch (Exception ex)
 		{
-			Logger.instance().warning("Error getting office code for id '" 
+			Logger.instance().warning("Error getting office code for id '"
 				+ officeId + "': " + ex);
 			return Constants.undefinedId;
 		}
@@ -2166,18 +2292,18 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 	}
 
 	@Override
-	public ScreeningDAI makeScreeningDAO() 
+	public ScreeningDAI makeScreeningDAO()
 		throws DbIoException
 	{
 		return new ScreeningDAO(this);
 	}
-	
+
 	@Override
 	public GroupHelper makeGroupHelper()
 	{
 		return new CwmsGroupHelper(this);
 	}
-	
+
 	@Override
 	public double rating(String specId, Date timeStamp, double... indeps)
 		throws DbCompException, RangeException
@@ -2185,7 +2311,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 		// int nIndeps = indeps.length;
 		// NOTE: indeps is already an array of doubles. I can pass
 		// it directly to the rateOne function.
-		
+
 		CwmsRatingDao crd = new CwmsRatingDao(this);
 		try
 		{
@@ -2232,11 +2358,11 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 			catch(Exception ex) {}
 			getTaskListStmt = null;
 		}
-		
+
 		// Return the connection to the CWMS connection pool. Do not close directly.
 		doCloseConnection(getConnection());
 	}
-	
+
 	public static void doCloseConnection(Connection con)
 	{
 		// Return connection to CWMS connection pool.
@@ -2271,7 +2397,7 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 
 		return ret;
 	}
-	
+
 	@Override
 	public String getStorageUnitsForDataType(DataType dt)
 	{
@@ -2285,14 +2411,14 @@ Logger.instance().debug3("Office Privileges for user '" + username + "'");
 				return null;
 			cwmsParam = equiv.getCode();
 		}
-		
+
 		// Truncate to just base param
 		int hyphen = cwmsParam.indexOf('-');
 		if (hyphen > 0)
 			cwmsParam = cwmsParam.substring(0, hyphen);
 		return baseParam.getStoreUnits4Param(cwmsParam);
 	}
-	
+
 	@Override
 	public String flags2display(int flags)
 	{

--- a/src/main/java/decodes/dcpmon/DcpMonitorConfig.java
+++ b/src/main/java/decodes/dcpmon/DcpMonitorConfig.java
@@ -59,7 +59,7 @@ public class DcpMonitorConfig
 
 	/** carrier more than this will result in 'C' code. */
 	public long maxCarrierMS = 2500L;
-	
+
 	/** Last time configuration was loaded. */
 	public long lastLoadTime;
 
@@ -67,6 +67,7 @@ public class DcpMonitorConfig
 	private Properties rawProps;
 
 	/** @deprecated */
+	@Deprecated
 	public boolean hadsUse = true;
 
 	public String pdtLocalFile = "/tmp/pdt";
@@ -78,18 +79,18 @@ public class DcpMonitorConfig
 
 	/** Name of merge directory. */
 	public String mergeDir = "$DECODES_INSTALL_DIR/dcptoimport";
-	
+
 	/** File name of the control-district-list file within the merge dir */
 	public String controlDistList = "controlling-districts.txt";
-	
-	/** This is used in particular for the RiverGages group names 
+
+	/** This is used in particular for the RiverGages group names
 	 * This is used to convert from District to an actual group name
 	 * in the dcpmon.conf */
 	public String controlDistSuffix = "-RIVERGAGES-DAS";
-	
+
 	/** This is the dcpmon type */
 	public String dcpmonNameType;
-	
+
 	/**
 	 * This is used to tell the Dcp Monitor that we want to monitor
 	 * all available channels.
@@ -99,18 +100,18 @@ public class DcpMonitorConfig
 
 	/** Set to true to have computations performed when viewing DCP Messages. */
 	public boolean enableComputations = false;
-	
+
 	/** If computations enabled, you must provide a comp config file. */
 	public String compConfig = "$DECODES_INSTALL_DIR/computations.conf";
-	
+
 	public String rtstatUrl = "file:///tmp/lrgsstatus.html";
-	
+
 	public int statusErrorThreshold = 3600 * 4;
-	
+
 	/** For web service components, we need a singleton */
 	private static DcpMonitorConfig _instance = new DcpMonitorConfig();
 	public static DcpMonitorConfig instance() { return _instance; }
-	
+
 	/** Private constructor. Sets default values for all parameters. */
 	public DcpMonitorConfig()
 	{

--- a/src/main/java/decodes/sql/AuthFile.java
+++ b/src/main/java/decodes/sql/AuthFile.java
@@ -31,6 +31,7 @@ so that only the owner has ANY access to it.
 This class provides utilities for reading the current user's authorization file.
 @deprecated Use ilex.util.UserAuthFile("$HOME/.decodes.auth");
 */
+@Deprecated
 class AuthFile
 {
 	/** The file to read */
@@ -43,11 +44,11 @@ class AuthFile
 	/** default constructor */
 	public AuthFile()
 	{
-		this(System.getProperty("user.home") 
+		this(System.getProperty("user.home")
 			+ System.getProperty("file.separator") + ".decodes.auth");
 	}
 
-	/** 
+	/**
 	  Construct with filename.
 	  @param fn the filename
 	*/
@@ -79,7 +80,7 @@ class AuthFile
 		data[63] = (byte)pw.length();
 		for(i=0; i<pw.length(); i++)
 		{
-			int v = (int)password.charAt(i) 
+			int v = (int)password.charAt(i)
 				+ (int)username.charAt(i%username.length());
 			v ^= seed[i%seed.length];
 			data[64+i] = (byte)v;
@@ -103,7 +104,7 @@ class AuthFile
 		FileInputStream fis = new FileInputStream(authFile);
 		fis.read(data);
 		fis.close();
-		
+
 		int i=0;
 		for(i=0; i<63 && data[i] != 0; i++);
 		username = new String(data, 0, i);

--- a/src/main/java/decodes/sql/SqlDatabaseIO.java
+++ b/src/main/java/decodes/sql/SqlDatabaseIO.java
@@ -1,8 +1,8 @@
 /*
  * $Id: SqlDatabaseIO.java,v 1.15 2020/02/14 15:13:44 mmaloney Exp $
- * 
+ *
  * Open Source Software
- * 
+ *
  * $Log: SqlDatabaseIO.java,v $
  * Revision 1.15  2020/02/14 15:13:44  mmaloney
  * Implement isOpenTSDB
@@ -213,7 +213,7 @@ public class SqlDatabaseIO
 
 	/** Bit fields determine options used by this database. */
 	protected String databaseOptions;
-	
+
 	/** TSDB Database Version, if this is a TSDB */
 	protected int tsdbVersion = TsdbDatabaseVersion.VERSION_2;
 
@@ -230,8 +230,8 @@ public class SqlDatabaseIO
 
 	/** User name used to connect to the database. */
 	protected String _dbUser;
-	
-	/** 
+
+	/**
 	 * Routing Spec Threads in certain apps establish their own connection.
 	 * This is necessary to prevent them from interfering with other threads.
 	 */
@@ -249,7 +249,7 @@ public class SqlDatabaseIO
 
 	/** Used to format timestamps read from the database. */
 	protected SimpleDateFormat readDateFmt = null;
-	
+
 	/** Used for log messages */
 	protected SimpleDateFormat debugDateFmt = new SimpleDateFormat("MM/dd/yyyy-HH:mm:ss z");
 
@@ -266,17 +266,17 @@ public class SqlDatabaseIO
 		// by their various constructors.  For example, the PlatformListIO
 		// can't be instantiated until after the ConfigListIO and the
 		// SiteIO objects are created.
-		
+
 		_engineeringUnitIO = new EngineeringUnitIO(this);
 		_unitConverterIO = new UnitConverterIO(this);
 		_networkListListIO = new NetworkListListIO(this);
 		_formatStatementIO = new FormatStatementIO(this);
 		_scriptSensorIO = new ScriptSensorIO(this, _unitConverterIO);
-		_decodesScriptIO = new DecodesScriptIO(this, _formatStatementIO, 
+		_decodesScriptIO = new DecodesScriptIO(this, _formatStatementIO,
 			_scriptSensorIO);
 		_configListIO = new ConfigListIO(this, _decodesScriptIO);
 		_equipmentModelListIO = new EquipmentModelListIO(this);
-		_platformListIO = new PlatformListIO(this, _configListIO, 
+		_platformListIO = new PlatformListIO(this, _configListIO,
 			_equipmentModelListIO, _decodesScriptIO);
 		_dataSourceListIO = new DataSourceListIO(this);
 		_presentationGroupListIO = new PresentationGroupListIO(this);
@@ -298,7 +298,7 @@ public class SqlDatabaseIO
 		throws DatabaseException
 	{
 		this();
-		
+
 		connectToDatabase(sqlDbLocation);
 		keyGenerator = KeyGeneratorFactory.makeKeyGenerator(
 			DecodesSettings.instance().sqlKeyGenerator, _conn);
@@ -314,7 +314,7 @@ public class SqlDatabaseIO
 	* @param keyGenerator the Key Generator to use
 	* @param location the database location string for log messages
 	*/
-	public void useExternalConnection(Connection conn, 
+	public void useExternalConnection(Connection conn,
 		KeyGenerator keyGenerator, String location)
 	{
 		_conn = conn;
@@ -336,7 +336,7 @@ public class SqlDatabaseIO
 		if (sqlDbLocation == null || sqlDbLocation.trim().length() == 0)
 			return;
 		_sqlDbLocation = sqlDbLocation;
-		
+
 		String driverClass = DecodesSettings.instance().jdbcDriverClass;
 		// Load the JDBC Driver Class
 		try
@@ -369,7 +369,7 @@ public class SqlDatabaseIO
 				_conn = null;
 			}
 		}
-		
+
 		if (_conn == null)
 		{
 			// Retrieve username and password for database
@@ -387,7 +387,7 @@ public class SqlDatabaseIO
 
 			connectUserPassword(authFile.getUsername(), authFile.getPassword());
 		}
-		
+
 		// MJM 2018-2/21 Force autoCommit on.
 		try { _conn.setAutoCommit(true);}
 		catch(SQLException ex)
@@ -396,16 +396,16 @@ public class SqlDatabaseIO
 		}
 
 		determineVersion();
-		
+
 		try {
 			setDBDatetimeFormat();
 		} catch (SQLException e) {
 			Logger.instance().debug3(e.toString());
 		}
-		
+
 		postConnectInit();
 	}
-	
+
 	private void connectUserPassword(String user, String pw)
 		throws DatabaseException
 	{
@@ -417,20 +417,20 @@ public class SqlDatabaseIO
 		_conn = null;
 		while(_conn == null)
 		{
-			try 
+			try
 			{
 				Logger.instance().info("Connecting to " + _sqlDbLocation
 					+ " as user '" + user + "'");
-				
+
 				_conn = DriverManager.getConnection(_sqlDbLocation, user, pw);
 			}
-			catch (Exception ex) 
+			catch (Exception ex)
 			{
 				_conn = null;
 		   		if (System.currentTimeMillis() - startTry > 30000L)
 					throw new DatabaseException(
 						"Error getting JDBC connection using driver '"
-						+ DecodesSettings.instance().jdbcDriverClass 
+						+ DecodesSettings.instance().jdbcDriverClass
 						+ "' to database at '" + _sqlDbLocation
 						+ "' for user '" + user + "': " + ex.toString());
 				else
@@ -443,7 +443,7 @@ public class SqlDatabaseIO
 		}
 
 	}
-	
+
 	/**
 	 * A subclass can override this method to perform initialization tasks after
 	 * a successful database connection.
@@ -451,7 +451,7 @@ public class SqlDatabaseIO
 	protected void postConnectInit()
 		throws DatabaseException
 	{
-		
+
 	}
 
 	protected void setDBDatetimeFormat()
@@ -463,14 +463,14 @@ public class SqlDatabaseIO
 		{
 			if (_isOracle)
 			{
-				
+
 				stmnt = getConnection().createStatement();
 
 				q = "SELECT PARAM_VALUE FROM REF_DB_PARAMETER WHERE PARAM_NAME = 'TIME_ZONE'";
 				ResultSet rs = null;
 //				Logger.instance().info(q);
 				try
-				{ 
+				{
 					rs = stmnt.executeQuery(q);
 					if (rs != null && rs.next())
 						databaseTimeZone = rs.getString(1);
@@ -493,11 +493,11 @@ public class SqlDatabaseIO
 				q = "ALTER SESSION SET TIME_ZONE = '" + databaseTimeZone + "'";
 				Logger.instance().debug3(q);
 				stmnt.execute(q);
-	
+
 				q = "ALTER SESSION SET nls_date_format = 'yyyy-mm-dd hh24:mi:ss'";
 				Logger.instance().debug3(q);
 				stmnt.execute(q);
-				
+
 				q = "ALTER SESSION SET nls_timestamp_format = 'yyyy-mm-dd hh24:mi:ss'";
 				Logger.instance().debug3(q);
 				stmnt.execute(q);
@@ -509,15 +509,15 @@ public class SqlDatabaseIO
 		}
 		catch(SQLException ex)
 		{
-			
+
 		}
 		finally
 		{
 			if (stmnt != null)
 				try { stmnt.close(); } catch (Exception ex) {}
 		}
-	}	
-	
+	}
+
 	public synchronized void determineVersion()
 	{
 		try
@@ -530,7 +530,7 @@ public class SqlDatabaseIO
 			Logger.instance().warning("SqlDatabaseIO.determineVersion() "
 				+ "Cannot determine Database Product Name: " + ex);
 		}
-		
+
 		TimeZone tz = TimeZone.getTimeZone(DecodesSettings.instance().sqlTimeZone);
 		String writeFmt = DecodesSettings.instance().sqlDateFormat;
 		String readFmt = DecodesSettings.instance().SqlReadDateFormat;
@@ -549,12 +549,12 @@ public class SqlDatabaseIO
 		readVersionInfo(this);
 		TimeSeriesDb.readVersionInfo(this);
 	}
-	
+
 	public static void readVersionInfo(DatabaseConnectionOwner dco)
 	{
 		/*
 		  Attempt to read the database's version number.
-		  Catch exception. Database version < 6 will not have the version 
+		  Catch exception. Database version < 6 will not have the version
 		  table.
 		*/
 		int databaseVersion = DecodesDatabaseVersion.DECODES_DB_5;  // earliest possible value.
@@ -606,7 +606,7 @@ public class SqlDatabaseIO
 		dco.setDecodesDatabaseVersion(databaseVersion, databaseOptions);
 		Logger.instance().info("Connected to DECODES SQL database version " + databaseVersion);
 	}
-		
+
 	/** @return 'SQL'. */
 	public String getDatabaseType()
 	{
@@ -633,10 +633,11 @@ public class SqlDatabaseIO
 		return databaseOptions;
 	}
 
-	/** 
+	/**
 	  @return true if this database type requires login.
 	  @deprecated This always returns false -- implemented a different way.
 	*/
+	@Deprecated
 	public boolean requiresLogin( )
 	{
 		//System.out.println("SqlDatabaseIO.requiresLogin()");
@@ -661,7 +662,7 @@ public class SqlDatabaseIO
 	*/
 	public void close( )
 	{
-		try 
+		try
 		{
 			if (_conn.isClosed())
 				return;
@@ -687,7 +688,7 @@ public class SqlDatabaseIO
 		{
 			enumSqlDao.readEnumList(top);
 		}
-		catch (DbIoException ex) 
+		catch (DbIoException ex)
 		{
 			throw new DatabaseException(ex.toString());
 		}
@@ -696,7 +697,7 @@ public class SqlDatabaseIO
 			enumSqlDao.close();
 		}
 	}
-	
+
 	public synchronized DbEnum readEnum(String enumName)
 		throws DatabaseException
 	{
@@ -705,7 +706,7 @@ public class SqlDatabaseIO
 		{
 			return enumSqlDao.getEnum(enumName);
 		}
-		catch (DbIoException ex) 
+		catch (DbIoException ex)
 		{
 			throw new DatabaseException(ex.toString());
 		}
@@ -810,13 +811,13 @@ public class SqlDatabaseIO
 	{
 		//System.out.println("  SqlDatabaseIO.readPlatformList()");
 
-		try 
+		try
 		{
 			_platformListIO.read(platformList);
 			if (commitAfterSelect)
 				commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			System.err.println(e);
 			e.printStackTrace(System.err);
@@ -834,13 +835,13 @@ public class SqlDatabaseIO
 	{
 		//System.out.println("  SqlDatabaseIO.readConfigList()");
 
-		try 
+		try
 		{
 			_configListIO.read(pcList);
 			if (commitAfterSelect)
 				commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			System.err.println(e);
 			e.printStackTrace(System.err);
@@ -867,13 +868,13 @@ public class SqlDatabaseIO
 	public synchronized void readEquipmentModelList(EquipmentModelList eml)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_equipmentModelListIO.read(eml);
 			if (commitAfterSelect)
 				commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			throw new DatabaseException(e.toString());
 		}
@@ -890,13 +891,13 @@ public class SqlDatabaseIO
 	{
 		//System.out.println("  SqlDatabaseIO.readRoutingSpecList()");
 
-		try 
+		try
 		{
 			_routingSpecListIO.read(rsList);
 			if (commitAfterSelect)
 				commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			e.printStackTrace(System.err);
 			throw new DatabaseException(e.toString());
@@ -915,13 +916,13 @@ public class SqlDatabaseIO
 	{
 		//System.out.println("  SqlDatabaseIO.readDataSourceList()");
 
-		try 
+		try
 		{
 			_dataSourceListIO.read(dsList);
 			if (commitAfterSelect)
 				commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			throw new DatabaseException(e.toString());
 		}
@@ -936,18 +937,18 @@ public class SqlDatabaseIO
 	public synchronized void readNetworkListList(NetworkListList nlList)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_networkListListIO.read(nlList);
 			if (commitAfterSelect)
 				commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			throw new DatabaseException(e.toString());
 		}
 	}
-	
+
 	/**
 	 * Non-cached method to read the list of network list specs currently
 	 * defined in the database.
@@ -956,19 +957,19 @@ public class SqlDatabaseIO
 	public synchronized ArrayList<NetworkListSpec> getNetlistSpecs()
 		throws DatabaseException
 	{
-		try 
+		try
 		{
-			ArrayList<NetworkListSpec> ret = 
+			ArrayList<NetworkListSpec> ret =
 				_networkListListIO.getNetlistSpecs();
 			if (commitAfterSelect)
 				commit();
 			return ret;
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			throw new DatabaseException(e.toString());
 		}
-		
+
 	}
 
 
@@ -981,13 +982,13 @@ public class SqlDatabaseIO
 	public synchronized void readPresentationGroupList(PresentationGroupList pgList)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_presentationGroupListIO.read(pgList);
 			if (commitAfterSelect)
 				commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			System.err.println(e);
 			e.printStackTrace(System.err);
@@ -1012,7 +1013,7 @@ public class SqlDatabaseIO
 		{
 			throw new DatabaseException(ex.getMessage());
 		}
-		finally 
+		finally
 		{
 			dtdao.close();
 			Database.setDb(oldDb);
@@ -1032,7 +1033,7 @@ public class SqlDatabaseIO
 		{
 			throw new DatabaseException(ex.getMessage());
 		}
-		finally 
+		finally
 		{
 			dtdao.close();
 		}
@@ -1060,14 +1061,14 @@ public class SqlDatabaseIO
 		Logger.instance().log(Logger.E_INFORMATION,
 			"Writing engineering unit list.");
 
-		try 
+		try
 		{
 			_engineeringUnitIO.write(top);
 			UnitConverterSet ucs = top.getDatabase().unitConverterSet;
 			_unitConverterIO.write(ucs);
 //			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1151,7 +1152,7 @@ public class SqlDatabaseIO
 			siteDao.close();
 		}
 	}
-	
+
 	public synchronized Site getSiteBySiteName(SiteName sn)
 		throws DatabaseException
 	{
@@ -1186,13 +1187,13 @@ public class SqlDatabaseIO
 	{
 		//System.out.println("SqlDatabaseIO.readPlatform()");
 
-		try 
+		try
 		{
-			_platformListIO.readPlatform(p); 
+			_platformListIO.readPlatform(p);
 			if (commitAfterSelect)
 				commit();
 		}
-		catch (SQLException ex) 
+		catch (SQLException ex)
 		{
 			System.err.println(ex);
 			ex.printStackTrace();
@@ -1204,7 +1205,7 @@ public class SqlDatabaseIO
 		Date timeStamp)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			DbKey id = _platformListIO.lookupPlatformId(
 				mediumType, mediumId, timeStamp);
@@ -1212,28 +1213,28 @@ public class SqlDatabaseIO
 				commit();
 			return id;
 		}
-		catch (SQLException ex) 
+		catch (SQLException ex)
 		{
 			System.err.println(ex);
 			ex.printStackTrace();
 			throw new DatabaseException(ex.toString());
 		}
 	}
-	
+
 	/** Find a platform ID by site name, and optionally, designator */
-	public synchronized DbKey lookupCurrentPlatformId(SiteName sn, 
+	public synchronized DbKey lookupCurrentPlatformId(SiteName sn,
 		String designator, boolean useDesignator)
 		throws DatabaseException
 	{
-			try 
+			try
 			{
-				DbKey id = _platformListIO.lookupCurrentPlatformId(sn, 
+				DbKey id = _platformListIO.lookupCurrentPlatformId(sn,
 					designator, useDesignator);
 				if (commitAfterSelect)
 					commit();
 				return id;
 			}
-			catch (SQLException ex) 
+			catch (SQLException ex)
 			{
 				System.err.println(ex);
 				ex.printStackTrace();
@@ -1250,12 +1251,12 @@ public class SqlDatabaseIO
 	public synchronized void writePlatform( Platform p )
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_platformListIO.writePlatform(p);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			String msg = e.getMessage();
 			if (!msg.toLowerCase().contains("insufficient priv"))
@@ -1274,8 +1275,8 @@ public class SqlDatabaseIO
 
 	/**
 	  @param p the object to check in the database.
-	  @return Date object representing the last modify time for this 
-	  platform in the database, or null if the platform no longer exists 
+	  @return Date object representing the last modify time for this
+	  platform in the database, or null if the platform no longer exists
 	  in the database.
 	*/
 	public synchronized Date getPlatformLMT(Platform p)
@@ -1314,12 +1315,12 @@ public class SqlDatabaseIO
 	public synchronized void deletePlatform( Platform p )
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_platformListIO.delete(p);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1345,13 +1346,13 @@ public class SqlDatabaseIO
 	public void readConfig(PlatformConfig pc)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_configListIO.readConfig(pc.getId());
 			if (commitAfterSelect)
 				commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			e.printStackTrace(System.err);
 			throw new DatabaseException(e.toString());
@@ -1368,12 +1369,12 @@ public class SqlDatabaseIO
 	public synchronized void writeConfig(PlatformConfig pc)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_configListIO.write(pc);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			String msg = e.getMessage();
 			if (!msg.toLowerCase().contains("insufficient priv"))
@@ -1399,12 +1400,12 @@ public class SqlDatabaseIO
 	public synchronized void deleteConfig(PlatformConfig pc)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_configListIO.delete(pc);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1437,12 +1438,12 @@ public class SqlDatabaseIO
 	public void writeEquipmentModel(EquipmentModel eqm)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_equipmentModelListIO.write(eqm);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1460,12 +1461,12 @@ public class SqlDatabaseIO
 	public synchronized void deleteEquipmentModel(EquipmentModel eqm)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_equipmentModelListIO.delete(eqm);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1503,12 +1504,12 @@ public class SqlDatabaseIO
 	public synchronized void writePresentationGroup(PresentationGroup pg)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_presentationGroupListIO.write(pg);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1526,12 +1527,12 @@ public class SqlDatabaseIO
 	public synchronized void deletePresentationGroup(PresentationGroup pg)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_presentationGroupListIO.delete(pg);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1544,8 +1545,8 @@ public class SqlDatabaseIO
 
 	/**
 	  @param pg the object to check in the database.
-	  @return Date object representing the last modify time for this 
-	  presentation group in the database, or null if the group no 
+	  @return Date object representing the last modify time for this
+	  presentation group in the database, or null if the group no
 	  longer exists in the database.
 	*/
 	public Date getPresentationGroupLMT(PresentationGroup pg)
@@ -1582,12 +1583,12 @@ public class SqlDatabaseIO
 	public synchronized void writeRoutingSpec(RoutingSpec rs)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_routingSpecListIO.write(rs);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1605,12 +1606,12 @@ public class SqlDatabaseIO
 	public synchronized void deleteRoutingSpec(RoutingSpec rs)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_routingSpecListIO.delete(rs);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1623,8 +1624,8 @@ public class SqlDatabaseIO
 
 	/**
 	  @param rs the object to check in the database.
-	  @return Date object representing the last modify time for this 
-	  routing spec in the database, or null if the routing spec no longer 
+	  @return Date object representing the last modify time for this
+	  routing spec in the database, or null if the routing spec no longer
 	  exists in the database.
 	*/
 	public synchronized Date getRoutingSpecLMT(RoutingSpec rs)
@@ -1653,12 +1654,12 @@ public class SqlDatabaseIO
 	public void writeDataSource(DataSource ds)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_dataSourceListIO.write(ds);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1677,12 +1678,12 @@ public class SqlDatabaseIO
 	public synchronized void deleteDataSource(DataSource ds)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_dataSourceListIO.delete(ds);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1703,13 +1704,13 @@ public class SqlDatabaseIO
 	public synchronized void readNetworkList( NetworkList ob )
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_networkListListIO.readNetworkList(ob);
 			if (commitAfterSelect)
 				commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			throw new DatabaseException(e.toString());
 		}
@@ -1724,12 +1725,12 @@ public class SqlDatabaseIO
 	public synchronized void writeNetworkList(NetworkList nl)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_networkListListIO.write(nl);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1747,12 +1748,12 @@ public class SqlDatabaseIO
 	public synchronized void deleteNetworkList(NetworkList nl)
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			_networkListListIO.delete(nl);
 			commit();
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			try { rollback(); }
 			catch (SQLException e1)
@@ -1765,8 +1766,8 @@ public class SqlDatabaseIO
 
 	/**
 	  @param nl the object to check in the database.
-	  @return Date object representing the last modify time for this 
-	  network list in the database, or null if the network list no longer 
+	  @return Date object representing the last modify time for this
+	  network list in the database, or null if the network list no longer
 	  exists in the database.
 	*/
 	public synchronized Date getNetworkListLMT(NetworkList nl)
@@ -1774,12 +1775,12 @@ public class SqlDatabaseIO
 	{
 		if (getDecodesDatabaseVersion() >= 6)
 		{
-			try 
+			try
 			{
-				Date d = _networkListListIO.getLMT(nl); 
+				Date d = _networkListListIO.getLMT(nl);
 				if (commitAfterSelect)
 					commit();
-				return d; 
+				return d;
 			}
 			catch(Exception ex)
 			{
@@ -1814,7 +1815,7 @@ public class SqlDatabaseIO
 		{
 			enumSqlDao.writeEnumList(enumList);
 		}
-		catch (DbIoException ex) 
+		catch (DbIoException ex)
 		{
 			throw new DatabaseException(ex.toString());
 		}
@@ -1825,11 +1826,12 @@ public class SqlDatabaseIO
 	}
 
 
-	/** 
+	/**
 	  @deprecated Platform IDs are now assigned with the getKey method
 	  in this class.
 	  @see SqlDatabaseIO#getKey
 	*/
+	@Deprecated
 	public Counter getPlatformIdCounter()
 	{
 		//System.out.println("SqlDatabaseIO.getPlatformIdCounter()");
@@ -1858,7 +1860,7 @@ public class SqlDatabaseIO
 	{
 		return _conn;
 	}
-	
+
 	public void setConnection(Connection conn)
 	{
 		_conn = conn;
@@ -1899,7 +1901,7 @@ public class SqlDatabaseIO
 	{
 		commitAfterSelect=status;
 	}
-	
+
 	/**
 	  Reads  names of NetworkList  from the database.  This uses
 	  the transport id to uniquely identify the networklist containing that transport id
@@ -1909,19 +1911,19 @@ public class SqlDatabaseIO
 	public synchronized ArrayList<String> readNetworkListName( String transportId )
 		throws DatabaseException
 	{
-		try 
+		try
 		{
 			 ArrayList<String> networkListArray=_platformListIO.readNetworKListName(transportId);
 			if (commitAfterSelect)
 				commit();
 			return networkListArray;
 		}
-		catch (SQLException e) 
+		catch (SQLException e)
 		{
 			throw new DatabaseException(e.toString());
 		}
 	}
-	
+
 //	/**
 //	  Reads  names of NetworkList  from the database.  This uses
 //	  the transport id to uniquely identify the networklist containing that transport id
@@ -1929,7 +1931,7 @@ public class SqlDatabaseIO
 //	  @param transportId the value of transport id contained in network list.
 //	*/
 //	public synchronized void updateTransportId( String oldtransportId, String newTransportId )
-//		
+//
 //	{
 //		try{
 //		_platformListIO.updateTransportId(oldtransportId, newTransportId);
@@ -1939,7 +1941,7 @@ public class SqlDatabaseIO
 //			//System.out.println(ex);
 //			ex.printStackTrace(System.out);
 //		}
-//			catch (SQLException e) 
+//			catch (SQLException e)
 //			{
 //				//System.out.println(e);
 //				e.printStackTrace(System.out);
@@ -1950,18 +1952,18 @@ public class SqlDatabaseIO
 //					e1.printStackTrace(System.err);
 //
 //				}
-//				
+//
 //			}
-//			
+//
 //	}
-	
+
 	public boolean isOracle()
 	{
 		return _isOracle;
 	}
-	
+
 	public boolean isCwms() { return false; }
-	
+
 	@Override
 	public int getTsdbVersion()
 	{
@@ -1998,7 +2000,7 @@ public class SqlDatabaseIO
 	{
 		return new PropertiesSqlDao(this);
 	}
-	
+
 	@Override
 	public DataTypeDAI makeDataTypeDAO()
 	{
@@ -2011,7 +2013,7 @@ public class SqlDatabaseIO
 		{
 			return oracleDateParser.getTimeStamp(rs, column);
 		}
-		try 
+		try
 		{
 			java.sql.Timestamp ts = rs.getTimestamp(column, readCal);
 			if (rs.wasNull())
@@ -2182,7 +2184,7 @@ public class SqlDatabaseIO
 		if (getDecodesDatabaseVersion() >= DecodesDatabaseVersion.DECODES_DB_10)
 			return new ScheduleEntryDAO(this);
 		else
-			return null; 
+			return null;
 	// ISSUE: I need to have an xml schedule entry DAO or none at all?
 	// XmlScheduleEntryDAO wants parent to be XmlDatabaseIO.
 	}
@@ -2209,7 +2211,7 @@ public class SqlDatabaseIO
 		if (getDecodesDatabaseVersion() >= DecodesDatabaseVersion.DECODES_DB_10)
 			return new PlatformStatusDAO(this);
 		else
-			return null; 
+			return null;
 	}
 
 	@Override
@@ -2217,7 +2219,7 @@ public class SqlDatabaseIO
 	{
 		return new DeviceStatusDAO(this);
 	}
-	
+
 	@Override
 	public DacqEventDAI makeDacqEventDAO()
 	{
@@ -2233,7 +2235,7 @@ public class SqlDatabaseIO
 		// This is a CWMS thing. Base class returns null.
 		return null;
 	}
-	
+
 	public OracleDateParser makeOracleDateParser(TimeZone tz)
 	{
 		return new OracleDateParser(tz);

--- a/src/main/java/decodes/sql/SqlDbObjIo.java
+++ b/src/main/java/decodes/sql/SqlDbObjIo.java
@@ -1,8 +1,8 @@
 /*
  * $Id$
- * 
+ *
  * Open Source Software
- * 
+ *
  * $Log$
  * Revision 1.1.1.1  2014/05/19 15:28:59  mmaloney
  * OPENDCS 6.0 Initial Checkin
@@ -49,14 +49,14 @@ public class SqlDbObjIo
 
 	/** Used to format timestamps written to the database. */
 	private SimpleDateFormat writeDateFmt = null;
-	
+
 	/** Used to parse dates & timestamps read from the database */
 	private SimpleDateFormat readDateFmt = null;
 
 	private Calendar readCal = null;
-	
+
 	private OracleDateParser oracleDateParser = null;
-	
+
 	/**
 	 * Lazy initialization, called at the first time a date or timestamp
 	 * is needing to be parsed or formatted. Can't do this in the constructor
@@ -81,13 +81,13 @@ public class SqlDbObjIo
 		writeDateFmt = new SimpleDateFormat(writeFmt);
 		writeDateFmt.setTimeZone(TimeZone.getTimeZone(_dbio.databaseTimeZone));
 //		debug3("set writeDateFmt to '" + writeFmt + "' with timezone '" + _dbio.databaseTimeZone + "'");
-		
+
 		readDateFmt = new SimpleDateFormat(readFmt);
 		readDateFmt.setTimeZone(TimeZone.getTimeZone(_dbio.databaseTimeZone));
 		readCal = Calendar.getInstance(TimeZone.getTimeZone(_dbio.databaseTimeZone));
 //		debug3("set readDateFmt to '" + readFmt + "' with timezone '" + _dbio.databaseTimeZone + "'");
 	}
-	
+
 	/**
 	* Construct with a reference to this object's parent.
 	* @param dbio the parent dbio object.
@@ -147,7 +147,7 @@ public class SqlDbObjIo
 		if (arg == null) return "NULL";
 		return sqlReqString(arg);
 	}
-	
+
 	public String sqlOptString(String arg, int maxlen)
 	{
 		if (arg != null && arg.length() > maxlen)
@@ -166,7 +166,7 @@ public class SqlDbObjIo
 		String a = "";
 		int from = 0;
 		int to;
-		while ( (to = arg.indexOf('\'', from)) != -1 ) 
+		while ( (to = arg.indexOf('\'', from)) != -1 )
 		{
 			a += arg.substring(from, to) + "''";
 			from = to + 1;
@@ -222,6 +222,7 @@ public class SqlDbObjIo
 	  @deprecated  for compatibility with Oracle, which doesn't support the
 	  SQL boolean data type.
 	*/
+	@Deprecated
 	public String sqlBool(boolean b)
 	{
 		return b ? "true" : "false";
@@ -299,16 +300,16 @@ public class SqlDbObjIo
 		{
 			stmt = createStatement();
 
-			Logger.instance().log(Logger.E_DEBUG2, 
+			Logger.instance().log(Logger.E_DEBUG2,
 				"Executing update query '" + q + "'");
 			int numChanged = stmt.executeUpdate(q);
-			if (numChanged == 0) 
+			if (numChanged == 0)
 				throw new DatabaseException("Failed to update the " +
 					"SQL database.  The query was \"" + q + "\"");
 		}
 		finally
 		{
-			try { if (stmt != null) stmt.close(); } 
+			try { if (stmt != null) stmt.close(); }
 			catch(Exception x) {}
 		}
 	}
@@ -334,7 +335,7 @@ public class SqlDbObjIo
 	}
 
 	/** @return the database connection. */
-	public Connection connection() 
+	public Connection connection()
 	{
 		return _dbio.getConnection();
 	}
@@ -394,11 +395,11 @@ public class SqlDbObjIo
 	public String escapeString(String s)
 	{
 		if ( s == null ) return("null");
-		
-		//If the SQL database is Oracle, set escapeBackslash = false 
+
+		//If the SQL database is Oracle, set escapeBackslash = false
 		if (_dbio.isOracle())
 			escapeBackslash = false;
-		
+
 		s = sqlReqString(s);
 		if (!escapeBackslash)
 			return s;
@@ -417,7 +418,7 @@ public class SqlDbObjIo
 		}
 		return (escaped ? "E" : "") + ret.toString();
 	}
-	
+
 	/**
 	  Convenience method to generate debug msg.
 	  @param msg the message

--- a/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -1165,7 +1165,7 @@ public abstract class TimeSeriesDb
 
 		// Oracle was providing things in the wrong timestamp using current_timestamp.
 		// TODO: needs to be checked against Postgres
-		String curTime = this.isOracle() ? "sysdate" : "current_timestamp" );
+		String curTime = this.isOracle() ? "sysdate" : "current_timestamp" ;
 		try(
 			PreparedStatement deleteNormal = conn.prepareStatement("delete from CP_COMP_TASKLIST where RECORD_NUM = ?");
 			PreparedStatement deleteFailedAfterMaxRetries = conn.prepareStatement(

--- a/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -6,10 +6,10 @@
 *  source code for your own purposes, except that no part of the information
 *  contained in this file may be claimed to be proprietary.
 *
-*  Except for specific contractual terms between ILEX and the federal 
+*  Except for specific contractual terms between ILEX and the federal
 *  government, this source code is provided completely without warranty.
 *  For more information contact: info@ilexeng.com
-*  
+*
 *  $Log: TimeSeriesDb.java,v $
 *  Revision 1.25  2020/02/14 15:15:40  mmaloney
 *  dev
@@ -290,7 +290,7 @@
 *  added getMediumIdForPlatform
 *
 *  Revision 1.69  2011/10/05 17:07:40  mmaloney
-*  moved determineTsdbVersion to this base-class setConnection method. 
+*  moved determineTsdbVersion to this base-class setConnection method.
 *
 *  Revision 1.68  2011/06/16 14:06:55  mmaloney
 *  move doQuery2 to base class
@@ -407,6 +407,8 @@ import ilex.var.NamedVariable;
 import ilex.var.TimedVariable;
 import ilex.var.Variable;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -481,14 +483,14 @@ public abstract class TimeSeriesDb
 	implements HasProperties, DatabaseConnectionOwner
 {
 	public static String module = "tsdb";
-	
+
 	/** The application ID of the connected program */
 	protected DbKey appId = Constants.undefinedId;
 
 	/** The model run ID currently in use for writing data. */
 	protected int writeModelRunId;
 
-	/** 
+	/**
 	 * Flag indicating test mode: If set no changes should be made
 	 * to the database. Log messages only.
 	 */
@@ -525,8 +527,8 @@ public abstract class TimeSeriesDb
 	/** TSDB description */
 	public String tsdbDescription;
 
-	/** 
-	* Set to true if the SDI is sufficient to specify a unique time series. 
+	/**
+	* Set to true if the SDI is sufficient to specify a unique time series.
 	* For USBR-HDB: false, interval and table selector are also required.
 	* for USACE-CWMS: true - SDI is ts_code, which is unique key.
 	*/
@@ -541,29 +543,29 @@ public abstract class TimeSeriesDb
 	protected String decodesDatabaseOptions = "";
 
 	protected String dbUser = "unknown";
-	
+
 	protected Properties props = new Properties();
 
 	protected String cpCompDepends_col1 = null;
 //	protected TsIdCache tsIdCache = null;
 	protected long lastTsidCacheRead = 0L;
-	protected SimpleDateFormat debugDateFmt = 
+	protected SimpleDateFormat debugDateFmt =
 		new SimpleDateFormat("MM/dd/yyyy-HH:mm:ss z");
 
 	protected Calendar readCal = null;
 	private OracleDateParser oracleDateParser = null;
 	protected String databaseTimezone = "UTC";
 	protected boolean _isOracle = false;
-	
-	/** 
+
+	/**
 	 * Set by the reclaimTasklistSec Computation App Property.
 	 * Default=0, meaning that the feature is disabled.
 	 */
 	protected int reclaimTasklistSec = 0;
-	
+
 	// If reclaimTasklistSec > 0, this is the time the reclaim was last done.
 	protected long lastReclaimMsec = 0L;
-	
+
 	/**
 	 * Lazy initialization, called at the first time a date or timestamp
 	 * is needing to be parsed or formatted. Can't do this in the constructor
@@ -575,7 +577,7 @@ public abstract class TimeSeriesDb
 	public TimeSeriesDb()
 	{
 //		DecodesSettings settings = DecodesSettings.instance();
-		
+
 		writeModelRunId = Constants.undefinedIntKey;
 		testMode = false;
 		conn = null;
@@ -594,7 +596,7 @@ public abstract class TimeSeriesDb
 	public Connection getConnection() { return conn; }
 
 	/**
-	 * Sets the JDBC connection in use by this object. 
+	 * Sets the JDBC connection in use by this object.
 	 * @param conn the connection
 	 */
 	public void setConnection(Connection conn)
@@ -604,7 +606,7 @@ public abstract class TimeSeriesDb
 	}
 
 	public KeyGenerator getKeyGenerator() { return keyGenerator; }
-	
+
 	/**
 	 * Uses the class in DecodesSettings to create a key generator.
 	 * @throws BadConnectException on any error.
@@ -624,9 +626,9 @@ public abstract class TimeSeriesDb
 				"Cannot initialize key generator from class '" + keyGenClass
 					+ "' :" + ex.toString());
 		}
-	}	
+	}
 
-	
+
 	public DbKey getKey(String tableName)
 		throws DbIoException
 	{
@@ -690,7 +692,7 @@ public abstract class TimeSeriesDb
 			throw new DbIoException(msg);
 		}
 	}
-	
+
 	/** An extra do-query for inside-loop queries. */
 	public ResultSet doQuery2(String q) throws DbIoException
 	{
@@ -755,7 +757,7 @@ public abstract class TimeSeriesDb
 			int numChanged = modStmt.executeUpdate(q);
 			return numChanged;
 // Don't do this. Some queries are OK if they modify nothing.
-//			if (numChanged == 0) 
+//			if (numChanged == 0)
 //			{
 //				String msg = "Failure in modify query '" + q + "'";
 //				Logger.instance().warning(msg);
@@ -801,7 +803,7 @@ public abstract class TimeSeriesDb
 	{
 		if (field == null)
 			return "NULL";
-		else 
+		else
 		{
 			// Have to escape any single quotes in the string.
 			if (field.indexOf('\'') >= 0)
@@ -819,10 +821,10 @@ public abstract class TimeSeriesDb
 	public void commit()
 		throws DbIoException
 	{
-		try 
+		try
 		{
 			conn.commit();
-			conn.clearWarnings(); 
+			conn.clearWarnings();
 		}
 		catch(SQLException ex) {}
 	}
@@ -852,16 +854,16 @@ public abstract class TimeSeriesDb
 			return false;
 		}
 	}
-	
+
 
 
 	//===================================================================
-	// The following methods form the main interface for a time series 
+	// The following methods form the main interface for a time series
 	// database. The abstract ones must be overloaded.
 	//===================================================================
 
 	/**
-	 * Connect this app to the database and return appID. 
+	 * Connect this app to the database and return appID.
 	 * The credentials property set contains username, password,
 	 * etc, for connecting to database.
 	 * <p>
@@ -873,8 +875,8 @@ public abstract class TimeSeriesDb
 	 */
 	public abstract DbKey connect( String appName, Properties credentials )
 		throws BadConnectException;
-	
-	
+
+
 	/**
 	 * Provides common post-connect initialization like loading the intervals
 	 * and setting the application ID.
@@ -883,10 +885,10 @@ public abstract class TimeSeriesDb
 		throws BadConnectException
 	{
 		determineTsdbVersion(getConnection(), this);
-		
+
 		// If an application name is provided, lookup the ID.
 		if (appName != null && appName.trim().length() > 0)
-		{	
+		{
 			LoadingAppDAI loadingAppDAO = makeLoadingAppDAO();
 			try
 			{
@@ -901,7 +903,7 @@ public abstract class TimeSeriesDb
 				throw new BadConnectException(msg);
 			}
 		}
-		
+
 		// Load the intervals
 		IntervalDAI intervalDAO = this.makeIntervalDAO();
 		try { intervalDAO.loadAllIntervals(); }
@@ -913,7 +915,7 @@ public abstract class TimeSeriesDb
 			ex.printStackTrace(System.err);
 		}
 	}
-	
+
 	/**
 	 * Unconditionally close the connection.
 	 */
@@ -987,7 +989,7 @@ public abstract class TimeSeriesDb
 			siteDao.close();
 		}
 	}
-	
+
 	/**
 	 * Looks up the SDI for and sets it within a DbCompParm.
 	 * Called from GUI when making assignment from site ID & data type.
@@ -998,7 +1000,7 @@ public abstract class TimeSeriesDb
 	public abstract void setParmSDI(DbCompParm parm, DbKey siteId, String dtcode)
 		throws DbIoException, NoSuchObjectException;
 
-	
+
 	/**
 	 * Fills a time series with values from the given date range (inclusive).
 	 * Must handle any unit conversions required between the unitsAbbr
@@ -1033,7 +1035,7 @@ public abstract class TimeSeriesDb
 	 * @param until the upper-bound of the range
 	 * @param include_lower true to include value at the lower-bound time.
 	 * @param include_upper true to include value at the upper-bound time.
-	 * @param overwriteExisting 
+	 * @param overwriteExisting
 	 * @return number of values added to the time series.
 	 * @throws DbIoException on Database IO error.
 	 * @throws BadTimeSeriesException if time series doesn't exist.
@@ -1078,7 +1080,7 @@ public abstract class TimeSeriesDb
 			timeSeriesDAO.close();
 		}
 	}
-	
+
 	/**
 	 * Retrieves the previous value to the specified time and stores it in the
 	 * passed time series. That is the most recent value with a time stamp
@@ -1133,10 +1135,10 @@ public abstract class TimeSeriesDb
 
 	/**
 	 * Returns an DataCollection containing zero or more TimeSeries,
-	 * containing all data added or deleted since the last call of this 
+	 * containing all data added or deleted since the last call of this
 	 * method by this application ID.
 	 * <p>
-	 * New values are marked with the DB_ADDED flag. Deleted values 
+	 * New values are marked with the DB_ADDED flag. Deleted values
 	 * marked with the DB_DELETED flag.
 	 * @param applicationId used to lookup & save the since time.
 	 * @return DataCollection with newly added or deleted values.
@@ -1144,7 +1146,7 @@ public abstract class TimeSeriesDb
 	 */
 	public abstract DataCollection getNewData( DbKey applicationId )
 		throws DbIoException;
-	
+
 	/**
 	 * Releases triggers associated with the new data in the passed collection.
 	 * The implementation may use information contained in the collection's
@@ -1157,52 +1159,105 @@ public abstract class TimeSeriesDb
 		RecordRangeHandle rrh = dc.getTasklistHandle();
 		if (rrh == null)
 			return;
-		while(rrh.size() > 0)
-		{
-			String q = "delete from CP_COMP_TASKLIST "
-			  + "where RECORD_NUM IN (" + rrh.getRecNumList(250) + ")";
-			doModify(q);
-//			commit();
-		}
 
 		int maxRetries = DecodesSettings.instance().maxComputationRetries;
 		boolean doRetryFailed = DecodesSettings.instance().retryFailedComputations;
 
-		while(rrh.getFailedRecnums().size() > 0)
-		{
-			String failRecNumList = rrh.getFailedRecNumList(250);
 
-			// Add the retry limit for failed computations
-			if (doRetryFailed && maxRetries > 0)
+		try(
+			PreparedStatement deleteNormal = conn.prepareStatement("delete from CP_COMP_TASKLIST where RECORD_NUM = ?");
+			PreparedStatement deleteFailedAfterMaxRetries = conn.prepareStatement(
+					  "delete from CP_COMP_TASKLIST "
+					+ "where RECORD_NUM = ? " // failRecList
+					+ "and (( current_timestamp - DATE_TIME_LOADED) > " // curTimeName
+					+ "INTERVAL '? hour')" ); //String.format(maxCompRetryTimeFrmt, maxRetries) + ")"); //
+			PreparedStatement updateFailedRetry = conn.prepareStatement(
+				"update CP_COMP_TASKLIST set FAIL_TIME = ? where RECORD_NUM = ? and "
+			+	"((current_timestamp - DATE_TIME_LOADED) <= INTERVAL '? hour')");
+			PreparedStatement updateFailTime = conn.prepareStatement("UPDATE CP_COMP_TASKLIST SET FAIL_TIME = current_timestamp where record_num = ?");
+
+
+		){
+			while(rrh.size() > 0)
 			{
-				String q = "delete from CP_COMP_TASKLIST "
-						  + "where RECORD_NUM IN (" + failRecNumList + ") "
-						  + "and ((" + curTimeName + " - DATE_TIME_LOADED) > "
-						  + String.format(maxCompRetryTimeFrmt, maxRetries) + ")";
-				doModify(q);
-				commit();
-				q = "update CP_COMP_TASKLIST set FAIL_TIME = " + curTimeName +
-					" where RECORD_NUM in(" + failRecNumList + ")" + 
-					" and ((" + curTimeName + " - DATE_TIME_LOADED) <= "
-					+ String.format(maxCompRetryTimeFrmt, maxRetries) + ")";
-				doModify(q);
-				commit();
-			} 
-			else
-			{
-				// DB V5 handles failed computations by setting a FAIL_TIME
-				// on the task list record. Previous version just delete record.
-				String q = (tsdbVersion >= 4 && doRetryFailed)
-				  ?	("UPDATE CP_COMP_TASKLIST SET FAIL_TIME = " + curTimeName)
-				  : "DELETE FROM CP_COMP_TASKLIST ";
-				q = q + " WHERE RECORD_NUM IN (" 
-					+ failRecNumList + ")";
-				doModify(q);
-				commit();
+				String []records = rrh.getRecNumList(250).split(",");
+				for( String rec: records ){
+					if( "".equalsIgnoreCase(rec) ) continue;
+					deleteNormal.setLong(1, Long.parseLong(rec.trim()));
+					deleteNormal.addBatch();
+				}
+
+				deleteNormal.executeBatch();
 			}
+
+			while(rrh.getFailedRecnums().size() > 0)
+			{
+				String failRecNumList = rrh.getFailedRecNumList(250);
+				String records[] = failRecNumList.split(",");
+				//Array failRecs = conn.createArrayOf("integer", failRecNumList.split(","));
+				// Add the retry limit for failed computations
+				if (doRetryFailed && maxRetries > 0)
+				{
+					debug3("updating failed records based on retry count");
+					for( String rec: records ){
+						if( "".equalsIgnoreCase(rec) ) continue;
+						deleteFailedAfterMaxRetries.setLong(1,Long.parseLong(rec.trim()));
+						//deleteFailedAfterMaxRetries.setString(2,curTimeName);
+						deleteFailedAfterMaxRetries.setInt(2,maxRetries);
+						deleteFailedAfterMaxRetries.addBatch();
+					}
+					deleteFailedAfterMaxRetries.executeBatch();
+					info("deleted failed recs past retry in (" + failRecNumList +")" );
+					for( String rec: records){
+						if( "".equalsIgnoreCase(rec) ) continue;
+						//updateFailedRetry.setString(1,curTimeName);
+						updateFailedRetry.setLong(1,Long.parseLong(rec.trim()));
+						updateFailedRetry.setInt(2, maxRetries);
+						updateFailedRetry.addBatch();
+
+					}
+					updateFailedRetry.executeBatch();
+					info("updated fail time on (" + failRecNumList + "))" );
+				}
+				else
+				{
+					// DB V5 handles failed computations by setting a FAIL_TIME
+					// on the task list record. Previous version just delete record.
+					if( tsdbVersion >= 4 && doRetryFailed ) {
+						debug3("updating failed records");
+						for( String rec: records ){
+							//updateFailTime.setString(1, curTimeName);
+							updateFailTime.setLong(1, Long.parseLong(rec.trim()));
+							//updateFailTime.setArray(2, failRecs);
+							updateFailTime.execute();
+						}
+						updateFailTime.executeBatch();
+						info("updated fail time on (" + failRecNumList + "))" );
+					} else {
+						for( String rec: records ){
+							if( "".equalsIgnoreCase(rec) ) continue;
+							deleteNormal.setLong(1, Long.parseLong(rec.trim()));
+							deleteNormal.addBatch();
+						}
+
+						deleteNormal.executeBatch();
+						info("deleted failed records: (" +failRecNumList +" )" );
+					}
+					commit();
+				}
+			}
+
+		} catch( SQLException err ){
+					//warning(err.getLocalizedMessage());
+					StringWriter sw = new StringWriter();
+					PrintWriter pw = new PrintWriter(sw);
+					err.printStackTrace(pw);
+					warning("removing items from task list failed:");
+					warning(sw.toString());
+					throw new DbIoException(err.getLocalizedMessage());
 		}
 	}
-	
+
 	/**
 	 * Called when allowed by properties and when the tasklist is empty.
 	 * Enabled by Decodes Setting reclaimTasklistSec. The default is 0 meaning
@@ -1213,7 +1268,7 @@ public abstract class TimeSeriesDb
 	public void reclaimTasklistSpace()
 		throws DbIoException
 	{
-		if (isOracle() 
+		if (isOracle()
 		 && reclaimTasklistSec > 0
 		 && System.currentTimeMillis() - lastReclaimMsec > (reclaimTasklistSec*1000L))
 		{
@@ -1226,7 +1281,7 @@ public abstract class TimeSeriesDb
 		// Unnecessary for PostgreSQL because auto-vacuum should be on
 	}
 
-	
+
 	/**
 	 * @return a list of names of all algorithms defined in thie database.
 	 * @throws DbIoException on Database IO error.
@@ -1246,7 +1301,7 @@ public abstract class TimeSeriesDb
 		catch(SQLException ex)
 		{
 			String msg = "Error listing algorithms: " + ex;
-			logger.warning(msg);	
+			logger.warning(msg);
 			throw new DbIoException(msg);
 		}
 	}
@@ -1264,7 +1319,7 @@ public abstract class TimeSeriesDb
 			while(rs != null && rs.next())
 				ret.add(new AlgorithmInList(DbKey.createDbKey(rs, 1), rs.getString(2),
 					rs.getString(3), 0, TextUtil.getFirstLine(rs.getString(4))));
-			
+
 			q = "select a.algorithm_id, count(1) as CompsUsingAlgo "
 				+ "from cp_algorithm a, cp_computation b "
 				+ "where a.algorithm_id = b.algorithm_id "
@@ -1283,17 +1338,17 @@ public abstract class TimeSeriesDb
 					}
 				}
 			}
-		
+
 			return ret;
 		}
 		catch(SQLException ex)
 		{
 			String msg = "Error listing algorithms for GUI: " + ex;
-			logger.warning(msg);	
+			logger.warning(msg);
 			throw new DbIoException(msg);
 		}
 	}
-	
+
 
 	/**
 	 * Sets the model run id for subsequent write operations of modeled data.
@@ -1303,7 +1358,7 @@ public abstract class TimeSeriesDb
 	{
 		this.writeModelRunId = modelRunId;
 	}
-	
+
 	@Override
 	public int getWriteModelRunId()
 	{
@@ -1331,7 +1386,7 @@ public abstract class TimeSeriesDb
 	 * Validate the passed information to make sure it represents a valid
 	 * parameter within this database. If not, throw ConstraintException.
 	 */
-	public abstract void validateParm(DbKey siteId, String dtcode, 
+	public abstract void validateParm(DbKey siteId, String dtcode,
 		String interval, String tabSel, int modelId)
 		throws ConstraintException, DbIoException;
 
@@ -1347,26 +1402,26 @@ public abstract class TimeSeriesDb
 		return Constants.undefinedIntKey;
 	}
 
-	
-	
+
+
 	/**
 	 * Finds the correct coefficient stored in the database for a specific set
-	 * of sdi, table selector, interval, and date. Assumes Oct 1 as beginning 
+	 * of sdi, table selector, interval, and date. Assumes Oct 1 as beginning
 	 * of year.
 	 * @param sdi the Site datatype id
 	 * @param ts the table selector
 	 * @param interval the interval
 	 * @param date the date of interest
 	 * @return the value of the coefficient
-	 * @throws DbCompException 
+	 * @throws DbCompException
 	 */
-	public double getCoeff(DbKey sdi, String ts, String interval, 
+	public double getCoeff(DbKey sdi, String ts, String interval,
 		Date date)
 		throws DbIoException, DbCompException
 	{
 		throw new DbIoException("Method getCoeff not implemented.");
 	}
-	
+
 	/**
 	 * Given a data type code of unknown standard, attempt to
 	 * interpret it as an existing data type in the database.
@@ -1377,11 +1432,11 @@ public abstract class TimeSeriesDb
 	{
 		try
 		{
-			String q = "SELECT id, standard FROM DataType WHERE upper(code) = " 
+			String q = "SELECT id, standard FROM DataType WHERE upper(code) = "
 				+ sqlString(dtcode.toUpperCase());
 			DataType pref = null;
 			DataType first = null;
-			
+
 			ResultSet rs = doQuery2(q);
 			while(rs != null && rs.next())
 			{
@@ -1410,7 +1465,7 @@ public abstract class TimeSeriesDb
 	}
 
 	/**
-	 * Used to present user with a list of valid datatypes 
+	 * Used to present user with a list of valid datatypes
 	 * for a given site. Returns 2-dimensional array of Strings suitable
 	 * for populating a table from which the user can select.
 	 * The first row of the table (i.e. r[0]) must contain the column
@@ -1425,14 +1480,14 @@ public abstract class TimeSeriesDb
 	{
 		// Default impl here just returns an empty array with 1 column
 		// labeled "Data Type".
-		
+
 		String header[] = new String[1];
 		header[0] = "Data Type";
 		ArrayList<String[]> ret = new ArrayList<String[]>();
 		ret.add(header);
 		return ret;
 	}
-	
+
 	/** @return label to use for 'limit' column in tables. */
 	public String getLimitLabel() { return "Lim"; }
 
@@ -1443,11 +1498,11 @@ public abstract class TimeSeriesDb
 	{
 		return "";
 	}
-	
+
 	/** @return label to use for 'revision' column in tables. */
 	public String getRevisionLabel() { return "Rev"; }
 
-	/** 
+	/**
 	 * @return string representation of revision status represented in the flag bits.
 	 */
 	public String flags2RevisionCodes(int flags)
@@ -1455,7 +1510,7 @@ public abstract class TimeSeriesDb
 		return null;
 	}
 
-	
+
 	public DbKey getDataSourceId(DbKey appId, DbComputation comp)
 		throws DbIoException
 	{
@@ -1490,7 +1545,7 @@ public abstract class TimeSeriesDb
 			if (rs != null && rs.next())
 			{
 				eu.setName(rs.getString(1));
-				eu.setFamily(rs.getString(2));		
+				eu.setFamily(rs.getString(2));
 				eu.setMeasures(rs.getString(3));
 			}
 		}
@@ -1501,7 +1556,7 @@ public abstract class TimeSeriesDb
 		}
 		return eu;
 	}
-	
+
 	public static void determineTsdbVersion(Connection con, TimeSeriesDb tsdb)
 	{
 		try
@@ -1514,11 +1569,11 @@ public abstract class TimeSeriesDb
 		}
 		catch (SQLException ex)
 		{
-			String msg = "determineTsdbVersion() " + 
+			String msg = "determineTsdbVersion() " +
 				"Cannot determine Database Product name and/or version: " + ex;
 			Logger.instance().warning(msg);
 		}
-		
+
 		TimeZone tz = TimeZone.getTimeZone(DecodesSettings.instance().sqlTimeZone);
 		String writeFmt = DecodesSettings.instance().sqlDateFormat;
 		String readFmt = DecodesSettings.instance().SqlReadDateFormat;
@@ -1538,23 +1593,23 @@ public abstract class TimeSeriesDb
 		readVersionInfo(tsdb);
 		tsdb.info("Connected to TSDB Version " + tsdb.tsdbVersion + ", Description: " + tsdb.tsdbDescription);
 		tsdb.readTsdbProperties();
-		tsdb.cpCompDepends_col1 = tsdb.isHdb() || tsdb.tsdbVersion >= TsdbDatabaseVersion.VERSION_9 
+		tsdb.cpCompDepends_col1 = tsdb.isHdb() || tsdb.tsdbVersion >= TsdbDatabaseVersion.VERSION_9
 			? "TS_ID" : "SITE_DATATYPE_ID";
-		
+
 	}
-	
+
 	public OracleDateParser makeOracleDateParser(TimeZone tz)
 	{
 		return new OracleDateParser(tz);
 	}
-	
+
 	public static void readVersionInfo(DatabaseConnectionOwner dco)
 	{
 		/*
 		  Attempt to read the database's version number.
 		*/
 		int tsdbVersion = TsdbDatabaseVersion.VERSION_2;  // earliest possible value.
-		String tsdbDescription = "";	
+		String tsdbDescription = "";
 		String q = "SELECT * FROM tsdb_database_version";
 		Statement stmt = null;
 		try
@@ -1574,7 +1629,7 @@ public abstract class TimeSeriesDb
 		}
 		catch(Exception ex)
 		{
-			String msg = "readVersionInfo() " + 
+			String msg = "readVersionInfo() " +
 				"Cannot determine TimeSeries Database version: " + ex;
 			Logger.instance().warning(msg);
 			tsdbVersion = TsdbDatabaseVersion.VERSION_2;  // earliest possible value.
@@ -1605,12 +1660,12 @@ public abstract class TimeSeriesDb
 		}
 		catch(Exception ex)
 		{
-			String msg = "readTsdbProperties() " + 
+			String msg = "readTsdbProperties() " +
 				"Cannot read TimeSeries Database properties: " + ex;
 			logger.warning(msg);
 		}
 	}
-	
+
 	public void writeTsdbProperties(Properties props)
 		throws DbIoException
 	{
@@ -1629,13 +1684,13 @@ public abstract class TimeSeriesDb
 			doModify(q);
 			if (val != null)
 			{
-				q = "insert into tsdb_property values(" + sqlString(key) 
+				q = "insert into tsdb_property values(" + sqlString(key)
 					+ ", " + sqlString(val) + ")";
 				doModify(q);
 			}
 		}
 	}
-	
+
 	public Site getSiteById(DbKey id)
 		throws DbIoException, NoSuchObjectException
 	{
@@ -1647,7 +1702,7 @@ public abstract class TimeSeriesDb
 		}
 	}
 
-	/** 
+	/**
 	 * Adds a property to this object's meta-data.
 	 * @param name the property name.
 	 * @param value the property value.
@@ -1679,11 +1734,11 @@ public abstract class TimeSeriesDb
 	/**
 	 * The first string is the label for site/location
 	 * The second string is the label for data type/param
-	 * 
+	 *
 	 * @return
 	 */
 	public abstract String[] getTsIdParts();
-	
+
 	/**
 	 * Removes a property assignment.
 	 * @param name the property name.
@@ -1725,7 +1780,7 @@ public abstract class TimeSeriesDb
 	{
 		Logger.instance().fatal(module + " " + msg);
 	}
-	
+
 	/**
 	 * Construct a new TSID object appropriate for this DB, but do no I/O.
 	 * @return new, empty TSID object.
@@ -1750,7 +1805,7 @@ public abstract class TimeSeriesDb
 			tsGroupDAO.close();
 		}
 	}
-	
+
 	/**
 	 * @return a TsGroup by its unique name.
 	 */
@@ -1796,7 +1851,7 @@ public abstract class TimeSeriesDb
 	{
 		// Save ID before write
 		DbKey id = group.getGroupId();
-		
+
 		TsGroupDAI tsGroupDAO = makeTsGroupDAO();
 		try
 		{
@@ -1825,13 +1880,13 @@ public abstract class TimeSeriesDb
 					whereClause.append("" + groupId + ",");
 				whereClause.deleteCharAt(whereClause.length()-1);
 				whereClause.append(")");
-				
+
 				String q = tsdbVersion < TsdbDatabaseVersion.VERSION_6
 					? ("SELECT DISTINCT COMPUTATION_ID FROM CP_COMP_TS_PARM "
 						+ whereClause.toString())
 					: ("SELECT COMPUTATION_ID FROM CP_COMPUTATION "
 						+ whereClause.toString());
-				
+
 				ArrayList<DbKey> compIds = new ArrayList<DbKey>();
 				ResultSet rs = doQuery(q);
 				while (rs.next())
@@ -1860,7 +1915,7 @@ public abstract class TimeSeriesDb
 			}
 		}
 	}
-	
+
 	/**
 	 * Recursive function to find all of the group IDs that are 'affected' by
 	 * the passed groupId. That is, find groups that either include or exclude
@@ -1964,19 +2019,19 @@ public abstract class TimeSeriesDb
 //		commit();
 	}
 
-	
+
 	public String getDbUser() { return dbUser; }
-	
+
 	@Override
 	public boolean isCwms() { return false; }
-	
+
 	@Override
 	public boolean isHdb() { return false; }
-	
+
 	@Override
 	public boolean isOpenTSDB() { return false; }
 
-	
+
 	public ArrayList<String> listParamTypes()
 		throws DbIoException
 	{
@@ -1989,7 +2044,7 @@ public abstract class TimeSeriesDb
 	 * @return
 	 */
 	public String[] getDataTypesByStandard(String dataTypeStandard)
-	  throws DbIoException 
+	  throws DbIoException
 	{
 		ArrayList<String> ret = new ArrayList<String>();
 
@@ -2026,9 +2081,9 @@ public abstract class TimeSeriesDb
 
 		return retString;
 	}
-	
+
 	public String[] getParamTypes() throws DbIoException { return null; }
-	
+
 	/**
 	 * Passed one of the 'part' specifiers of a TimeSeriesIdentifier. If the
 	 * database defines a limited set of valid choices, return the list.
@@ -2076,7 +2131,7 @@ public abstract class TimeSeriesDb
 	}
 
 // TODO MJM Consider moving the following into CompDependsDAO.
-	
+
 	/**
 	 * Passed a time series with valid meta data (tsid).
 	 * Determine the computations that depend on this time series.
@@ -2103,15 +2158,15 @@ public abstract class TimeSeriesDb
 		}
 		return cts.getDependentCompIds().size();
 	}
-	
+
 //	public void removeTsDependencies(TimeSeriesIdentifier tsid)
 //		throws DbIoException
 //	{
 //		DbKey key = tsid.getKey();
 //		// Remove any computation dependencies to this time-series.
-//		doModify("DELETE FROM CP_COMP_DEPENDS WHERE " + cpCompDepends_col1 + " = " 
+//		doModify("DELETE FROM CP_COMP_DEPENDS WHERE " + cpCompDepends_col1 + " = "
 //			+ key);
-//		
+//
 //		// Disable any computations that use this time-series as input or
 //		// output.
 //		String q = "select distinct a.computation_id from "
@@ -2122,14 +2177,14 @@ public abstract class TimeSeriesDb
 //		String mq = "update cp_computation set enabled = 'N' "
 //			+ "where computation_id in (" + q + ")";
 //		doModify(mq);
-//		
+//
 //		// If this ts is explicitly included in a group, remove it.
 //		q = "delete from tsdb_group_member_ts where "
 //			+ (getTsdbVersion() >= TsdbDatabaseVersion.VERSION_9 ? "ts_id" : "data_id")
 //			+ " = "+key;
 //		doModify(q);
 //	}
-//	
+//
 	/**
 	 * Return the platform ID of a given type for the specified platform, or null
 	 * if there is none.
@@ -2142,7 +2197,7 @@ public abstract class TimeSeriesDb
 		String q = "select mediumid from transportmedium"
 			+ " where platformId = " + platformID
 			+ " and upper(mediumtype) = " + sqlString(mediumType.toUpperCase());
-		
+
 		try
 		{
 			ResultSet rs = doQuery2(q);
@@ -2158,7 +2213,7 @@ public abstract class TimeSeriesDb
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Get next CP_COMP_DEPENDS_NOTIFY record and remove it from the table.
 	 * @return next CP_COMP_DEPENDS_NOTIFY record or null if none.
@@ -2183,10 +2238,10 @@ public abstract class TimeSeriesDb
 					ret.setEventType(s.charAt(0));
 				ret.setKey(DbKey.createDbKey(rs, 3));
 				ret.setDateTimeLoaded(getFullDate(rs, 4));
-				
-				doModify("delete from CP_DEPENDS_NOTIFY where RECORD_NUM = " 
+
+				doModify("delete from CP_DEPENDS_NOTIFY where RECORD_NUM = "
 					+ ret.getRecordNum(), true);
-				
+
 				return ret;
 			}
 		}
@@ -2196,7 +2251,7 @@ public abstract class TimeSeriesDb
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Given a unique time-series identifier string, make a CTimeSeries
 	 * object, populated with meta-data from the database.
@@ -2219,7 +2274,7 @@ public abstract class TimeSeriesDb
 			timeSeriesDAO.close();
 		}
 	}
-	
+
 	/**
 	 * Given a time-series identifier, make a CTimeSeries
 	 * object, populated with meta-data from the database.
@@ -2232,7 +2287,7 @@ public abstract class TimeSeriesDb
 		throws DbIoException, NoSuchObjectException
 	{
 		DbKey sdi = isHdb() ? ((HdbTsId)tsid).getSdi() : tsid.getKey();
-		CTimeSeries ret = new CTimeSeries(sdi, tsid.getInterval(), 
+		CTimeSeries ret = new CTimeSeries(sdi, tsid.getInterval(),
 			tsid.getTableSelector());
 		ret.setTimeSeriesIdentifier(tsid);
 		ret.setDisplayName(tsid.getDisplayName());
@@ -2276,7 +2331,7 @@ public abstract class TimeSeriesDb
 	{
 		warning("writeTasklistRecord not implemented");
 	}
-	
+
 	/**
 	 * Use database-specific flag definitions to determine whether the
 	 * passed variable should be considered 'questionable'.
@@ -2288,7 +2343,7 @@ public abstract class TimeSeriesDb
 		// The base class implementation here always returns false.
 		return false;
 	}
-	
+
 	/**
 	 * Use database-specific flag definitions to set the passed variable
 	 * as 'questionable'.
@@ -2299,13 +2354,13 @@ public abstract class TimeSeriesDb
 		// The base class implementation here does nothing.
 		return;
 	}
-	
+
 	public void setTsdbVersion(int version, String description)
 	{
 		this.tsdbVersion = version;
 		this.tsdbDescription = description;
 	}
-	
+
 	public void setDecodesDatabaseVersion(int version, String options)
 	{
 		this.decodesDatabaseVersion = version;
@@ -2323,25 +2378,25 @@ public abstract class TimeSeriesDb
 	{
 		return new PropertiesSqlDao(this);
 	}
-	
+
 	@Override
 	public DataTypeDAI makeDataTypeDAO()
 	{
 		return new DataTypeDAO(this);
 	}
-	
+
 	public boolean isOracle()
 	{
 		return _isOracle;
 	}
-	
+
 	public Date getFullDate(ResultSet rs, int column)
 	{
 		if (oracleDateParser != null)
 		{
 			return oracleDateParser.getTimeStamp(rs, column);
 		}
-		try 
+		try
 		{
 			java.sql.Timestamp ts = rs.getTimestamp(column, readCal);
 			if (rs.wasNull())
@@ -2367,19 +2422,19 @@ public abstract class TimeSeriesDb
 			}
 		}
 	}
-	
+
 	@Override
 	public String getDatabaseTimezone()
 	{
 		return databaseTimezone;
 	}
-	
+
 	@Override
 	public DbKey getAppId()
 	{
 		return appId;
 	}
-	
+
 	public void setAppId(DbKey appId)
 	{
 		this.appId = appId;
@@ -2403,16 +2458,16 @@ public abstract class TimeSeriesDb
 			return ts;
 		return "'" + ts + "'";
 	}
-	
+
 	@Override
 	public SimpleDateFormat getLogDateFormat() { return debugDateFmt; }
-	
+
 	@Override
 	public SiteDAI makeSiteDAO()
 	{
 		return new SiteDAO(this);
 	}
-	
+
 	public XmitRecordDAO makeXmitRecordDao(int maxDays)
 	{
 		return new XmitRecordDAO(this, maxDays);
@@ -2429,7 +2484,7 @@ public abstract class TimeSeriesDb
 	{
 		return new AlgorithmDAO(this);
 	}
-	
+
 	@Override
 	public TsGroupDAI makeTsGroupDAO()
 	{
@@ -2441,19 +2496,19 @@ public abstract class TimeSeriesDb
 	{
 		return new ComputationDAO(this);
 	}
-	
+
 	@Override
 	public CompDependsDAI makeCompDependsDAO()
 	{
 		return new CompDependsDAO(this);
 	}
-	
+
 	@Override
 	public PlatformStatusDAI makePlatformStatusDAO()
 	{
 		return new PlatformStatusDAO(this);
 	}
-	
+
 	@Override
 	public DeviceStatusDAI makeDeviceStatusDAO()
 	{
@@ -2465,20 +2520,20 @@ public abstract class TimeSeriesDb
 	{
 		return new DacqEventDAO(this);
 	}
-	
+
 	@Override
-	public ScreeningDAI makeScreeningDAO() 
+	public ScreeningDAI makeScreeningDAO()
 		throws DbIoException
 	{
 		// This is a CWMS thing. So Base class returns null.
 		return null;
 	}
-	
+
 	public GroupHelper makeGroupHelper()
 	{
 		return null;
 	}
-	
+
 	@Override
 	public ArrayList<TimeSeriesIdentifier> expandTsGroup(TsGroup tsGroup)
 		throws DbIoException
@@ -2489,7 +2544,7 @@ public abstract class TimeSeriesDb
 		groupHelper.expandTsGroup(tsGroup);
 		return tsGroup.getExpandedList();
 	}
-	
+
 	/**
 	 * Perform a database-specific rating. This method should be overloaded by concrete
 	 * database class if the database supports rating.
@@ -2510,13 +2565,13 @@ public abstract class TimeSeriesDb
 	{
 		return new ArrayList<String>();
 	}
-	
+
 	@Override
 	public AlarmDAI makeAlarmDAO()
 	{
 		return new AlarmDAO(this);
 	}
-	
+
 	/**
 	 * Given a datatype, return the default storage units for that data type
 	 * in this database. CWMS and HDB implement this differently. The default
@@ -2528,7 +2583,7 @@ public abstract class TimeSeriesDb
 	{
 		return null;
 	}
-	
+
 	/**
 	 * Convert a time series flag value into a character representation. Flag bits
 	 * are defined differently in the underlying databases.

--- a/src/main/java/decodes/util/DecodesSettings.java
+++ b/src/main/java/decodes/util/DecodesSettings.java
@@ -1,6 +1,6 @@
 /*
 *  $Id: DecodesSettings.java,v 1.31 2020/01/31 19:45:13 mmaloney Exp $
-*  
+*
 *  $Log: DecodesSettings.java,v $
 *  Revision 1.31  2020/01/31 19:45:13  mmaloney
 *  dev
@@ -167,7 +167,7 @@ public class DecodesSettings
 	implements PropertiesOwner
 {
 	private static DecodesSettings _instance = null;
-	
+
 	public enum DbTypes { XML, DECODES_SQL, NWIS, CWMS, HDB, OPENTSDB };
 
 	/** Code meaning NO database (for production only) */
@@ -219,16 +219,16 @@ public class DecodesSettings
 	/** Time zone used for determining aggregate periods in computations. */
 	public String aggregateTimeZone = "UTC";
 
-	/** 
-	 * For SQL Database, this sets the Connection autoCommit option. 
+	/**
+	 * For SQL Database, this sets the Connection autoCommit option.
 	 * Set to true/false. The default is blank, which leaves the connection at
 	 * whatever default is provided by the JDBC driver.
 	 */
 	public String autoCommit = "true";
-	
+
 	/** Default Agency for use in variable expansions */
 	public String agency = "";
-	
+
 	/** Default Location for use in variable expansions */
 	public String location = "";
 
@@ -260,7 +260,7 @@ public class DecodesSettings
 
 	/** Default data type standard, used in DB-editor & some formatters. */
 	public String dataTypeStdPreference = Constants.datatype_SHEF;
-	
+
 	/** Timezone used in Decoding Wizard */
 	public String decwizTimeZone = "UTC";
 
@@ -295,6 +295,7 @@ public class DecodesSettings
 	public boolean setPlatformDesignatorName=false;
 
 	/** @deprecated Set to true if the 1st line of site description contains long name. */
+	@Deprecated
 	public boolean hdbSiteDescriptions = false;
 
 	/** Language for internationalization */
@@ -308,27 +309,27 @@ public class DecodesSettings
 
 	/** Indicates the minimum algorithm id showed in the comp edit algo list */
 	public int minAlgoId = 0;
-	
-	/** Indicates the minimum computation id showed in the comp edit 
+
+	/** Indicates the minimum computation id showed in the comp edit
 	 * computation list */
 	public int minCompId = 0;
-	
+
 	/** Indicates the minimum process id showed in the comp edit process list */
 	public int minProcId = 0;
 
-	/** 
-	 * Max allowable missing values for auto interp/prev/next/closest fill. 
+	/**
+	 * Max allowable missing values for auto interp/prev/next/closest fill.
 	 * This works for values where the interval is not 0 (i.e. not INSTANT).
-	 * The setting here defines the default. It can be overridden by 
+	 * The setting here defines the default. It can be overridden by
 	 * computation/algorithm properties of the same name.
 	 */
 	public int maxMissingValuesForFill = 3;
 
-	/** 
-	 * Max allowable missing time for auto interp/prev/next/closest fill. 
+	/**
+	 * Max allowable missing time for auto interp/prev/next/closest fill.
 	 * This works for any param, including INSTANT. The value is a number
 	 * of seconds.
-	 * The setting here defines the default. It can be overridden by 
+	 * The setting here defines the default. It can be overridden by
 	 * computation/algorithm properties of the same name.
 	 */
 	public int maxMissingTimeForFill = 3600*3;
@@ -338,85 +339,85 @@ public class DecodesSettings
 	 * Normally this is determined by the API based on your login.
 	 */
 	public String CwmsOfficeId = "";
-	
+
 	/** Set to true to allow DECODES to write CWMS Location records */
 	public boolean writeCwmsLocations = false;
-	
+
 	/** Show the Platform Wizard button on the button panel */
 	public boolean showPlatformWizard = false;
-	
+
 	/** Show the legacy network list button on the button panel */
 	public boolean showNetlistEditor = false;
-	
+
 	/** Show the time series list/edit button */
 	public boolean showTimeSeriesEditor = true;
-	
+
 	public boolean showComputationEditor = true;
-	
+
 	/** Show the time series group list/edit button */
 	public boolean showGroupEditor = true;
-	
+
 	/** Show the 'Test Computations' button */
 	public boolean showTestCmputations = true;
-	
+
 	/** Show the 'Algorithms' button on the launcher. */
 	public boolean showAlgorithmEditor = true;
-	
+
 	/** For CWMS Datchk Validation configuration */
 	public String datchkConfigFile = "$DCSTOOL_USERDIR/datchk.cfg";
-	
+
 	/** Routing Monitor URL */
 	public String routingMonitorUrl = "file://$DECODES_INSTALL_DIR/routmon/routmon.html";
-	
+
 	/** Command to start browser */
 	public String browserCmd = null;
-	
+
 	public String pdtLocalFile = "$DCSTOOL_USERDIR/pdt";
 	public String pdtUrl = "https://dcs1.noaa.gov/pdts_compressed.txt";
 	public String cdtLocalFile = "$DCSTOOL_USERDIR/chans_by_baud.txt";
 	public String cdtUrl = "https://dcs1.noaa.gov/chans_by_baud.txt";
 	public String nwsXrefLocalFile = "$DCSTOOL_USERDIR/nwsxref.txt";
 	public String nwsXrefUrl = "http://www.nws.noaa.gov/oh/hads/USGS/ALL_USGS-HADS_SITES.txt";
-	
+
 	/** Set the maximum computation retries for failed records in Task List.
 	 *  0: default, unlimited retries; 1: only retry once for failed comp records; etc */
 	public int maxComputationRetries = 0 ;
-	
+
 	/** Time zone to use in GUI displays */
-	public String guiTimeZone = "UTC"; 
+	public String guiTimeZone = "UTC";
 
 	/** Default setting for computation EffectiveStart. Can be overridden by
 	 * settings within each computation.
 	 */
 	public String CpEffectiveStart = "";
-	
+
 	/**
-	 * If (false) then don't attempt to retry failed computations. 
+	 * If (false) then don't attempt to retry failed computations.
 	 * If (true) then do attempt to retry by using FAIL_TIME in the tasklist
 	 * records to retry up to maxComputationRetries set above.
 	 */
 	public boolean retryFailedComputations = false;
-	
+
 	/**
 	 * Process the minute offset fields when decoding ASCII self-describing messages.
 	 */
 	public boolean asciiSelfDescProcessMOFF = true;
-	
+
 	/** Default max decimals if no presentation element is found */
 	public int defaultMaxDecimals = 4;
-	
+
 	public boolean platformListDesignatorCol = false;
-	
+
 	/** For OpenDCS 6.1, purge data acquisition events after this many days */
 	public int eventPurgeDays = 5;
-	
+
 	public String pollScriptDir = "$HOME/SHARED/dacq/poll-scripts";
 	public String pollMessageDir = "$HOME/SHARED/dacq/edl-done";
 	public String pollRoutingTemplate = "PollGuiTemplate";
 	public String pollTcpTemplate = "PollTcpTemplate";
-	
+
 	public boolean rememberScreenPosition = true;
-	
+
 	public String decodeScriptColor1 = null;
 	public String decodeScriptColor2 = null;
 	public String decodeScriptColor3 = null;
@@ -425,7 +426,7 @@ public class DecodesSettings
 	public String decodeScriptColor6 = null;
 	public String decodeScriptColor7 = null;
 	public String decodeScriptColor8 = null;
-	
+
 	// Python colors
 	public String pyNormalColor      = "0x000000";
 	public String pyKeywordColor     = "0x0000FF";
@@ -437,12 +438,12 @@ public class DecodesSettings
 	public String pyCpFuncColor      = "0x8B4513";
 
 	public String screeningUnitSystem = "English"; // SI or English
-	
+
 	public boolean showRoutingMonitor = true;
 	public boolean showPlatformMonitor = true;
-	
+
 	public int cwmsVersionOverride = 0;
-	
+
 	public String pakBusTableDefDir = "$DCSTOOL_USERDIR/pakbus";
 	public String pakBusMaxTableDefAge = "hour*48";
 	public int pakBusSecurityCode = 8894;
@@ -450,31 +451,31 @@ public class DecodesSettings
 	public int pakBusMaxBaudRate = 19200;
 
 	public boolean autoDeleteOnImport = false;
-	
+
 	public boolean showEventMonitor = false;
 	public boolean showAlarmEditor = false;
-	
+
 	public int fontAdjust = 0;
 	public int profileLauncherPort = 16109;
-	
+
 	public boolean tryOsDatabaseAuth = false;
-	
+
 	//===============================================================================
-	
+
 	private boolean _isLoaded = false;
 	private Date lastModified = null;
 	public int tsidFetchSize = 0;
-	
+
 	public boolean isLoaded() { return _isLoaded; }
 	private String profileName = null;
 	private File sourceFile = null;
 	public String snotelSpecFile = null;
-	
+
 	public boolean showHistoricalVersions = false;
 
 	private static PropertySpec propSpecs[] =
 	{
-//		new PropertySpec("editDatabaseType", 
+//		new PropertySpec("editDatabaseType",
 //			PropertySpec.JAVA_ENUM + "decodes.util.DecodesSettings.DbTypes",
 //			"Database types supported by OPENDCS"),
 //		new PropertySpec("editDatabaseLocation", PropertySpec.STRING,
@@ -686,7 +687,7 @@ public class DecodesSettings
 		new PropertySpec("pyCpFuncColor", PropertySpec.STRING,
 			"Hex color representation for CP Function Names in a python script. Should be 6 digits."
 			+ " That is, 2 hex digits each for the RGB values."),
-		new PropertySpec("screeningUnitSystem", 
+		new PropertySpec("screeningUnitSystem",
 			PropertySpec.JAVA_ENUM + "decodes.util.UnitSystem",
 			"Unit system to use for limit values in screening editor and execution"),
 		new PropertySpec("cwmsVersionOverride", PropertySpec.INT,
@@ -696,7 +697,7 @@ public class DecodesSettings
 		new PropertySpec("tsidFetchSize", PropertySpec.INT,
 			"(default=0, meaning to use the JDBC default) For databases with many thousand TSIDs,"
 			+ " increasing the fetch size can speed up application initialization."),
-			
+
 		new PropertySpec("pakBusTableDefDir", PropertySpec.DIRECTORY,
 			"Directory where PakBus stations table-definitions are cached."),
 		new PropertySpec("pakBusMaxTableDefAge", PropertySpec.STRING,
@@ -725,7 +726,7 @@ public class DecodesSettings
 		new PropertySpec("showHistoricalVersions", PropertySpec.BOOLEAN,
 			"(default=false) If TRUE, show historical platform versions (deprecated feature)"),
 	};
-	
+
 	/**
 	 * Default constructor.  This initializes all of the settings
 	 * to their defaults.
@@ -764,7 +765,7 @@ public class DecodesSettings
 		}
 		_isLoaded = true;
 	}
-	
+
 	private void setDbTypeCode()
 	{
 		if (editDatabaseType.equalsIgnoreCase("xml"))
@@ -802,7 +803,7 @@ public class DecodesSettings
 		editDatabaseLocation = EnvExpander.expand(editDatabaseLocation);
 	}
 
-	
+
 	/**
 	  Saves internal settings into properties.
 	  @param props the Properties object
@@ -830,7 +831,7 @@ public class DecodesSettings
 		props.remove("databaseTypeCode");
 		props.remove("editDatabaseTypeCode");
 	}
-	
+
 	public boolean isToolkitOwner()
 	{
 		return TextUtil.strEqual(EnvExpander.expand("$DCSTOOL_HOME"),
@@ -882,7 +883,7 @@ public class DecodesSettings
 Logger.instance().info("Set DecodesSettings source=" + sourceFile.getPath());
 		this.sourceFile = sourceFile;
 	}
-	
+
 	/**
 	 * @return the class name corresponding to the db type.
 	 */
@@ -904,4 +905,3 @@ Logger.instance().info("Set DecodesSettings source=" + sourceFile.getPath());
 		return null;
 	}
 }
-

--- a/src/main/java/ilex/net/BasicClient.java
+++ b/src/main/java/ilex/net/BasicClient.java
@@ -117,6 +117,7 @@ public class BasicClient
 	* @param debug debug stream
 	* @deprecated
 	*/
+	@Deprecated
 	public void setDebugStream( PrintStream debug )
 	{
 		this.debug = debug;
@@ -131,7 +132,7 @@ public class BasicClient
 	{
 		if (isConnected())
 			disconnect();
-		
+
 		lastConnectAttempt = System.currentTimeMillis();
 		if (debug != null)
 			debug.println("Connecting to host "
@@ -156,8 +157,8 @@ public class BasicClient
 	*/
 	private static synchronized Socket doConnect( String host, int port ) throws IOException, UnknownHostException
 	{
-		Socket ret = new Socket();				
-		InetSocketAddress iaddr = new InetSocketAddress(host, port);		
+		Socket ret = new Socket();
+		InetSocketAddress iaddr = new InetSocketAddress(host, port);
 		if (iaddr.isUnresolved())
 			throw new UnknownHostException(host);
 		ret.connect(iaddr, 20000);
@@ -174,7 +175,7 @@ public class BasicClient
 	public void disconnect( )
 	{
 Logger.instance().debug2("BasicClient " + getName() + " disconnect()");
-		try 
+		try
 		{
 			try
 			{
@@ -206,7 +207,7 @@ Logger.instance().debug2("BasicClient " + getName() + " disconnect()");
 				Logger.instance().debug1("Error closing socket: "+e.getMessage());
 				e.printStackTrace();
 			}
-			
+
 			if (debug != null)
 				debug.println("Disconnected form host '"
 					+ (host != null ? host : "(unknown)")
@@ -247,7 +248,7 @@ Logger.instance().debug2("BasicClient " + getName() + " disconnect()");
 	*/
 	public boolean isConnected( )
 	{
-		
+
 		return socket != null;
 	}
 
@@ -269,7 +270,7 @@ Logger.instance().debug2("BasicClient " + getName() + " disconnect()");
 	public String getHost( ) { return host; }
 
 	/**
-	* Sets the host name. 
+	* Sets the host name.
 	* If currently connected this does nothing until you dis and re connect.
 	* @param host
 	*/
@@ -295,4 +296,3 @@ Logger.instance().debug2("BasicClient " + getName() + " disconnect()");
 	*/
 	public long getLastConnectAttempt( ) { return lastConnectAttempt; }
 }
-

--- a/src/main/java/lrgs/drgsrecv/PdtSched.java
+++ b/src/main/java/lrgs/drgsrecv/PdtSched.java
@@ -11,10 +11,11 @@ import java.io.LineNumberReader;
 import ilex.util.Logger;
 
 /**
- * 
+ *
  * @author mjmaloney
  * @deprecated use decodes.util.Pdt instead
  */
+@Deprecated
 public class PdtSched
 {
 	private Vector pdtSched;
@@ -38,7 +39,7 @@ public class PdtSched
 		Logger.instance().info("Loading PDT from '" + file.getPath() + "'");
 		Vector oldSched = pdtSched;
 		pdtSched = new Vector();
-		shortLines = badAddresses = badSecondaryChan = badPrimaryChan = 
+		shortLines = badAddresses = badSecondaryChan = badPrimaryChan =
 			badStTimes = 0;
 		try
 		{
@@ -54,16 +55,16 @@ public class PdtSched
 		}
 		catch(IOException ex)
 		{
-			Logger.instance().warning("IO Error reading PDT File '" 
+			Logger.instance().warning("IO Error reading PDT File '"
 				+ file.getPath() + "': " + ex + " -- Old PDT restored.");
 			pdtSched = oldSched;
 			return false;
 		}
 		Collections.sort(pdtSched);
-		Logger.instance().info("Parsed PDT File '" + file.getPath() 
+		Logger.instance().info("Parsed PDT File '" + file.getPath()
 			+ "' good entries=" + pdtSched.size()
-			+ ", shortLines=" + shortLines 
-			+ ", badAddresses=" + badAddresses 
+			+ ", shortLines=" + shortLines
+			+ ", badAddresses=" + badAddresses
 			+ ", badSecondaryChan=" + badSecondaryChan
 			+ ", badPrimaryChan=" + badPrimaryChan
 			+ ", badStTimes=" + badStTimes);
@@ -96,7 +97,7 @@ public class PdtSched
 		String addrs = line.substring(6, 6+8);
 		long addr = -1;
 		try { addr = Long.parseLong(addrs, 16); }
-		catch(NumberFormatException ex) 
+		catch(NumberFormatException ex)
 		{
 			badAddresses++;
 			return null;
@@ -104,12 +105,12 @@ public class PdtSched
 		int stChan = -1;
 		int rdChan = -1;
 		char t = line.charAt(14);
-		try 
+		try
 		{
-			if (t == 'S') 
-				stChan = Integer.parseInt(line.substring(15,15+3)); 
-			else if (t == 'R') 
-				rdChan = Integer.parseInt(line.substring(15,15+3)); 
+			if (t == 'S')
+				stChan = Integer.parseInt(line.substring(15,15+3));
+			else if (t == 'R')
+				rdChan = Integer.parseInt(line.substring(15,15+3));
 		}
 		catch(NumberFormatException ex)
 		{
@@ -117,12 +118,12 @@ public class PdtSched
 			return null;
 		}
 		t = line.charAt(18);
-		try 
+		try
 		{
-			if (t == 'S') 
-				stChan = Integer.parseInt(line.substring(19,19+3)); 
-			else if (t == 'R') 
-				rdChan = Integer.parseInt(line.substring(19,19+3)); 
+			if (t == 'S')
+				stChan = Integer.parseInt(line.substring(19,19+3));
+			else if (t == 'R')
+				rdChan = Integer.parseInt(line.substring(19,19+3));
 		}
 		catch(NumberFormatException ex)
 		{
@@ -149,7 +150,7 @@ public class PdtSched
 				return null;
 			}
 		}
-		return 
+		return
 			new PdtSchedEntry(addr, stChan, rdChan, window, interval, xmitSOD);
 	}
 

--- a/src/main/java/lrgs/drgsrecv/PdtSchedEntry.java
+++ b/src/main/java/lrgs/drgsrecv/PdtSchedEntry.java
@@ -19,10 +19,11 @@ This class contains a subset of PDT entries which are necessary to monitor
 and validate the incoming stream of DCP messages.
 @deprecated - use decodes.util.PdtEntry instead.
 */
+@Deprecated
 public class PdtSchedEntry
 	implements Comparable
 {
-	/** 
+	/**
 	 * DCP Address stored as a 32 bit integer.
 	 * Must be cast & masked to an unsigned 32-bit quantity.
 	 */
@@ -39,7 +40,7 @@ public class PdtSchedEntry
 	private short rdChan;
 
 	/**
-	 * Transmit window duration in seconds. 
+	 * Transmit window duration in seconds.
 	 */
 	private short xmitWindow;
 
@@ -58,11 +59,11 @@ public class PdtSchedEntry
 	 * @param dcpAddr DCP Address
 	 * @param stChan Channel for self-timed messages
 	 * @param rdChan Channel for random messages
-	 * @param xmitWindow Transmit window duration in seconds. 
+	 * @param xmitWindow Transmit window duration in seconds.
 	 * @param xmitInterval Transmit interval in seconds.
 	 * @param firstXmit Second of day for first transmission.
 	 */
-	public PdtSchedEntry(long dcpAddr, int stChan, int rdChan, 
+	public PdtSchedEntry(long dcpAddr, int stChan, int rdChan,
 		int xmitWindow, int xmitInterval, int firstXmit)
 	{
 		this.dcpAddr = (int)(dcpAddr & 0xffffffffL);
@@ -90,7 +91,7 @@ public class PdtSchedEntry
 	public int getRdChan() { return (int)rdChan; }
 
 	/**
-	 * @return Transmit window duration in seconds. 
+	 * @return Transmit window duration in seconds.
 	 */
 	public int getXmitWindow() { return xmitWindow; }
 

--- a/src/main/java/lrgs/drgsrecv/PdtSchedTest.java
+++ b/src/main/java/lrgs/drgsrecv/PdtSchedTest.java
@@ -7,10 +7,11 @@ import java.util.Iterator;
 import lrgs.common.DcpAddress;
 
 /**
- * 
+ *
  * @author mjmaloney
  * @deprecated We are using decodes.util.Pdt instead.
  */
+@Deprecated
 public class PdtSchedTest
 {
 	public static void main(String args[])
@@ -22,7 +23,7 @@ public class PdtSchedTest
 		{
 			PdtSchedEntry pse = (PdtSchedEntry)it.next();
 			DcpAddress da = new DcpAddress(pse.getDcpAddress());
-			System.out.println(da.toString() 
+			System.out.println(da.toString()
 				+ " ST=" + pse.getStChan() + ", t=" +pse.getFirstXmit()
 				+ ", i=" + pse.getXmitInterval()
 				+ ", w=" + pse.getXmitWindow()

--- a/src/main/java/opendcs/dao/CompDependsDAO.java
+++ b/src/main/java/opendcs/dao/CompDependsDAO.java
@@ -1,6 +1,6 @@
 /**
  * $Id: CompDependsDAO.java,v 1.7 2020/05/07 13:50:16 mmaloney Exp $
- * 
+ *
  * $Log: CompDependsDAO.java,v $
  * Revision 1.7  2020/05/07 13:50:16  mmaloney
  * Also delete from scratchpad when deleting dependencies.
@@ -20,13 +20,13 @@
  * Revision 1.2  2014/07/03 12:53:41  mmaloney
  * debug improvements.
  *
- * 
- * This software was written by Cove Software, LLC ("COVE") under contract 
- * to the United States Government. 
- * 
+ *
+ * This software was written by Cove Software, LLC ("COVE") under contract
+ * to the United States Government.
+ *
  * No warranty is provided or implied other than specific contractual terms
  * between COVE and the U.S. Government
- * 
+ *
  * Copyright 2014 U.S. Army Corps of Engineers, Hydrologic Engineering Center.
  * All rights reserved.
  */
@@ -34,12 +34,16 @@ package opendcs.dao;
 
 import ilex.util.Logger;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+
+import org.h2.command.Prepared;
 
 import opendcs.dai.AlgorithmDAI;
 import opendcs.dai.CompDependsDAI;
@@ -67,8 +71,8 @@ public class CompDependsDAO extends DaoBase implements CompDependsDAI
 	public CompDependsDAO(DatabaseConnectionOwner tsdb)
 	{
 		super(tsdb, "CompDependsDAO");
-		cpCompDepends_col1 = tsdb.isHdb() 
-			|| tsdb.getTsdbVersion() >= TsdbDatabaseVersion.VERSION_9 ? 
+		cpCompDepends_col1 = tsdb.isHdb()
+			|| tsdb.getTsdbVersion() >= TsdbDatabaseVersion.VERSION_9 ?
 			"TS_ID" : "SITE_DATATYPE_ID";
 		algorithmDAO = tsdb.makeAlgorithmDAO();
 		tsGroupDAO = db.makeTsGroupDAO();
@@ -79,26 +83,53 @@ public class CompDependsDAO extends DaoBase implements CompDependsDAI
 		throws DbIoException
 	{
 		DbKey key = tsid.getKey();
-		// Remove any computation dependencies to this time-series.
-		doModify("DELETE FROM CP_COMP_DEPENDS WHERE " + cpCompDepends_col1 + " = " 
-			+ key);
-		
-		// Disable any computations that use this time-series as input or
-		// output.
-		String q = "select distinct a.computation_id from "
-			+ "cp_computation a, cp_comp_ts_parm b "
-			+ "where a.computation_id = b.computation_id "
-			+ "and a.enabled = 'Y' "
-			+ "and b.site_datatype_id = " + key;
-		String mq = "update cp_computation set enabled = 'N' "
-			+ "where computation_id in (" + q + ")";
-		doModify(mq);
-		
-		// If this ts is explicitly included in a group, remove it.
-		q = "delete from tsdb_group_member_ts where "
-			+ (db.getTsdbVersion() >= TsdbDatabaseVersion.VERSION_9 ? "ts_id" : "data_id")
-			+ " = "+key;
-		doModify(q);
+		Connection conn = db.getConnection();
+		boolean defaultAutoCommit = false;
+		try(
+			PreparedStatement deleteFromDepends = conn.prepareStatement(
+				"DELETE FROM CP_COMP_DEPENDS WHERE " + cpCompDepends_col1 +" = ?"
+			);
+			PreparedStatement updateEnabled = conn.prepareStatement(
+				"update cp_computation set enabled = 'N' "
+				+ "where computation_id in ("
+				+ 	"select distinct a.computation_id from "
+				+	 "cp_computation a, cp_comp_ts_parm b "
+				+ 	"where a.computation_id = b.computation_id "
+				+ 	"and a.enabled = 'Y' "
+				+ 	"and b.site_datatype_id = ?"
+				+ ")"
+			);
+			PreparedStatement deleteGroupMembershit = conn.prepareStatement(
+				"delete from tsdb_group_member_ts where "
+				+ (db.getTsdbVersion() >= TsdbDatabaseVersion.VERSION_9 ? "ts_id" : "data_id")
+				+ " = ?"
+			);
+		){
+			defaultAutoCommit = conn.getAutoCommit();
+			conn.setAutoCommit(false);
+			// Remove any computation dependencies to this time-series.
+			deleteFromDepends.setLong(1,key.getValue());
+			deleteFromDepends.execute();
+
+			updateEnabled.setLong(1,key.getValue());
+			updateEnabled.execute();
+
+			deleteFromDepends.setLong(1, key.getValue() );
+			deleteFromDepends.execute();
+
+			conn.commit(); // now that all parts of the transaction have gone through we know we're ready.
+		} catch( SQLException err ){
+			throw new DbIoException("failed to remove computations dependencies " + err.getLocalizedMessage());
+		}
+
+		finally {
+			try{
+				conn.setAutoCommit(defaultAutoCommit);
+			} catch( Exception ex ){
+				warning("failed to reset autocommit: " + ex);
+			}
+		}
+
 	}
 
 	@Override
@@ -109,11 +140,11 @@ public class CompDependsDAO extends DaoBase implements CompDependsDAI
 		{
 			DbKey compId = comp.getId();
 			debug3("writeCompDepends(" + comp.getName() + ", id=" + compId);
-			
+
 			deleteCompDependsForCompId(compId);
 			if (!comp.isEnabled())
 				return;
-			
+
 			DbCompAlgorithm algo = comp.getAlgorithm();
 			if (algo == null)
 			{
@@ -121,7 +152,7 @@ public class CompDependsDAO extends DaoBase implements CompDependsDAI
 				if (algoName != null)
 					algo = algorithmDAO.getAlgorithm(algoName);
 			}
-			
+
 			// If the computation has a group input, get the group and
 			// expand it.
 			TsGroup tsGroup = null;
@@ -131,7 +162,7 @@ public class CompDependsDAO extends DaoBase implements CompDependsDAI
 				if (tsGroup != null && !tsGroup.getIsExpanded())
 					db.expandTsGroup(tsGroup);
 			}
-		
+
 			// Make a HashSet of all possible ts_id's that can be input to this computation.
 			HashSet<DbKey> dataIds = new HashSet<DbKey>();
 			for(Iterator<DbCompParm> dcpit = comp.getParms(); dcpit.hasNext(); )
@@ -146,7 +177,7 @@ public class CompDependsDAO extends DaoBase implements CompDependsDAI
 				}
 				if (parmType == null || !parmType.startsWith("i"))
 					continue;
-	
+
 				DbKey sdi = dcp.getSiteDataTypeId();
 				// If it has an SDI, it means it is fully defined.
 				if (sdi != null && !sdi.isNull())
@@ -162,7 +193,7 @@ public class CompDependsDAO extends DaoBase implements CompDependsDAI
 					{
 						try
 						{
-							TimeSeriesIdentifier tsid = 
+							TimeSeriesIdentifier tsid =
 								db.transformTsidByCompParm(grpTsid, dcp, false, false, null);
 							if (tsid != null)
 								dataIds.add(tsid.getKey());
@@ -179,14 +210,23 @@ public class CompDependsDAO extends DaoBase implements CompDependsDAI
 				}
 				// Otherwise incomplete definition and no group - skip it.
 			}
-	
-debug3("Total dds for dependencies=" + dataIds.size());
-			for(DbKey dataId : dataIds)
-			{
-				String q = 
-				  "INSERT INTO CP_COMP_DEPENDS(" + cpCompDepends_col1 + ",COMPUTATION_ID) "
-				  + "VALUES(" + dataId + ", " + compId + ")";
-				doModify(q);
+
+			debug3("Total dds for dependencies=" + dataIds.size());
+			Connection conn = db.getConnection();
+			try(
+				PreparedStatement insertDepends = conn.prepareStatement(
+				"INSERT INTO CP_COMP_DEPENDS(" + cpCompDepends_col1 + ",COMPUTATION_ID) "
+					+ "VALUES(?,?)"
+				);
+			){ //NOTE: this may need some tuning for batch size,
+				// fairly simple to do with an on modulus size = 0 executeBatch statement
+				for(DbKey dataId : dataIds)
+				{
+					insertDepends.setLong(1, dataId.getValue() );
+					insertDepends.setLong(2, compId.getValue() );
+					insertDepends.addBatch();
+				}
+				insertDepends.executeBatch();
 			}
 		}
 		catch(Exception ex)
@@ -204,15 +244,15 @@ debug3("Total dds for dependencies=" + dataIds.size());
 	{
 		if (db.isHdb())
 			return;
-		
+
 		// Remove the CP_COMP_DEPENDS records & re-add.
 		String q = "DELETE FROM CP_COMP_DEPENDS WHERE " + cpCompDepends_col1 + " = "
 			+ timeSeriesKey;
 		doModify(q);
-		doModify("delete from cp_comp_depends_scratchpad where " + cpCompDepends_col1 + " = " 
+		doModify("delete from cp_comp_depends_scratchpad where " + cpCompDepends_col1 + " = "
 			+ timeSeriesKey);
 	}
-	
+
 	@Override
 	public void deleteCompDependsForCompId(DbKey compId)
 		throws DbIoException
@@ -222,10 +262,10 @@ debug3("Total dds for dependencies=" + dataIds.size());
 		// Remove the CP_COMP_DEPENDS records & re-add.
 		String q = "DELETE FROM CP_COMP_DEPENDS WHERE COMPUTATION_ID = " + compId;
 		doModify(q);
-		
+
 		doModify("delete from cp_comp_depends_scratchpad where COMPUTATION_ID = " + compId);
 	}
-	
+
 	public void close()
 	{
 		super.close();
@@ -237,15 +277,19 @@ debug3("Total dds for dependencies=" + dataIds.size());
 	public ArrayList<TimeSeriesIdentifier> getTriggersFor(DbKey compID)
 		throws DbIoException
 	{
-		String q = "SELECT " + cpCompDepends_col1 + " FROM CP_COMP_DEPENDS "
-			+ "WHERE COMPUTATION_ID = " + compID;
-		ResultSet rs = doQuery(q);
-		
 		TimeSeriesDAI timeSeriesDAO = db.makeTimeSeriesDAO();
 		ArrayList<TimeSeriesIdentifier> ret = new ArrayList<TimeSeriesIdentifier>();
-		try
+		Connection conn = db.getConnection();
+		try(
+			PreparedStatement getTriggers = conn.prepareStatement(
+				"SELECT " + cpCompDepends_col1 + " FROM CP_COMP_DEPENDS "
+				+ "WHERE COMPUTATION_ID = ?"
+			);
+		)
 		{
-			while(rs.next())
+			getTriggers.setLong(1,compID.getValue());
+			try( ResultSet rs = getTriggers.executeQuery(); ){
+				while(rs.next())
 			{
 				DbKey tsKey = DbKey.createDbKey(rs, 1);
 				try
@@ -258,10 +302,12 @@ debug3("Total dds for dependencies=" + dataIds.size());
 						+ "for computation " + compID);
 				}
 			}
+			}
+
 		}
 		catch (SQLException ex)
 		{
-			throw new DbIoException("Error executing '" + q + "': " + ex);
+			throw new DbIoException("Error executing trigger comp retrieval: " + ex);
 		}
 		finally
 		{
@@ -275,7 +321,7 @@ debug3("Total dds for dependencies=" + dataIds.size());
 		throws DbIoException
 	{
 		ArrayList<DbKey> ret = new ArrayList<DbKey>();
-		
+
 		StringBuilder inClause = new StringBuilder(" in (");
 		int n = 0;
 		for (TimeSeriesIdentifier tsid : tsids)
@@ -287,13 +333,13 @@ debug3("Total dds for dependencies=" + dataIds.size());
 		inClause.append(")");
 		if (n == 0)
 			return ret;
-		
+
 		String q = "select a.computation_id from cp_comp_depends a, cp_computation b"
 			+ " where a.computation_id = b.computation_id"
 			+ " and a." + cpCompDepends_col1 + inClause.toString();
 		if (!DbKey.isNull(appId))
 			q = q + " and b.loading_application_id = " + appId;
-			
+
 		try
 		{
 			ResultSet rs = doQuery(q);

--- a/src/main/java/opendcs/dao/ComputationDAO.java
+++ b/src/main/java/opendcs/dao/ComputationDAO.java
@@ -463,7 +463,7 @@ public class ComputationDAO
 		Connection conn = db.getConnection();
 		try(
 			PreparedStatement getComp = conn.prepareStatement(
-				"select " + compTableColumns + " from CP_COMPUATION where COMPUTATION_NAME = ?"
+				"select " + compTableColumns + " from CP_COMPUTATION where COMPUTATION_NAME = ?"
 			);
 			PreparedStatement getAppId = db.getConnection().prepareStatement(
 				"select LOADING_APPLICATION_NAME from HDB_LOADING_APPLICATION where LOADING_APPLICATION_ID = ?"

--- a/src/main/java/opendcs/dao/ComputationDAO.java
+++ b/src/main/java/opendcs/dao/ComputationDAO.java
@@ -1,6 +1,6 @@
 /*
 * $Id: ComputationDAO.java,v 1.15 2020/05/07 13:41:54 mmaloney Exp $
-* 
+*
 * $Log: ComputationDAO.java,v $
 * Revision 1.15  2020/05/07 13:41:54  mmaloney
 * When deleting a computation, first delete it's dependencies using CompDependsDAO.
@@ -48,11 +48,11 @@
 *
 * Revision 1.1.1.1  2014/05/19 15:28:59  mmaloney
 * OPENDCS 6.0 Initial Checkin
-* 
-* This software was written by Cove Software, LLC ("COVE") under contract 
-* to the United States Government. No warranty is provided or implied other 
+*
+* This software was written by Cove Software, LLC ("COVE") under contract
+* to the United States Government. No warranty is provided or implied other
 * than specific contractual terms between COVE and the U.S. Government.
-* 
+*
 * Copyright 2014 U.S. Army Corps of Engineers, Hydrologic Engineering Center.
 * All rights reserved.
 */
@@ -61,6 +61,8 @@ package opendcs.dao;
 import ilex.util.Logger;
 import ilex.util.TextUtil;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -99,10 +101,10 @@ import decodes.tsdb.compedit.ComputationInList;
 Data Access Object for reading/writing computations.
 */
 public class ComputationDAO
-	extends DaoBase 
+	extends DaoBase
 	implements ComputationDAI
 {
-	protected static DbObjectCache<DbComputation> compCache = 
+	protected static DbObjectCache<DbComputation> compCache =
 		new DbObjectCache<DbComputation>(60 * 60 * 1000L, false);
 
 	protected PropertiesDAI propsDao = null;
@@ -110,9 +112,9 @@ public class ComputationDAO
 	protected DataTypeDAI dataTypeDAO = null;
 	protected TsGroupDAI tsGroupDAO = null;
 	protected LoadingAppDAI loadingAppDAO = null;
-	
+
 	/** Defines columns to match the rs2comp method */
-	public String compTableColumns = 
+	public String compTableColumns =
 		"cp_computation.computation_id, computation_name, "
 		+ "cp_computation.algorithm_id, "
 		+ "cmmnt, loading_application_id, date_time_loaded, enabled, "
@@ -122,7 +124,7 @@ public class ComputationDAO
 		+ "algorithm_id, "
 		+ "cmmnt, loading_application_id, date_time_loaded, enabled, "
 		+ "effective_start_date_time, effective_end_date_time";
-	
+
 	public ComputationDAO(DatabaseConnectionOwner tsdb)
 	{
 		super(tsdb, "ComputationDao");
@@ -137,11 +139,11 @@ public class ComputationDAO
 			compTableColumnsNoTabName = compTableColumnsNoTabName + ", group_id";
 		}
 	}
-	
+
 	private void fillCache()
 	{
 		debug1("ComputationDAO.fillCache()");
-		
+
 		String q = "select " + compTableColumns + " from CP_COMPUTATION ";
 
 		try
@@ -157,7 +159,7 @@ public class ComputationDAO
 
 			n = propsDao.readPropertiesIntoCache("CP_COMP_PROPERTY", compCache);
 			Logger.instance().debug1("" + n + " cp_comp_property recs read.");
-			
+
 			ArrayList<CompAppInfo> apps = loadingAppDAO.listComputationApps(true);
 			ArrayList<DbCompAlgorithm> algos = algorithmDAO.listAlgorithms();
 
@@ -172,7 +174,7 @@ public class ComputationDAO
 					for(CompAppInfo cai : apps)
 						if (comp.getAppId().equals(cai.getAppId()))
 							comp.setApplicationName(cai.getAppName());
-				
+
 				if (!DbKey.isNull(comp.getAlgorithmId()))
 					for(DbCompAlgorithm algo : algos)
 						if (comp.getAlgorithmId().equals(algo.getId()))
@@ -181,7 +183,7 @@ public class ComputationDAO
 							comp.setAlgorithmName(algo.getName());
 						}
 			}
-			
+
 			// Note the parms rely on the algorithms being in place. So get them now.
 			q = "select a.* from CP_COMP_TS_PARM a, CP_COMPUTATION b "
 				+ "where a.COMPUTATION_ID = b.COMPUTATION_ID";
@@ -196,12 +198,12 @@ public class ComputationDAO
 					warning("CP_COMP_TS_PARM with comp id=" + compId + " with no matching computation.");
 					continue;
 				}
-				
+
 				rs2compParm(comp, rs);
 				n++;
 			}
 			Logger.instance().debug1("" + n + " cp_comp_ts_parm recs read.");
-			
+
 			for(CacheIterator it = compCache.iterator(); it.hasNext(); )
 			{
 				DbComputation comp = (DbComputation)it.next();
@@ -230,49 +232,57 @@ public class ComputationDAO
 		DbComputation ret = compCache.getByKey(compId, this);
 		if (ret != null)
 			return ret;
-		
-		String q = "select " + compTableColumns
-			+ " from CP_COMPUTATION where COMPUTATION_ID = "
-			+ compId;
-	
-		try
-		{
-			ResultSet rs = doQuery(q);
-			if (rs.next())
-			{
-				DbComputation comp = rs2comp(rs);
-				if (!comp.getAlgorithmId().isNull())
-				{
-					try
-					{
-						comp.setAlgorithm(algorithmDAO.getAlgorithmById(comp.getAlgorithmId()));
-					}
-					catch(NoSuchObjectException ex)
-					{
-						warning("Computation ID=" 
-							+ compId + " with algo ID="
-							+ comp.getAlgorithmId() + " -- cannot find matching "
-							+ "algorithm.");
-					}
-				}
-				fillCompSubordinates(comp);
 
-				DbKey appId = comp.getAppId();
-				if (!appId.isNull())
+		try(
+			PreparedStatement getComp = db.getConnection().prepareStatement(
+				"select " + compTableColumns + " from CP_COMPUTATION where COMPUTATION_ID = ?"
+			);
+			PreparedStatement getAppId = db.getConnection().prepareStatement(
+				"select LOADING_APPLICATION_NAME from HDB_LOADING_APPLICATION where LOADING_APPLICATION_ID = ?"
+			);
+		)
+		{
+			getComp.setLong(1,compId.getValue());
+			try( ResultSet rs = getComp.executeQuery(); ) {
+				if (rs.next())
 				{
-					q = "select LOADING_APPLICATION_NAME from "
-					  + "HDB_LOADING_APPLICATION where LOADING_APPLICATION_ID = " 
-					  + appId;
-					rs = doQuery(q);
-					if (rs.next())
-						comp.setApplicationName(rs.getString(1));
+					DbComputation comp = rs2comp(rs);
+					if (!comp.getAlgorithmId().isNull())
+					{
+						try
+						{
+							comp.setAlgorithm(algorithmDAO.getAlgorithmById(comp.getAlgorithmId()));
+						}
+						catch(NoSuchObjectException ex)
+						{
+							warning("Computation ID="
+								+ compId + " with algo ID="
+								+ comp.getAlgorithmId() + " -- cannot find matching "
+								+ "algorithm.");
+						}
+					}
+					fillCompSubordinates(comp);
+
+					DbKey appId = comp.getAppId();
+					if (!appId.isNull())
+					{
+						getAppId.setLong(1,appId.getValue());
+						try( ResultSet rs2 = getAppId.executeQuery(); ){
+							if (rs.next())
+							comp.setApplicationName(rs.getString(1));
+						}
+
+
+					}
+					compCache.put(comp);
+					return comp;
 				}
-				compCache.put(comp);
-				return comp;
+				else
+					throw new NoSuchObjectException("No computation with ID="
+						+ compId);
 			}
-			else
-				throw new NoSuchObjectException("No computation with ID="
-					+ compId);
+
+
 		}
 		catch(SQLException ex)
 		{
@@ -288,9 +298,9 @@ public class ComputationDAO
 	protected DbComputation rs2comp(ResultSet rs)
 		throws SQLException
 	{
-		
+
 		DbKey id = DbKey.createDbKey(rs, 1);
-		
+
 		String nm = rs.getString(2);
 		DbComputation comp = new DbComputation(id, nm);
 
@@ -317,34 +327,50 @@ public class ComputationDAO
 	protected void fillCompSubordinates(DbComputation comp)
 		throws SQLException, DbIoException
 	{
+		Connection conn = db.getConnection();
+		try(
+			PreparedStatement getParms = conn.prepareStatement(
+				"select * from CP_COMP_TS_PARM where computation_id = ?"
+			);
+			PreparedStatement getProps = conn.prepareStatement(
+				"select * from CP_COMP_PROPERTY where computation_id= ?"
+			);
+		){
+			getParms.setLong(1,comp.getId().getValue());
+
 			String q = "select * from CP_COMP_TS_PARM where computation_id = " + comp.getId();
-			ResultSet rs = doQuery(q);
-			while(rs.next())
+			try( ResultSet rs = getParms.executeQuery() ){
+				while(rs.next())
 				rs2compParm(comp, rs);
-
-			q = "select * from CP_COMP_PROPERTY where computation_id = " + comp.getId();
-			rs = doQuery(q);
-			while(rs != null && rs.next())
-			{
-				String name = rs.getString(2);
-				String value = rs.getString(3);
-				if (value == null)
-					value = "";
-
-				comp.setProperty(name, value);
 			}
+
+			getProps.setLong(1,comp.getId().getValue());
+			try( ResultSet rs = getProps.executeQuery()){
+				while(rs.next())
+				{
+					String name = rs.getString(2);
+					String value = rs.getString(3);
+					if (value == null)
+						value = "";
+
+					comp.setProperty(name, value);
+				}
+			}
+
 
 			// Retrieve groups used by computations (group DAO will cache)
 			if (!comp.getGroupId().isNull())
 				comp.setGroup(tsGroupDAO.getTsGroupById(comp.getGroupId()));
-			
+
 			// Make sure site IDs and datatype IDs are set in the parms
 			for(DbCompParm parm : comp.getParmList())
 				if (!parm.getSiteDataTypeId().isNull())
 					try { db.expandSDI(parm); }
 					catch (NoSuchObjectException e) {}
+
+		}
 	}
-	
+
 	/**
 	 * Result set contains cp_comp_ts_parm record for the passed computation.
 	 * @param comp
@@ -377,7 +403,7 @@ public class ComputationDAO
 			DbKey dtid = DbKey.createDbKey(rs, 8);
 			dcp.setDataTypeId(dtid);
 			dcp.setDataType(DataType.getDataType(dtid));
-			
+
 			/* Legacy: First implementation had groupd_id in the parm. */
 			if (db.getTsdbVersion() < TsdbDatabaseVersion.VERSION_6)
 				comp.setGroupId(DbKey.createDbKey(rs, 9));
@@ -398,19 +424,26 @@ public class ComputationDAO
 		DbComputation comp = (DbComputation)ob;
 		String q = "select DATE_TIME_LOADED from CP_COMPUTATION "
 			+ " where COMPUTATION_ID = " + comp.getKey();
-		try
-		{
-			ResultSet rs = doQuery2(q);
-			if (rs == null || !rs.next())
+		Connection conn = db.getConnection();
+		try(
+			PreparedStatement getTimeLoaded = conn.prepareStatement(
+				"select DATE_TIME_LOADED from CP_COMPUTATION where COMPUTATION_ID = ?"
+			);
+		) {
+			getTimeLoaded.setLong(1,comp.getId().getValue());
+			try(ResultSet rs = getTimeLoaded.executeQuery(); )
 			{
-				String msg 
-					= "No match finding DATE_TIME_LOADED for computation "
-					+ "id=" + comp.getKey() + ", name=" + comp.getUniqueName();
-				debug1(msg);
-				return false;
+				if (!rs.next())
+				{
+					String msg
+						= "No match finding DATE_TIME_LOADED for computation "
+						+ "id=" + comp.getKey() + ", name=" + comp.getUniqueName();
+					debug1(msg);
+					return false;
+				}
+				Date lmt = db.getFullDate(rs, 1);
+				return lmt.getTime() <= comp.getLastModified().getTime();
 			}
-			Date lmt = db.getFullDate(rs, 1);
-			return lmt.getTime() <= comp.getLastModified().getTime();
 		}
 		catch(Exception ex)
 		{
@@ -419,51 +452,60 @@ public class ComputationDAO
 			return false;
 		}
 	}
-	
+
 	@Override
 	public DbComputation getComputationByName(String name)
 		throws DbIoException, NoSuchObjectException
 	{
-		String q = "select " + compTableColumns 
+		String q = "select " + compTableColumns
 			+ " from CP_COMPUTATION where COMPUTATION_NAME = '"
 			+ name + "'";
-		
-		try
-		{
-			ResultSet rs = doQuery(q);
-			if (rs.next())
-			{
-				DbComputation comp = rs2comp(rs);
-				if (comp.getAlgorithmId() != Constants.undefinedId)
-				{
-					try
-					{
-						comp.setAlgorithm(algorithmDAO.getAlgorithmById(comp.getAlgorithmId()));
-					}
-					catch(NoSuchObjectException ex)
-					{
-						warning("Computation '" +name + "' with algo ID="
-							+ comp.getAlgorithmId() + " -- cannot find matching "
-							+ "algorithm.");
-					}
-				}
-				fillCompSubordinates(comp);
+		Connection conn = db.getConnection();
+		try(
+			PreparedStatement getComp = conn.prepareStatement(
+				"select " + compTableColumns + " from CP_COMPUATION where COMPUTATION_NAME = ?"
+			);
+			PreparedStatement getAppId = db.getConnection().prepareStatement(
+				"select LOADING_APPLICATION_NAME from HDB_LOADING_APPLICATION where LOADING_APPLICATION_ID = ?"
+			);
+		){
+			getComp.setString(1,name);
 
-				DbKey appId = comp.getAppId();
-				if (!appId.isNull())
+			try(ResultSet rs = getComp.executeQuery(); )
+			{
+				if (rs.next())
 				{
-					q = "select LOADING_APPLICATION_NAME from "
-					  + "HDB_LOADING_APPLICATION where LOADING_APPLICATION_ID = " 
-					  + appId;
-					rs = doQuery(q);
-					if (rs.next())
-						comp.setApplicationName(rs.getString(1));
+					DbComputation comp = rs2comp(rs);
+					if (comp.getAlgorithmId() != Constants.undefinedId)
+					{
+						try
+						{
+							comp.setAlgorithm(algorithmDAO.getAlgorithmById(comp.getAlgorithmId()));
+						}
+						catch(NoSuchObjectException ex)
+						{
+							warning("Computation '" +name + "' with algo ID="
+								+ comp.getAlgorithmId() + " -- cannot find matching "
+								+ "algorithm.");
+						}
+					}
+					fillCompSubordinates(comp);
+
+					DbKey appId = comp.getAppId();
+					if (!appId.isNull())
+					{
+						getAppId.setLong(1,appId.getValue());
+						try(ResultSet rs2 = getAppId.executeQuery() ) {
+							if (rs.next())
+							comp.setApplicationName(rs.getString(1));
+						}
+					}
+					return comp;
 				}
-				return comp;
+				else
+					throw new NoSuchObjectException("No computation named '"
+						+ name + "'");
 			}
-			else
-				throw new NoSuchObjectException("No computation named '"
-					+ name + "'");
 		}
 		catch(SQLException ex)
 		{
@@ -472,6 +514,7 @@ public class ComputationDAO
 			throw new DbIoException(msg);
 		}
 	}
+
 
 	/**
 	 * Apply the application and algorithm parts of the filter to the cached computations.
@@ -482,10 +525,10 @@ public class ComputationDAO
 		throws DbIoException
 	{
 		debug1("listCompsForGUI " + filter);
-		
+
 		if (compCache.size() == 0)
 			fillCache();
-		
+
 		ArrayList<DbComputation> ret = new ArrayList<DbComputation>();
 		for(CacheIterator it = compCache.iterator(); it.hasNext(); )
 		{
@@ -497,10 +540,10 @@ public class ComputationDAO
 			DbKey algoId = filter.getAlgoId();
 			if (!algoId.isNull() && !algoId.equals(comp.getAlgorithmId()))
 				continue;
-			
+
 			if (filter.isEnabledOnly() && !comp.isEnabled())
 				continue;
-			
+
 			if (filter.getExecClassName() != null
 			 && comp.getAlgorithm() != null
 			 && !TextUtil.strEqual(filter.getExecClassName(), comp.getAlgorithm().getExecClass()))
@@ -510,7 +553,7 @@ public class ComputationDAO
 		}
 		return ret;
 	}
-	
+
 	/**
 	 * New 6.2 method for listing computations for the CompEdit GUI.
 	 * @param filter
@@ -549,11 +592,11 @@ public class ComputationDAO
 		}
 		// Group comp query does not include param fields.
 		String groupWhere = where.toString();
-	
+
 		// Build the query for NON group comps.
 		if (where.length() > 0)
 			where.append(" and ");
-		
+
 		where.append("(cmp.group_id is null or cmp.group_id = -1)");
 		if (!DbKey.isNull(filter.getSiteId())
 		 || !DbKey.isNull(filter.getDataTypeId())
@@ -561,7 +604,7 @@ public class ComputationDAO
 		{
 			tables = tables + ", cp_comp_ts_parm prm";
 			where.append(" and cmp.computation_id = prm.computation_id");
-			
+
 			if (db.isCwms() || db.isOpenTSDB())
 			{
 				// CWMS already has site_id and datatype_id in the fully-defined parms.
@@ -581,10 +624,10 @@ public class ComputationDAO
 			}
 
 			if (filter.getIntervalCode() != null)
-				where.append(" and lower(prm.INTERVAL" 
+				where.append(" and lower(prm.INTERVAL"
 					+ (db.isHdb()?"":"_ABBR") +") = '" + filter.getIntervalCode().toLowerCase() + "'");
 		}
-	
+
 		// Get all non-group computations via where clause using all filter
 		if (DbKey.isNull(filter.getGroupId()))
 		{
@@ -605,10 +648,10 @@ public class ComputationDAO
 					DbKey compId = DbKey.createDbKey(rs, 1);
 					if (compId.equals(lastCompId))
 						continue;
-					
+
 					ret.add(
 						new ComputationInList(compId, rs.getString(2),
-							DbKey.createDbKey(rs, 3), DbKey.createDbKey(rs, 5), 
+							DbKey.createDbKey(rs, 3), DbKey.createDbKey(rs, 5),
 							TextUtil.str2boolean(rs.getString(6)), rs.getString(4)));
 					n++;
 					lastCompId = compId;
@@ -620,7 +663,7 @@ public class ComputationDAO
 				throw new DbIoException("CompuationDao.compEditList(): Error in query '" + q + "': " + ex);
 			}
 		}
-		
+
 
 		// Now get all group comps completely. The number should be small.
 		String q = "select " + compTableColumns + " from CP_COMPUTATION "
@@ -629,18 +672,18 @@ public class ComputationDAO
 			q = q + " (GROUP_ID is not null and GROUP_ID != -1) ";
 		else // specific group is requested
 			q = q + " GROUP_ID = " + filter.getGroupId() + " ";
-			
+
 		if (groupWhere.length() > 0)
 			q = q + " and " + groupWhere.toString();
 
 		ArrayList<CompAppInfo> apps = loadingAppDAO.listComputationApps(true);
 		ArrayList<DbCompAlgorithm> algos = algorithmDAO.listAlgorithms();
-		
+
 		debug3("Expanding group comps and checking filter");
 		try
 		{
 			ArrayList<DbKey> groupCompIds = new ArrayList<DbKey>();
-			
+
 			ResultSet rs = doQuery(q);
 			int n = 0;
 			while(rs != null && rs.next())
@@ -651,7 +694,7 @@ public class ComputationDAO
 				n++;
 			}
 			Logger.instance().debug1("" + n + " cp_computation group comp recs read.");
-			
+
 			q = "select prop.computation_id, prop.prop_name, prop.prop_value "
 				+ "from cp_comp_property prop, cp_computation cmp "
 				+ "where prop.computation_id = cmp.computation_id and "
@@ -668,7 +711,7 @@ public class ComputationDAO
 				n++;
 			}
 			Logger.instance().debug1("" + n + " cp_comp_property recs read.");
-			
+
 			// Associate comps with groups, apps & algorithms.
 			for(CacheIterator it = compCache.iterator(); it.hasNext(); )
 			{
@@ -683,7 +726,7 @@ public class ComputationDAO
 							comp.setApplicationName(cai.getAppName());
 							break;
 						}
-				
+
 				if (!DbKey.isNull(comp.getAlgorithmId()))
 					for(DbCompAlgorithm algo : algos)
 						if (comp.getAlgorithmId().equals(algo.getId()))
@@ -693,7 +736,7 @@ public class ComputationDAO
 							break;
 						}
 			}
-			
+
 			// Note the parms rely on the algorithms being in place. So get them now.
 			q = "select prm.* "
 				+ "from CP_COMP_TS_PARM prm, CP_COMPUTATION cmp "
@@ -713,7 +756,7 @@ public class ComputationDAO
 				n++;
 			}
 			Logger.instance().debug1("" + n + " cp_comp_ts_parm recs read.");
-			
+
 			for(CacheIterator it = compCache.iterator(); it.hasNext(); )
 			{
 				DbComputation comp = (DbComputation)it.next();
@@ -724,7 +767,7 @@ public class ComputationDAO
 						try { db.expandSDI(parm); }
 						catch (NoSuchObjectException e) {}
 			}
-			
+
 			// Now the cache has all my group comps and groupCompIds is a list of the IDs
 			// that are for this query.
 			// Expand the groups, evaluate the comps, check the expanded params.
@@ -735,11 +778,11 @@ public class ComputationDAO
 
 				if (group == null) // Means comp had an invalid group ID
 				{
-					Logger.instance().warning("Computation ID=" + compId + " has invalid group ID=" 
+					Logger.instance().warning("Computation ID=" + compId + " has invalid group ID="
 						+ groupComp.getGroupId() + " -- skipped.");
 					continue;
 				}
-				
+
 				// If no TS-specific filtering is done, there's no need to expand.
 				if (DbKey.isNull(filter.getSiteId()) && DbKey.isNull(filter.getDataTypeId())
 				 && filter.getIntervalCode() == null)
@@ -751,13 +794,13 @@ public class ComputationDAO
 								groupComp.isEnabled(), groupComp.getComment()));
 					continue;
 				}
-				
+
 				// Group object may be shared by multiple comps. Only expand it once.
 				if (!group.getIsExpanded())
 					db.expandTsGroup(group);
-				
+
 				for(TimeSeriesIdentifier tsid : group.getExpandedList())
-					try 
+					try
 					{
 						if (filter.passes(DbCompResolver.makeConcrete((TimeSeriesDb)db, tsid, groupComp, false)))
 						{
@@ -774,7 +817,7 @@ public class ComputationDAO
 							+ ") " + groupComp.getName() + ": " + ex);
 					}
 			}
-			
+
 		}
 		catch(Exception ex)
 		{
@@ -811,7 +854,7 @@ public class ComputationDAO
 	@Override
 	public void writeComputation( DbComputation comp )
 		throws DbIoException
-	{		
+	{
 		Logger.instance().debug2("writeComputation name=" + comp.getName());
 		DbKey id = comp.getId();
 		boolean isNew = id.isNull();
@@ -823,7 +866,7 @@ public class ComputationDAO
 			// Try to determine id from name.
 			try
 			{
-				id = getComputationId(comp.getName());			
+				id = getComputationId(comp.getName());
 				isNew = id.isNull();
 				if (!isNew)
 					info("Determined comp id=" + id
@@ -833,10 +876,10 @@ public class ComputationDAO
 			catch(NoSuchObjectException ex) { /* ignore */ }
 		}
 
-		try 
+		try
 		{
 			DbKey appId = comp.getAppId();
-			
+
 			if (appId.isNull())
 			{
 				String appName = comp.getApplicationName();
@@ -859,7 +902,7 @@ public class ComputationDAO
 				}
 			}
 			DbKey algoId = comp.getAlgorithmId();
-			
+
 			if (algoId.isNull())
 			{
 				String algoName = comp.getAlgorithmName();
@@ -902,15 +945,15 @@ public class ComputationDAO
 			else // update
 			{
 				q = "UPDATE CP_COMPUTATION"
-			  		+  " SET COMPUTATION_NAME = " + sqlString(comp.getName()) 
+			  		+  " SET COMPUTATION_NAME = " + sqlString(comp.getName())
 					+ ", ALGORITHM_ID = " + comp.getAlgorithmId()
 					+ ", CMMNT = " + sqlString(comp.getComment())
 					+ ", LOADING_APPLICATION_ID = " + appIdStr
 					+ ", DATE_TIME_LOADED = " + db.sqlDate(comp.getLastModified())
 					+ ", ENABLED = " + db.sqlBoolean(comp.isEnabled())
-					+ ", EFFECTIVE_START_DATE_TIME = " 
+					+ ", EFFECTIVE_START_DATE_TIME = "
 						+ db.sqlDate(comp.getValidStart())
-					+ ", EFFECTIVE_END_DATE_TIME = " 
+					+ ", EFFECTIVE_END_DATE_TIME = "
 						+ db.sqlDate(comp.getValidEnd());
 				if (db.getTsdbVersion() >= TsdbDatabaseVersion.VERSION_6)
 					q = q + ", GROUP_ID = " + comp.getGroupId();
@@ -924,7 +967,7 @@ public class ComputationDAO
 			doModify(q);
 			q = "DELETE FROM CP_COMP_PROPERTY WHERE COMPUTATION_ID = " + id;
 			doModify(q);
-			
+
 			// For V5 databases, we must store the group ID in the first parm
 			// See the loop below.
 			DbKey groupId = db.getTsdbVersion() >= 6 ? Constants.undefinedId : comp.getGroupId();
@@ -932,20 +975,20 @@ public class ComputationDAO
 			for(Iterator<DbCompParm> it = comp.getParms(); it.hasNext(); )
 			{
 				DbCompParm dcp = it.next();
-				
+
 				// NOTE The HDB CP_COMP_TS_PARM_ARCHIVE table does not allow null in SDI, use -1.
-				String sdiValue = "" + 
+				String sdiValue = "" +
 					(db.isHdb() && DbKey.isNull(dcp.getSiteDataTypeId()) ? -1 : dcp.getSiteDataTypeId());
-				
+
 				q = "INSERT INTO CP_COMP_TS_PARM VALUES ("
 					+ id + ", "
 					+ sqlString(dcp.getRoleName()) + ", "
 					+ sdiValue + ", "
-					+ sqlString(dcp.getInterval()) + ", " 
-					+ sqlString(dcp.getTableSelector()) + ", " 
+					+ sqlString(dcp.getInterval()) + ", "
+					+ sqlString(dcp.getTableSelector()) + ", "
 					+ dcp.getDeltaT() + ", "
 					+ dcp.getModelId();
-				
+
 				if (db.getTsdbVersion() >= 5)
 				{
 					DataType dt = dcp.getDataType();
@@ -959,7 +1002,7 @@ public class ComputationDAO
 						dcp.setDataTypeId(dt.getId());
 					}
 					q = q + ", " + dcp.getDataTypeId();
-					
+
 					groupId = Constants.undefinedId;
 					if (db.getTsdbVersion() < 8)
 						q = q + ", " + groupId;  // old slot for group id
@@ -970,7 +1013,7 @@ public class ComputationDAO
 						q = q + ", " +
 							(dtu == null ? "null" : ("'" + dtu + "'"));
 					}
-					
+
 					if (db.getTsdbVersion() >= TsdbDatabaseVersion.VERSION_9)
 					{
 						q = q + ", " + dcp.getSiteId();
@@ -990,7 +1033,7 @@ public class ComputationDAO
 					+ id + ", "
 					+ sqlString(nm) + ", "
 					+ sqlString(comp.getProperty(nm)) + ")";
-				
+
 				doModify(q);
 			}
 
@@ -1016,7 +1059,7 @@ public class ComputationDAO
 			{
 				// Computations did not exist in OpenTSDB until OpenDCS Version 6.7 = DB Version 67
 				q = "insert into cp_depends_notify(record_num, event_type, key, date_time_loaded) "
-					+ "values(" + getKey("cp_depends_notify") 
+					+ "values(" + getKey("cp_depends_notify")
 					+ ", 'C', " + comp.getKey() + ", " + System.currentTimeMillis() + ")";
 					doModify(q);
 			}
@@ -1035,70 +1078,91 @@ public class ComputationDAO
 	{
 		String q = "select COMPUTATION_ID from CP_COMPUTATION "
 			+ "where COMPUTATION_NAME = '" + name + "'";
-		try
-		{
-			ResultSet rs = doQuery(q);
-			if (rs.next())
-				return DbKey.createDbKey(rs, 1);
-			throw new NoSuchObjectException("No computation for name '" + name 
-				+ "'");
+		Connection conn = db.getConnection();
+		try(
+			PreparedStatement getCompId = conn.prepareStatement(
+				"select COMPUTATION_ID from CP_COMPUTATION where COMPUTATION_NAME = ?"
+			);
+		) {
+			getCompId.setString(1,name);
+			try(ResultSet rs = getCompId.executeQuery();)
+			{
+
+				if (rs.next())
+					return DbKey.createDbKey(rs.getLong("COMPUTATION_ID"));
+				throw new NoSuchObjectException("No computation for name '" + name
+					+ "'");
+			}
 		}
 		catch(SQLException ex)
 		{
-			String msg = "Error getting computation ID for name '" 
+			String msg = "Error getting computation ID for name '"
 				+ name + "': " + ex;
 			failure(msg);
 			throw new DbIoException(msg);
 		}
+
 	}
 
 	@Override
 	public void deleteComputation(DbKey id)
 		throws DbIoException, ConstraintException
 	{
-		// Have to delete the dependencies, otherwise foreign key will prevent comp delete.
-		CompDependsDAI compDependsDAO = db.makeCompDependsDAO();
-		try
-		{
-			compDependsDAO.deleteCompDependsForCompId(id);
+
+		Connection conn = db.getConnection();
+		boolean defaultAutoCommit = false;
+
+
+
+		/*
+			I'm pretty sure this could just be a delete ... cascade on cp_computation
+			but that can go overboard so it'll require a little investigation first
+			so as not to break anything.
+		*/
+		try(
+			PreparedStatement deleteParms = conn.prepareStatement(
+				"delete from CP_COMP_TS_PARM where COMPUTATION_ID = ?"
+			);
+			PreparedStatement deleteProps = conn.prepareStatement(
+				"delete from CP_COMP_PROPERTY where COMPUTATION_ID = ?"
+			);
+			PreparedStatement deleteComp = conn.prepareStatement(
+				"delete from CP_COMPUTATION where COMPUTATION_ID = ?"
+			);
+		 ){
+			defaultAutoCommit = conn.getAutoCommit();
+			conn.setAutoCommit(false);
+				// Have to delete the dependencies, otherwise foreign key will prevent comp delete.
+			CompDependsDAI compDependsDAO = db.makeCompDependsDAO();
+			try
+			{
+				compDependsDAO.deleteCompDependsForCompId(id);
+			}
+			finally { compDependsDAO.close(); }
+
+
+			deleteParms.setLong(1,id.getValue());
+			deleteParms.execute();
+
+			deleteProps.setLong(1,id.getValue());
+			deleteProps.execute();
+
+			deleteComp.setLong(1,id.getValue());
+			deleteProps.execute();
+
+			conn.commit(); // now we commit knowing we deleted everything
+
+		} catch( SQLException err ){
+
+		} finally {
+			try{ conn.setAutoCommit(defaultAutoCommit); } catch(Exception err){ warning("could not reset autocommit on connection"); }
 		}
-		finally { compDependsDAO.close(); }
-		
+
 		String q = "delete from CP_COMP_TS_PARM where COMPUTATION_ID = " + id;
 		doModify(q);
 		q = "delete from CP_COMP_PROPERTY where COMPUTATION_ID = " + id;
 		doModify(q);
-		
-//		if (db.isCwms())
-//		{
-//			// CWMS DB 14 uses the Comp Depends Updater Daemon. So send a NOTIFY.
-//			if (db.getTsdbVersion() >= TsdbDatabaseVersion.VERSION_14)
-//			{
-//				q = "insert into cp_depends_notify(record_num, event_type, key, date_time_loaded) "
-//					+ "values(cp_depends_notifyidseq.nextval, 'C', "
-//					+ id + ", " + db.sqlDate(new Date()) + ")";
-//				doModify(q);
-//			}
-//			// Older versions the GUI must update dependencies directly.
-//			else if (db.getTsdbVersion() >= TsdbDatabaseVersion.VERSION_5)
-//			{
-//				CompDependsDAI compDependsDAO = db.makeCompDependsDAO();
-//				try { compDependsDAO.deleteCompDependsForCompId(id); }
-//				finally { compDependsDAO.close(); }
-//			}
-//		}
-//		else if (db.isOpenTSDB() && db.getTsdbVersion() >= TsdbDatabaseVersion.VERSION_67)
-//		{
-//			// Computations did not exist in OpenTSDB until OpenDCS Version 6.7 = DB Version 67
-//			q = "insert into cp_depends_notify(record_num, event_type, key, date_time_loaded) "
-//				+ "values(" + getKey("cp_depends_notify") 
-//				+ ", 'C', " + id + ", " + System.currentTimeMillis() + ")";
-//				doModify(q);
-//		}
 
-		
-		// Pre 14 version defined CP_COMP_DEPENDS.COMPUTATION_ID as a foreign
-		// key. So this must be done after the above.
 		q = "delete from CP_COMPUTATION where COMPUTATION_ID = "+id;
 		doModify(q);
 	}
@@ -1115,4 +1179,3 @@ public class ComputationDAO
 	}
 
 }
-

--- a/src/main/java/opendcs/dao/LoadingAppDao.java
+++ b/src/main/java/opendcs/dao/LoadingAppDao.java
@@ -669,7 +669,7 @@ public class LoadingAppDao
 				updateHeartbeat.setDate(1,new java.sql.Date(lock.getHeartbeat().getTime()));
 				updateHeartbeat.setString(2,lock.getStatus());
 				updateHeartbeat.setLong(3,lock.getAppId().getValue());
-				debug3("HEARTBEAT UPDATE:" + updateHeartbeat.toString());
+				debug3("updating heartbeat");
 				updateHeartbeat.execute();
 /*				String q = "UPDATE CP_COMP_PROC_LOCK SET HEARTBEAT = "
 					+ db.sqlDate(lock.getHeartbeat()) + ", CUR_STATUS = "

--- a/src/main/java/opendcs/dao/LoadingAppDao.java
+++ b/src/main/java/opendcs/dao/LoadingAppDao.java
@@ -575,7 +575,10 @@ public class LoadingAppDao
 			insertLockInfo.setLong(1,appInfo.getAppId().getValue());
 			insertLockInfo.setInt(2,pid);
 			insertLockInfo.setString(3,host);
-			insertLockInfo.setDate(4, new java.sql.Date(lock.getHeartbeat().getTime()));
+			if( db.isOpenTSDB() )
+				insertLockInfo.setLong(4, lock.getHeartbeat().getTime());
+			else
+				insertLockInfo.setDate(4, new java.sql.Date(lock.getHeartbeat().getTime()));
 			insertLockInfo.setString(5,lock.getStatus());
 			insertLockInfo.execute();
 
@@ -666,7 +669,11 @@ public class LoadingAppDao
 				}
 				lock.setHeartbeat(new Date());
 
-				updateHeartbeat.setDate(1,new java.sql.Date(lock.getHeartbeat().getTime()));
+				if( db.isOpenTSDB() )
+					updateHeartbeat.setLong(1, lock.getHeartbeat().getTime());
+				else
+					updateHeartbeat.setDate(1,new java.sql.Date(lock.getHeartbeat().getTime()));
+
 				updateHeartbeat.setString(2,lock.getStatus());
 				updateHeartbeat.setLong(3,lock.getAppId().getValue());
 				debug3("updating heartbeat");

--- a/src/main/java/opendcs/dao/LoadingAppDao.java
+++ b/src/main/java/opendcs/dao/LoadingAppDao.java
@@ -1,6 +1,6 @@
 /*
  * $Id: LoadingAppDao.java,v 1.12 2020/02/14 22:27:05 mmaloney Exp $
- * 
+ *
  * $Log: LoadingAppDao.java,v $
  * Revision 1.12  2020/02/14 22:27:05  mmaloney
  * Updates
@@ -39,7 +39,7 @@
  * OPENDCS 6.0 Initial Checkin
  *
  * This software was written by Cove Software, LLC ("COVE") under contract
- * to the United States Government. No warranty is provided or implied other 
+ * to the United States Government. No warranty is provided or implied other
  * than specific contractual terms between COVE and the U.S. Government.
  *
  * Copyright 2014 U.S. Army Corps of Engineers, Hydrologic Engineering Center.
@@ -85,8 +85,8 @@ import decodes.util.DecodesSettings;
  * Data Access Object for writing/reading DbEnum objects to/from a SQL database
  * @author mmaloney Mike Maloney, Cove Software, LLC
  */
-public class LoadingAppDao 
-	extends DaoBase 
+public class LoadingAppDao
+	extends DaoBase
 	implements LoadingAppDAI
 {
 	private PreparedStatement lockCheckStmt = null;
@@ -97,19 +97,19 @@ public class LoadingAppDao
 		super(tsdb, "LoadingAppDao");
 		lastModifiedSdf.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
-	
+
 	@Override
 	public List<String> listComputationsByApplicationId( DbKey appId, boolean enabledOnly )
 		throws DbIoException
 	{
 		String q = "select COMPUTATION_NAME from CP_COMPUTATION";
-				
+
 		if (appId != Constants.undefinedId)
 			q = q + " where LOADING_APPLICATION_ID = " + appId;
 		if (enabledOnly)
 			q = q + (appId != Constants.undefinedId ? " and " : " where ")
 				+ "enabled = 'Y'";
-		
+
 		try
 		{
 			ResultSet rs = doQuery(q);
@@ -153,7 +153,7 @@ public class LoadingAppDao
 			}
 
 			fillInProperties(ret, "");
-			
+
 			q = "select a.loading_application_id, count(1) as CompsUsingProc "
 				+ "from hdb_loading_application a, cp_computation b "
 				+ "where a.loading_application_id = b.loading_application_id "
@@ -173,7 +173,7 @@ public class LoadingAppDao
 		catch(SQLException ex)
 		{
 			String msg = "Error listing applications: " + ex;
-			warning(msg);	
+			warning(msg);
 			throw new DbIoException(msg);
 		}
 		finally
@@ -181,7 +181,7 @@ public class LoadingAppDao
 			propertiesDao.close();
 		}
 	}
-	
+
 	private void fillInProperties(ArrayList<CompAppInfo> list, String whereClause)
 		throws SQLException, DbIoException
 	{
@@ -200,9 +200,9 @@ public class LoadingAppDao
 					break;
 				}
 		}
-		
+
 	}
-	
+
 	@Override
 	public ArrayList<CompAppInfo> ComputationAppsIn(String inList)
 		throws DbIoException
@@ -232,7 +232,7 @@ public class LoadingAppDao
 		catch(SQLException ex)
 		{
 			String msg = "Error listing applications: " + ex;
-			warning(msg);	
+			warning(msg);
 			throw new DbIoException(msg);
 		}
 	}
@@ -257,7 +257,7 @@ public class LoadingAppDao
 			cai.setManualEditApp(TextUtil.str2boolean(rs.getString(2)));
 			cai.setComment(rs.getString(3));
 
-			propsDao.readProperties("REF_LOADING_APPLICATION_PROP", "LOADING_APPLICATION_ID", id, 
+			propsDao.readProperties("REF_LOADING_APPLICATION_PROP", "LOADING_APPLICATION_ID", id,
 				cai.getProperties());
 			String lmp = PropertiesUtil.getIgnoreCase(cai.getProperties(), "LastModified");
 			if (lmp != null)
@@ -272,7 +272,7 @@ public class LoadingAppDao
 		catch(SQLException ex)
 		{
 			String msg = "Error in getComputationApp(" + id + "): " + ex;
-			warning(msg);	
+			warning(msg);
 			throw new DbIoException(msg);
 		}
 		finally
@@ -291,12 +291,12 @@ public class LoadingAppDao
 		String appName = app.getAppName();
 		if (appName.length() > 24)
 			appName = appName.substring(0, 24);
-		
+
 		if (isNew)
 		{
 			// Could be import from XML to overwrite existing algorithm.
 			q = "select LOADING_APPLICATION_ID from HDB_LOADING_APPLICATION"
-			  + " where LOADING_APPLICATION_NAME = " 
+			  + " where LOADING_APPLICATION_NAME = "
 			  + sqlString(appName);
 			try
 			{
@@ -323,7 +323,7 @@ public class LoadingAppDao
 
 		PropertiesDAI propertiesDao = db.makePropertiesDAO();
 
-		try 
+		try
 		{
 			if (isNew)
 			{
@@ -333,16 +333,16 @@ public class LoadingAppDao
 					+ ") VALUES("
 					+ id
 					+ ", " + sqlString(appName)
-					+ ", 'N'" 
+					+ ", 'N'"
 					+ ", " + sqlString(app.getComment())
 				    + ")";
-				
+
 				doModify(q);
 				if (id.getValue() == 0L) // HDB does auto-sequence
 				{
-					q = 
+					q =
 					"select LOADING_APPLICATION_ID from HDB_LOADING_APPLICATION"
-			  		+ " where LOADING_APPLICATION_NAME = " 
+			  		+ " where LOADING_APPLICATION_NAME = "
 			  		+ sqlString(appName);
 					try
 					{
@@ -386,7 +386,7 @@ public class LoadingAppDao
 			}
 
 			app.getProperties().setProperty("LastModified", lastModifiedSdf.format(new Date()));
-			propertiesDao.writeProperties("REF_LOADING_APPLICATION_PROP", "LOADING_APPLICATION_ID", 
+			propertiesDao.writeProperties("REF_LOADING_APPLICATION_PROP", "LOADING_APPLICATION_ID",
 				app.getKey(), app.getProperties());
 		}
 		catch(DbIoException ex)
@@ -400,7 +400,7 @@ public class LoadingAppDao
 		}
 
 	}
-	
+
 	@Override
 	public void deleteComputationApp(CompAppInfo app)
 		throws DbIoException, ConstraintException
@@ -444,17 +444,17 @@ public class LoadingAppDao
 						throw new ConstraintException("Cannot delete application '" + app.getAppName()
 							+ "' with id=" + app.getKey() + " because " + num + " alarm screenings are "
 							+ "assigned to it.");
-				}	
+				}
 			}
 
-			
-			
+
+
 			q = "delete from REF_LOADING_APPLICATION_PROP "
 				+ "where LOADING_APPLICATION_ID = " + app.getKey();
 			doModify(q);
-			
-			
-			
+
+
+
 			// LOADING_APPLICATION_ID column doesn't exist in old versions of DACQ_EVENT.
 			if (db.getDecodesDatabaseVersion() >= DecodesDatabaseVersion.DECODES_DB_15)
 			{
@@ -493,7 +493,7 @@ public class LoadingAppDao
 	}
 
 	@Override
-	public DbKey lookupAppId(String name) 
+	public DbKey lookupAppId(String name)
 		throws DbIoException, NoSuchObjectException
 	{
 		String q = "select loading_application_id from HDB_LOADING_APPLICATION" +
@@ -508,7 +508,7 @@ public class LoadingAppDao
 		catch(SQLException ex)
 		{
 			String msg = "Error in lookupAppId(" + name + "): " + ex;
-			warning(msg);	
+			warning(msg);
 			throw new DbIoException(msg);
 		}
 	}
@@ -541,9 +541,9 @@ public class LoadingAppDao
 				}
 				if (!lock.isStale())
 				{
-					String msg = 
+					String msg =
 						"Cannot obtain lock for app ID " + appInfo.getAppId()
-						+ ". Currently owned by PID " + lock.getPID() 
+						+ ". Currently owned by PID " + lock.getPID()
 						+ " on host '" + lock.getHost() + "'";
 					fatal(msg);
 					throw new LockBusyException(msg);
@@ -552,7 +552,7 @@ public class LoadingAppDao
 		}
 		catch(SQLException ex)
 		{
-			String msg = "Error iterating result set for query '" + 
+			String msg = "Error iterating result set for query '" +
 				q + "': " + ex;
 			failure(msg);
 		}
@@ -560,7 +560,7 @@ public class LoadingAppDao
 			releaseCompProcLock(lock);
 		lock = new TsdbCompLock(appInfo.getAppId(), pid, host, new Date(), "Starting");
 		q = "INSERT INTO CP_COMP_PROC_LOCK VALUES ("
-			+ appInfo.getAppId() + ", " + pid + ", " + sqlString(host) + ", " 
+			+ appInfo.getAppId() + ", " + pid + ", " + sqlString(host) + ", "
 			+ db.sqlDate(lock.getHeartbeat()) + ", " + sqlString(lock.getStatus())
 			+ ")";
 		doModify(q);
@@ -601,12 +601,15 @@ public class LoadingAppDao
 	}
 
 	@Override
-	public void checkCompProcLock(TsdbCompLock lock) 
+	public void checkCompProcLock(TsdbCompLock lock)
 		throws LockBusyException, DbIoException
 	{
 		TsdbCompLock tlock;
 //		Logger.instance().debug3("Checking lock for appID=" + lock.getAppId());
-		try
+		try( PreparedStatement updateHeartbeat =
+			db.getConnection().prepareStatement(
+				"UPDATE CP_COMP_PROC_LOCK SET HEARTBEAT = ?, CUR_STATUS = ? WHERE LOADING_APPLICATION_ID = ?"
+			))
 		{
 			// Retrieve the lock for this process.
 			if (lockCheckStmt == null)
@@ -625,20 +628,25 @@ public class LoadingAppDao
 				{
 					throw new LockBusyException(
 						"Lock for app ID " + lock.getAppId()
-						+ " has been stolen by PID " + tlock.getPID() 
+						+ " has been stolen by PID " + tlock.getPID()
 						+ " on host '" + tlock.getHost() + "'"
 						+ ", my PID=" + lock.getPID()
 						+ ", my host='" + lock.getHost() + "'");
 				}
 				lock.setHeartbeat(new Date());
 
-				String q = "UPDATE CP_COMP_PROC_LOCK SET HEARTBEAT = "
+				updateHeartbeat.setDate(1,new java.sql.Date(lock.getHeartbeat().getTime()));
+				updateHeartbeat.setString(2,lock.getStatus());
+				updateHeartbeat.setLong(3,lock.getAppId().getValue());
+				debug3("HEARTBEAT UPDATE:" + updateHeartbeat.toString());
+				updateHeartbeat.execute();
+/*				String q = "UPDATE CP_COMP_PROC_LOCK SET HEARTBEAT = "
 					+ db.sqlDate(lock.getHeartbeat()) + ", CUR_STATUS = "
 					+ sqlString(lock.getStatus())
 					+ " WHERE LOADING_APPLICATION_ID = "
 					+ lock.getAppId();
-					
-				doModify(q);
+
+				doModify(q);*/
 			}
 			else
 				throw new LockBusyException("Lock for app ID " + lock.getAppId()
@@ -651,7 +659,7 @@ public class LoadingAppDao
 	}
 
 	@Override
-	public List<TsdbCompLock> getAllCompProcLocks() 
+	public List<TsdbCompLock> getAllCompProcLocks()
 		throws DbIoException
 	{
 		ArrayList<TsdbCompLock> ret = new ArrayList<TsdbCompLock>();
@@ -666,7 +674,7 @@ public class LoadingAppDao
 		{
 			warning("Error iterating results for query '" + q + "': " + ex);
 		}
-		
+
 		q = "SELECT LOADING_APPLICATION_ID, LOADING_APPLICATION_NAME FROM HDB_LOADING_APPLICATION";
 		rs = doQuery(q);
 		try
@@ -687,7 +695,7 @@ public class LoadingAppDao
 		{
 			warning("Error iterating results for query '" + q + "': " + ex);
 		}
-		
+
 		return ret;
 	}
 
@@ -696,7 +704,7 @@ public class LoadingAppDao
 	{
 		return true;
 	}
-	
+
 	@Override
 	public void close()
 	{


### PR DESCRIPTION
After realizing just how bad the problem was in our databases, thanks to a report from one of the districts, with duplicate queries sucking up space I moved some critical queries to using bind variables

- CompLock the update heartbeat was taking up 100 MB for a single process due to the date changing every time it was called.
- TimeSeriesDB::releaseData since this was always called with different inputs and a different number each time
  - I am still working through a bug with updating the failtime so don't merge this yet.
- CwmsTimeSeriesdb::getNewData - this was using preparedstatements but not bind variables, leaving no way for oracle to save one plan for each instance.
- LoadingApplicationDAO
- ComputationDAO - only thing that would be used in a long running program like compproc.
- CompDependsDAO

The biggest benefit will be for those that run multiple instances of compproc, but even those that don't, at least in Oracle the query for updating the lock heartbeat was using so much of the share space that it'll start ejecting things that should stay resident. I don't know the exact performance on Postgres but all of the major DBMSs implement query, and thus query plan, pooling. 

There's still a little work to be done, but I wanted to get it visible as soon as possible in case I missed something critical.

[build.xml]
I updated the target and source version to 1.8, it's 2021. No one should be using java 1.6 for anything and the try-with-resources structure is a rather wonderful thing for sql development.