### PR TITLE
Bugfix/OPENDCS-50 UI freeze due to modal dialog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,8 @@ dependencies {
 
     izpack 'org.codehaus.izpack:izpack-standalone-compiler:4.3.5'
 
-    testRuntimeOnly 'org.junit:junit:4.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
 }
 
 import org.apache.tools.ant.filters.ReplaceTokens
@@ -227,4 +228,8 @@ task cwmstar( type: Tar){
     compression = Compression.GZIP
 
 
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src/main/java/decodes/dbeditor/DbEditorTab.java
+++ b/src/main/java/decodes/dbeditor/DbEditorTab.java
@@ -48,13 +48,8 @@ public abstract class DbEditorTab extends JPanel
 	*/
 	public void launchDialog(JDialog dlg)
 	{
-		JFrame jf = getParentFrame();
-		Point loc = jf.getLocation();
-		Dimension frmSize = jf.getSize();
-		Dimension dlgSize = dlg.getPreferredSize();
-		int x = (frmSize.width - dlgSize.width) / 2 + loc.x;
-		int y = (frmSize.height - dlgSize.height) / 2 + loc.y;
-		dlg.setLocation(x, y);
+		dlg.validate();
+		dlg.setLocationRelativeTo(getParentFrame());
 		dlg.setVisible(true);
 	}
 	

--- a/src/main/java/decodes/gui/GuiDialog.java
+++ b/src/main/java/decodes/gui/GuiDialog.java
@@ -101,12 +101,8 @@ public class GuiDialog extends JDialog
 	*/
 	public void launchDialog(JDialog dlg)
 	{
-		Point loc = getLocation();
-		Dimension frmSize = getSize();
-		Dimension dlgSize = dlg.getPreferredSize();
-		int x = (frmSize.width - dlgSize.width) / 2 + loc.x;
-		int y = (frmSize.height - dlgSize.height) / 2 + loc.y;
-		dlg.setLocation(x, y);
+		dlg.validate();
+		dlg.setLocationRelativeTo(dlg);
 		dlg.setVisible(true);
 	}
 
@@ -246,6 +242,4 @@ public class GuiDialog extends JDialog
 			changeTrackFile = null;
 		}
 	}
-
-
 }

--- a/src/main/java/decodes/gui/TopFrame.java
+++ b/src/main/java/decodes/gui/TopFrame.java
@@ -173,13 +173,8 @@ public class TopFrame extends JFrame
 	*/
 	public void launchDialog(JDialog dlg)
 	{
-		Point loc = getLocation();
-		Dimension frmSize = getSize();
-		Dimension dlgSize = dlg.getPreferredSize();
-		int x = (frmSize.width - dlgSize.width) / 2 + loc.x;
-		int y = (frmSize.height - dlgSize.height) / 2 + loc.y;
-	
-		dlg.setLocation(x, y);
+		dlg.validate();
+		dlg.setLocationRelativeTo(this);
 		dlg.setVisible(true);
 	}
 

--- a/src/main/java/decodes/platwiz/PlatformWizard.java
+++ b/src/main/java/decodes/platwiz/PlatformWizard.java
@@ -119,12 +119,8 @@ public class PlatformWizard
 	*/
 	public void launchDialog(JDialog dlg)
 	{
-		Point loc = frame.getLocation();
-		Dimension frmSize = frame.getSize();
-		Dimension dlgSize = dlg.getPreferredSize();
-		int x = (frmSize.width - dlgSize.width) / 2 + loc.x;
-		int y = (frmSize.height - dlgSize.height) / 2 + loc.y;
-		dlg.setLocation(x, y);
+		dlg.validate();
+		dlg.setLocationRelativeTo(frame);
 		dlg.setVisible(true);
 	}
 

--- a/src/main/java/decodes/rledit/RefListFrame.java
+++ b/src/main/java/decodes/rledit/RefListFrame.java
@@ -1239,17 +1239,12 @@ public class RefListFrame extends JFrame
 	  Launches the passed modal dialog at a reasonable position on the screen.
 	  @param dlg the dialog.
 	*/
-	protected void launchDialog(JDialog dlg)
+	private void launchDialog(JDialog dlg)
 	{
 		dlg.setModal(true);
-		java.awt.Point loc = this.getLocation();
-		Dimension frmSize = this.getSize();
-		Dimension dlgSize = dlg.getPreferredSize();
-		int x = (frmSize.width - dlgSize.width) / 2 + loc.x;
-		int y = (frmSize.height - dlgSize.height) / 2 + loc.y;
-		dlg.setLocation(x, y);
+		dlg.validate();
+		dlg.setLocationRelativeTo(this);
 		dlg.setVisible(true);
-		//dlg.show();
 	}
 
 	/**

--- a/src/main/java/decodes/tsdb/groupedit/TsDbGrpEditorTab.java
+++ b/src/main/java/decodes/tsdb/groupedit/TsDbGrpEditorTab.java
@@ -34,13 +34,8 @@ public abstract class TsDbGrpEditorTab extends JPanel
 	*/
 	public void launchDialog(JDialog dlg)
 	{
-		JFrame jf = TopFrame.instance();
-		Point loc = jf.getLocation();
-		Dimension frmSize = jf.getSize();
-		Dimension dlgSize = dlg.getPreferredSize();
-		int x = (frmSize.width - dlgSize.width) / 2 + loc.x;
-		int y = (frmSize.height - dlgSize.height) / 2 + loc.y;
-		dlg.setLocation(x, y);
+		dlg.validate();
+		dlg.setLocationRelativeTo(TopFrame.instance());
 		dlg.setVisible(true);
 	}
 

--- a/src/main/java/lritdcs/StatusDisplayFrame.java
+++ b/src/main/java/lritdcs/StatusDisplayFrame.java
@@ -577,19 +577,11 @@ public class StatusDisplayFrame extends JFrame {
 		myPollThread.cmd = "flush all";
 	}
 
-	protected void launchDialog(JDialog dlg) {
+	private void launchDialog(JDialog dlg) {
 		dlg.setModal(true);
-		java.awt.Point loc = this.getLocation();
-		Dimension frmSize = this.getSize();
-		Dimension dlgSize = dlg.getPreferredSize();
-		int x = (frmSize.width - dlgSize.width) / 2 + loc.x;
-		if (x < 0)
-			x = 10;
-		int y = (frmSize.height - dlgSize.height) / 2 + loc.y;
-		if (y < 0)
-			y = 10;
-		dlg.setLocation(x, y);
-		dlg.show();
+		dlg.validate();
+		dlg.setLocationRelativeTo(this);
+		dlg.setVisible(true);
 	}
 
 	public void addEvent(String event, String from) {


### PR DESCRIPTION
call validate on the dialog before setting the dialog visible so that the native windowing reallocates native screen resources after calling dispose. This solves a bug in Windows where resources are not reallocated in the Window::setVisible method. https://docs.oracle.com/javase/7/docs/api/java/awt/Window.html#dispose()