### PR TITLE
New event listener for launcher GUI profile selection box

### DIFF
--- a/src/main/java/decodes/launcher/LauncherFrame.java
+++ b/src/main/java/decodes/launcher/LauncherFrame.java
@@ -1335,7 +1335,8 @@ Logger.instance().info("LauncherFrame ctor - getting dacq launcher actions...");
 	
 	private void profileComboChanged()
 	{
-		// Activate/Deactivate tsdb buttons when profile selection changes
+		// Each time the profile selection combo box changes, check the new properties file
+		// Activate/Deactivate tsdb buttons depending on database type
 		String profileName = getSelectedProfile();
 		String profilePath;
 		


### PR DESCRIPTION
Added an event listener to the launcher GUI profile selection box. Each time the profile selection changes, check the correct properties file and enable/disable the buttons that are only enabled for time series db's (computations, groups, etc.). This allows you to get to things like the computation editor via the launcher if your default profile isn't a time series db.