### PR TITLE
#80 add a limit to the amount of time between gaps of data for CWMS ts processing

### DIFF
--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
@@ -155,7 +155,6 @@ public class CwmsTimeSeriesDAO
 {
 	protected static DbObjectCache<TimeSeriesIdentifier> cache = 
 		new DbObjectCache<TimeSeriesIdentifier>(60 * 60 * 1000L, false);
-	private static final long MAX_TIME_GAP_FOR_HISTORICAL = Integer.getInteger("opendcs.cwmstsdb.max_timegap_historical.days", 7) - 1L;
 	protected SiteDAI siteDAO = null;
 	protected DataTypeDAI dataTypeDAO = null;
 	private String dbOfficeId = null;
@@ -1424,7 +1423,7 @@ public class CwmsTimeSeriesDAO
 			return false;
 		}
 		long daysBetween = TimeUnit.MILLISECONDS.toDays(currentTimestamp.getTime() - lastTimestamp.getTime());
-		return daysBetween > MAX_TIME_GAP_FOR_HISTORICAL;
+		return daysBetween > (DecodesSettings.instance().cp_cwmstsdb_getNewData_max_timegap_days - 1);
 	}
 
 

--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
@@ -1423,7 +1423,7 @@ public class CwmsTimeSeriesDAO
 			return false;
 		}
 		long daysBetween = TimeUnit.MILLISECONDS.toDays(currentTimestamp.getTime() - lastTimestamp.getTime());
-		return daysBetween > (DecodesSettings.instance().cp_cwmstsdb_getNewData_max_timegap_days - 1);
+		return daysBetween >= DecodesSettings.instance().cp_cwmstsdb_getNewData_max_timegap_days;
 	}
 
 

--- a/src/main/java/decodes/util/DecodesSettings.java
+++ b/src/main/java/decodes/util/DecodesSettings.java
@@ -343,6 +343,9 @@ public class DecodesSettings
 	/** Set to true to allow DECODES to write CWMS Location records */
 	public boolean writeCwmsLocations = false;
 
+	/** Set to the count of days before CWMS TS getNewData will assume gaps are between historical and current data */
+	public int cp_cwmstsdb_getNewData_max_timegap_days = 7;
+
 	/** Show the Platform Wizard button on the button panel */
 	public boolean showPlatformWizard = false;
 
@@ -569,6 +572,8 @@ public class DecodesSettings
 			" in querying the database."),
 		new PropertySpec("writeCwmsLocations", PropertySpec.BOOLEAN,
 			"Set to true to allow DECODES to write CWMS Location records"),
+		new PropertySpec("cp_cwmstsdb_getNewData_max_timegap_days", PropertySpec.INT,
+			"Set to the count of days before CWMS TS getNewData will assume gaps are between historical and current data"),
 		new PropertySpec("showPlatformWizard", PropertySpec.BOOLEAN,
 			"Show the Platform Wizard button on the button panel"),
 		new PropertySpec("showNetlistEditor", PropertySpec.BOOLEAN,

--- a/src/test/java/decodes/cwms/CwmsTimeSeriesDAOTest.java
+++ b/src/test/java/decodes/cwms/CwmsTimeSeriesDAOTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-final class TestCwmsTimeSeriesDAO
+final class CwmsTimeSeriesDAOTest
 {
 	@Test
 	public void testExceedsMaxTimeGap()

--- a/src/test/java/decodes/cwms/TestCwmsTimeSeriesDAO.java
+++ b/src/test/java/decodes/cwms/TestCwmsTimeSeriesDAO.java
@@ -1,0 +1,40 @@
+package decodes.cwms;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class TestCwmsTimeSeriesDAO
+{
+	@Test
+	public void testExceedsMaxTimeGap()
+	{
+		try(CwmsTimeSeriesDAO cwmsTimeSeriesDAO = new CwmsTimeSeriesDAO(new CwmsTimeSeriesDb(), "SWT"))
+		{
+			Calendar first = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+			first.set(2015, Calendar.JANUARY, 1, 0, 0, 0);
+			Calendar second = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+			second.set(2015, Calendar.JANUARY, 9, 0, 0, 0);
+			assertTrue(cwmsTimeSeriesDAO.exceedsMaxTimeGap(first.getTime(), second.getTime()));
+			second.set(2015, Calendar.JANUARY, 8, 0, 0, 0);
+			assertTrue(cwmsTimeSeriesDAO.exceedsMaxTimeGap(first.getTime(), second.getTime()));
+		}
+	}
+
+	@Test
+	public void testWithinMaxTimeGap()
+	{
+		try(CwmsTimeSeriesDAO cwmsTimeSeriesDAO = new CwmsTimeSeriesDAO(new CwmsTimeSeriesDb(), "SWT"))
+		{
+			Calendar first = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+			first.set(2015, Calendar.JANUARY, 1, 0, 0, 0);
+			Calendar second = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+			second.set(2015, Calendar.JANUARY, 7, 23, 59, 59);
+			assertFalse(cwmsTimeSeriesDAO.exceedsMaxTimeGap(first.getTime(), second.getTime()));
+		}
+	}
+}


### PR DESCRIPTION
resolves https://github.com/opendcs/opendcs/issues/80

The maximum time gap is set to 7 days with an overridable system property "opendcs.cwmstsdb.max_timegap_historical.days"