### PR TITLE
Fix issue 21 reload algo before test run in GUI

### DIFF
--- a/src/main/java/decodes/tsdb/comprungui/CompRunGuiFrame.java
+++ b/src/main/java/decodes/tsdb/comprungui/CompRunGuiFrame.java
@@ -60,6 +60,7 @@ import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.table.AbstractTableModel;
 
+import opendcs.dai.AlgorithmDAI;
 import opendcs.dai.TimeSeriesDAI;
 import opendcs.dai.TsGroupDAI;
 
@@ -955,7 +956,7 @@ public class CompRunGuiFrame extends TopFrame
 					outputParms.add(parm);
 				}
 			}
-			try
+			try (AlgorithmDAI algoDAO = theDb.makeAlgorithmDAO())
 			{
 				Logger.instance().info(
 					"Running computation " + comp.getName() + " modelRunId=" + comp.getModelRunId()
@@ -984,6 +985,7 @@ public class CompRunGuiFrame extends TopFrame
 								+ tsid.getUniqueString()));
 				}
 				// run inputs through computation
+				comp.setAlgorithm(algoDAO.getAlgorithmById(comp.getAlgorithmId()));
 				comp.prepareForExec(theDb);
 				comp.apply(runme, theDb);
 			}
@@ -996,6 +998,11 @@ public class CompRunGuiFrame extends TopFrame
 			catch (DbIoException e)
 			{
 				showError(module + " DbIOException in " + "runButtonPressed() " + e.getMessage());
+				continue;
+			}
+			catch (NoSuchObjectException e)
+			{
+				showError(module + " Cannot read Algorithm in " + "runButtonPressed() " + e.getMessage());
 				continue;
 			}
 


### PR DESCRIPTION
## Problem Description

Fixes #21
This was not limited to python algorithms. E.g. If some simple algorithm defined a default property value and it wasn't overloaded in the computation, the same behavior would appear.

## Solution

In the computation-run-GUI, reload the algorithm before preparing the computation for execution.

## how you tested the change

One of the regression tests used a python algorithm. I performed the steps described in the issue to recreate the problem and then to verify that it is fixed after changing the code.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests that run during ant test
   - [ ] Test procedure descriptions
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
