### PR TITLE
Cleanup/decodes script

### DIFF
--- a/src/main/java/decodes/db/DecodesScript.java
+++ b/src/main/java/decodes/db/DecodesScript.java
@@ -92,7 +92,9 @@ public class DecodesScript extends IdDatabaseObject
 
         DecodesSettings settings = DecodesSettings.instance();
         if ( settings.decodesFormatLabelMode.equals("case-sensitive" ) )
+        {
             labelIsCaseSensitive = true;
+        }
         scriptName = name;
         scriptType = Constants.scriptTypeDecodes;
         platformConfig = null;
@@ -125,7 +127,9 @@ public class DecodesScript extends IdDatabaseObject
         {
             ScriptSensor ss = it.next();
             if (ss.sensorNumber == sensorNumber)
+            {
                 return ss;
+            }
         }
         return null;
     }
@@ -138,7 +142,9 @@ public class DecodesScript extends IdDatabaseObject
     {
         ScriptSensor ss = getScriptSensor(newss.sensorNumber);
         if (ss != null)
+        {
             scriptSensors.remove(ss);
+        }
         for(int i=0; i<scriptSensors.size(); i++)
         {
             ss = scriptSensors.elementAt(i);
@@ -156,14 +162,20 @@ public class DecodesScript extends IdDatabaseObject
       in Constants.java.
      * @return the data order for this script
      */
-    public char getDataOrder() { return dataOrder; }
+    public char getDataOrder()
+    {
+        return dataOrder;
+    }
 
     /**
       Sets the data order for this script (must one of values defined
       in Constants.java.
      * @param order the data order.
      */
-    public void setDataOrder(char order) { dataOrder = order; }
+    public void setDataOrder(char order)
+    {
+        dataOrder = order;
+    }
 
     /**
     * This compares two DecodesScripts, and returns true if they can be
@@ -192,18 +204,25 @@ public class DecodesScript extends IdDatabaseObject
             return false;
         DecodesScript ds = (DecodesScript)ob;
         if (this == ds)
+        {
             return true;
+        }
         if (!scriptName.equals(ds.scriptName)
          || !scriptType.equals(ds.scriptType)
          || scriptSensors.size() != ds.scriptSensors.size()
          || formatStatements.size() != ds.formatStatements.size()
          || dataOrder != ds.dataOrder)
+        {
             return false;
+        }
         for (int i = 0; i < scriptSensors.size(); i++)
         {
             ScriptSensor ss1 = (ScriptSensor) scriptSensors.elementAt(i);
             ScriptSensor ss2 = (ScriptSensor) ds.scriptSensors.elementAt(i);
-            if (!ss1.equals(ss2)) return false;
+            if (!ss1.equals(ss2))
+            {
+                return false;
+            }
         }
         for (int i = 0; i < formatStatements.size(); i++)
         {
@@ -211,7 +230,10 @@ public class DecodesScript extends IdDatabaseObject
                 (FormatStatement) formatStatements.elementAt(i);
             FormatStatement fs2 =
                 (FormatStatement) ds.formatStatements.elementAt(i);
-            if (!fs1.equals(fs2)) return false;
+            if (!fs1.equals(fs2))
+            {
+                return false;
+            }
         }
         return true;
     }
@@ -220,7 +242,8 @@ public class DecodesScript extends IdDatabaseObject
     * This is inherited from the DatabaseObject interface.  This always
     * returns "DecodesScript".
     */
-    public String getObjectType() {
+    public String getObjectType()
+    {
         return "DecodesScript";
     }
 
@@ -233,8 +256,14 @@ public class DecodesScript extends IdDatabaseObject
     public DecodesScript copy(PlatformConfig newPc)
     {
         DecodesScript ret = noIdCopy(newPc);
-        try { ret.setId(getId()); }
-        catch(DatabaseException ex) {} // won't happen.
+        try
+        {
+            ret.setId(getId());
+        }
+        catch(DatabaseException ex)
+        {
+            // won't happen.
+        }
         return ret;
     }
 
@@ -255,7 +284,9 @@ public class DecodesScript extends IdDatabaseObject
             ScriptSensor newSs = new ScriptSensor(ret, ss.sensorNumber);
             //newSs.unitConverterId = ss.unitConverterId;
             if (ss.rawConverter != null)
+            {
                 newSs.rawConverter = ss.rawConverter.copy();
+            }
             //newSs.rawConverter = ss.rawConverter;
             ret.scriptSensors.add(newSs);
         }
@@ -325,7 +356,9 @@ public class DecodesScript extends IdDatabaseObject
             }
         }
         if (execFmt != null)
+        {
             execFmt.prepareForExec();
+        }
 
         _prepared = true;
     }
@@ -335,7 +368,7 @@ public class DecodesScript extends IdDatabaseObject
      */
     public boolean isPrepared()
     {
-            return _prepared;
+        return _prepared;
     }
 
     /** From DatabaseObject interface; this does nothing.  */
@@ -373,12 +406,19 @@ public class DecodesScript extends IdDatabaseObject
         for(Iterator<FormatStatement> it = formatStatements.iterator(); it.hasNext(); )
         {
             FormatStatement fs = it.next();
-            if ( !labelIsCaseSensitive  ) {
+            if ( !labelIsCaseSensitive  )
+            {
                 if ( label.equalsIgnoreCase(fs.label))
-                      return fs;
-            } else {
-                if (label.equals(fs.label))
+                {
                     return fs;
+                }
+            }
+            else
+            {
+                if (label.equals(fs.label))
+                {
+                    return fs;
+                }
             }
         }
         return null;
@@ -394,13 +434,19 @@ public class DecodesScript extends IdDatabaseObject
             IncompleteDatabaseException, InvalidDatabaseException
     {
         if (!isPrepared())
+        {
             prepareForExec();
+        }
 
         if (trackDecoding)
+        {
             decodedSamples = new ArrayList<DecodedSample>();
+        }
 
         if (formatStatements.size() == 0)
+        {
             throw new DecoderException("No format statements");
+        }
 
         FormatStatement fs = formatStatements.elementAt(0);
         DecodedMessage decmsg = new DecodedMessage(rawmsg);
@@ -448,7 +494,9 @@ public class DecodesScript extends IdDatabaseObject
         // performance measurements to be set as sensors. Do it here so that the sensor
         // interval and offset can be used for proper timing.
         if (includePMs != null && includePMs.size() > 0)
+        {
             addPMs(decmsg);
+        }
 
         decmsg.finishMessage();
         decmsg.applyInitialEuConversions();
@@ -462,7 +510,9 @@ public class DecodesScript extends IdDatabaseObject
     public void addDecodedSample(DecodedSample decodedSample)
     {
         if (decodedSamples != null)
+        {
             decodedSamples.add(decodedSample);
+        }
     }
 
     /**
@@ -482,7 +532,9 @@ public class DecodesScript extends IdDatabaseObject
     {
         int idx = scriptType.indexOf(':');
         if (idx < 0 || scriptType.length() <= idx+1)
+        {
             return null;
+        }
         return scriptType.substring(idx+1);
     }
 
@@ -493,14 +545,7 @@ public class DecodesScript extends IdDatabaseObject
 
     public boolean isMissingSymbol(String symbol)
     {
-//Logger.instance().debug3("script.isMissingSymbol '" + symbol + "' checking against " + missingSymbols.size()
-//    + " defined symbols.");
         return missingSymbols.contains(symbol);
-//        for(String s : missingSymbols)
-//            if (s.equals(symbol))
-//                return true;
-//else Logger.instance().debug3("   doesn't equal '" + s + "'");
-//        return false;
     }
 
     public void setIncludePMs(ArrayList<String> includePMs)
@@ -508,8 +553,12 @@ public class DecodesScript extends IdDatabaseObject
         this.includePMs = includePMs;
         if (includePMs != null && includePMs.size() == 0)
             this.includePMs = null;
-if (this.includePMs != null) Logger.instance().debug1("setIncludePMs: includePMs has "
-+ includePMs.size() + " strings. [0]=" + includePMs.get(0));
+        if (this.includePMs != null)
+        {
+            Logger.instance()
+                  .debug1("setIncludePMs: includePMs has "
+                         + includePMs.size() + " strings. [0]=" + includePMs.get(0));
+        }
     }
 
     /**
@@ -519,15 +568,27 @@ if (this.includePMs != null) Logger.instance().debug1("setIncludePMs: includePMs
     {
         RawMessage rm = decodedMessage.getRawMessage();
         if (rm == null)
+        {
             return;
+        }
         Platform p = null;
-        try { p = rm.getPlatform(); }
-        catch(UnknownPlatformException ex) { return; }
-        if (p == null)
+        try
+        {
+            p = rm.getPlatform();
+        }
+        catch(UnknownPlatformException ex)
+        {
             return;
+        }
+        if (p == null)
+        {
+            return;
+        }
         PlatformConfig pc = p.getConfig();
         if (pc == null)
+        {
             return;
+        }
       nextPM:
         for(String pmname : includePMs)
         {
@@ -545,7 +606,8 @@ Logger.instance().debug1("addPMs looking for '" + pmname + "'");
                 if (cs.sensorName.equalsIgnoreCase(pmname))
                 {
                     decodedMessage.addSample(cs.sensorNumber, v, 0);
-Logger.instance().debug1("addPM: added pm '" + pmname + "' to sensor " + cs.sensorNumber + " with value '" + v.toString() + "'");
+                    Logger.instance()
+                          .debug1("addPM: added pm '" + pmname + "' to sensor " + cs.sensorNumber + " with value '" + v.toString() + "'");
                     continue nextPM;
                 }
             }

--- a/src/main/java/decodes/db/DecodesScript.java
+++ b/src/main/java/decodes/db/DecodesScript.java
@@ -16,6 +16,10 @@ import decodes.util.DecodesSettings;
 import ilex.util.Logger;
 import ilex.var.Variable;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Vector;
@@ -550,4 +554,42 @@ Logger.instance().debug1("addPM: added pm '" + pmname + "' to sensor " + cs.sens
 		}
 	}
 
+	public static DecodesScriptBuilder from(final DecodesScriptReader scriptReader) throws IOException
+	{
+		DecodesScriptBuilder builder = new DecodesScriptBuilder();
+		builder.script = new DecodesScript(null);
+		FormatStatement fs = null;
+		while ((fs = scriptReader.nextStatement(builder.script)) != null)
+		{
+			builder.script.formatStatements.add(fs);
+		}
+		return builder;
+	}
+
+
+	public static class DecodesScriptBuilder
+	{
+		private DecodesScript script;
+
+		public DecodesScript build() throws DecodesScriptException
+		{
+			if (script.scriptName == null)
+			{
+				throw new DecodesScriptException("A script name must be supplied.");
+			}
+			return script;
+		}
+
+		public DecodesScriptBuilder platformConfig(PlatformConfig pc)
+		{
+			script.platformConfig = pc;
+			return this;
+		}
+
+		public DecodesScriptBuilder scriptName(String name)
+		{
+			script.scriptName = name;
+			return this;
+		}
+	}
 }

--- a/src/main/java/decodes/db/DecodesScript.java
+++ b/src/main/java/decodes/db/DecodesScript.java
@@ -17,9 +17,6 @@ import ilex.util.Logger;
 import ilex.var.Variable;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Vector;
@@ -30,6 +27,7 @@ import java.util.Iterator;
  */
 public class DecodesScript extends IdDatabaseObject
 {
+    public static final Logger logger = Logger.instance();
     public static final EmptyDecodesScriptReader EMPTY_SCRIPT = new EmptyDecodesScriptReader();
     // _id is stored in the IdDatabaseObject superclass.
 
@@ -460,22 +458,22 @@ public class DecodesScript extends IdDatabaseObject
             }
             catch(EndOfDataException ex)
             {
-                Logger.instance().log(Logger.E_DEBUG1,
+                logger.log(Logger.E_DEBUG1,
                 "Format statements attempted to read past the end of message.");
                 fs = null;
             }
             catch(SwitchFormatException ex)
             {
-                Logger.instance().debug3(ex.toString());
+                logger.debug3(ex.toString());
                 fs = ex.getNewFormat();
             }
             catch(FieldParseException ex)
             {
-                Logger.instance().log(Logger.E_DEBUG1, ex.toString());
+                logger.log(Logger.E_DEBUG1, ex.toString());
                 fs = getFormatStatement("ERROR");
                 if (fs == null)
                 {
-                    Logger.instance().log(Logger.E_WARNING,
+                    logger.log(Logger.E_WARNING,
                         "No ERROR statement, terminating script: "
                         + ex.toString());
                     throw ex;
@@ -483,7 +481,7 @@ public class DecodesScript extends IdDatabaseObject
             }
             catch(EndlessLoopException ex )
             {
-                Logger.instance().log(Logger.E_WARNING,
+                logger.log(Logger.E_WARNING,
                         "Platform Config: "+ platformConfig.getName()+", script <"+scriptName+"> in endless loop  -- terminated: " + ex);
                 throw new DecoderException("Platform Config: "+ platformConfig.getName()+", script <"+scriptName+"> in endless loop  -- terminated.");
             }
@@ -555,8 +553,7 @@ public class DecodesScript extends IdDatabaseObject
             this.includePMs = null;
         if (this.includePMs != null)
         {
-            Logger.instance()
-                  .debug1("setIncludePMs: includePMs has "
+            logger.debug1("setIncludePMs: includePMs has "
                          + includePMs.size() + " strings. [0]=" + includePMs.get(0));
         }
     }
@@ -592,11 +589,11 @@ public class DecodesScript extends IdDatabaseObject
       nextPM:
         for(String pmname : includePMs)
         {
-Logger.instance().debug1("addPMs looking for '" + pmname + "'");
+            logger.debug1("addPMs looking for '" + pmname + "'");
             Variable v = rm.getPM(pmname);
             if (v == null)
             {
-                Logger.instance().info(
+                logger.info(
                     "addPMs: Message for '" + new String(rm.getHeader())
                     + "' does not have requested performance measurement '" + pmname + "' -- ignored.");
                 continue;
@@ -606,13 +603,12 @@ Logger.instance().debug1("addPMs looking for '" + pmname + "'");
                 if (cs.sensorName.equalsIgnoreCase(pmname))
                 {
                     decodedMessage.addSample(cs.sensorNumber, v, 0);
-                    Logger.instance()
-                          .debug1("addPM: added pm '" + pmname + "' to sensor " + cs.sensorNumber + " with value '" + v.toString() + "'");
+                    logger.debug1("addPM: added pm '" + pmname + "' to sensor " + cs.sensorNumber + " with value '" + v.toString() + "'");
                     continue nextPM;
                 }
             }
             // Fell through, no matching sensor:
-            Logger.instance().info("addPMs: The platform config for '" + new String(rm.getHeader())
+            logger.info("addPMs: The platform config for '" + new String(rm.getHeader())
                 + "' does not have a sensor named '" + pmname + "' -- discarded.");
         }
     }

--- a/src/main/java/decodes/db/DecodesScript.java
+++ b/src/main/java/decodes/db/DecodesScript.java
@@ -613,22 +613,42 @@ public class DecodesScript extends IdDatabaseObject
         }
     }
 
+    /**
+     * Start a builder for a decodes script with a given reader.
+     * @param scriptReader concrete implementation that provides the required statements
+     * @return a Builder object for further operations.
+     * @since 2022-11-05
+     */
     public static DecodesScriptBuilder from(final DecodesScriptReader scriptReader)
     {
         DecodesScriptBuilder builder = new DecodesScriptBuilder(scriptReader);
         return builder;
     }
 
+    /**
+     * Used for starting a new blank decodes script. 
+     * @return a Builder object for further operations
+     */
     public static DecodesScriptBuilder empty()
     {
         return from(EMPTY_SCRIPT);
     }
 
+    /**
+     * NOTE: in the future this will return an immutable copy/reference
+     * @return the Vector of format statements
+     * @since 2022-11-05
+     */
     public Vector<FormatStatement> getFormatStatements()
     {
         return this.formatStatements;
     }
 
+    /**
+     * Utility class to help with creating DecodesScript objects 
+     * and making sure they're in a valid state.
+     * @since 2022-11-05
+     */
     public static class DecodesScriptBuilder
     {
         private DecodesScript script;
@@ -640,6 +660,13 @@ public class DecodesScript extends IdDatabaseObject
             script = new DecodesScript("");
         }
 
+        /**
+         * Finalize the creation of a decodes script. After this 
+         * the script should be ready for decoding operations.
+         * @return DecodesScript
+         * @throws DecodesScriptException Any issues preparing the script
+         * @throws IOException any issues retrieving format statements
+         */
         public DecodesScript build() throws DecodesScriptException, IOException
         {
             try
@@ -658,12 +685,22 @@ public class DecodesScript extends IdDatabaseObject
             }
         }
 
+        /**
+         * Assign a platform configuration 
+         * @param pc initialized PlatformConfig
+         * @return the builder for further operations
+         */
         public DecodesScriptBuilder platformConfig(PlatformConfig pc)
         {
             script.platformConfig = pc;
             return this;
         }
 
+        /**
+         * Set the name
+         * @param name valid decodes script name. Letters, Numbers, -, _
+         * @return the builder for further operations
+         */
         public DecodesScriptBuilder scriptName(String name)
         {
             script.scriptName = name;

--- a/src/main/java/decodes/db/DecodesScript.java
+++ b/src/main/java/decodes/db/DecodesScript.java
@@ -30,586 +30,586 @@ import java.util.Iterator;
  */
 public class DecodesScript extends IdDatabaseObject
 {
-	public static final EmptyDecodesScriptReader EMPTY_SCRIPT = new EmptyDecodesScriptReader();
-	// _id is stored in the IdDatabaseObject superclass.
+    public static final EmptyDecodesScriptReader EMPTY_SCRIPT = new EmptyDecodesScriptReader();
+    // _id is stored in the IdDatabaseObject superclass.
 
-	/**
-	 * Name of this script. Must be unique within a configuration.
-	 */
-	public String scriptName;
+    /**
+     * Name of this script. Must be unique within a configuration.
+     */
+    public String scriptName;
 
-	/** Script type. The only type thus far implemented is 'DECODES'.*/
-	public String scriptType;
+    /** Script type. The only type thus far implemented is 'DECODES'.*/
+    public String scriptType;
 
-	/** Links */
-	public PlatformConfig platformConfig;
+    /** Links */
+    public PlatformConfig platformConfig;
 
-	/**
-	* This stores references to the ScriptSensors.  This data member will
-	* never be null.  Note that the index
-	* of each element of this Vector does not necessarily correspond with
-	* the sensor number.
-	*/
-	public Vector<ScriptSensor> scriptSensors;
+    /**
+    * This stores references to the ScriptSensors.  This data member will
+    * never be null.  Note that the index
+    * of each element of this Vector does not necessarily correspond with
+    * the sensor number.
+    */
+    public Vector<ScriptSensor> scriptSensors;
 
-	/** The format statments that make up the executable script.*/
-	private Vector<FormatStatement> formatStatements;
+    /** The format statments that make up the executable script.*/
+    private Vector<FormatStatement> formatStatements;
 
-	/**
-	  Data Order for this script is Ascending, Descending or Undefined.
-	  Use values in Constants.java.
-	  Default is Undefined, meaning to use the value in Equipment Model.
-	*/
-	private char dataOrder;
+    /**
+      Data Order for this script is Ascending, Descending or Undefined.
+      Use values in Constants.java.
+      Default is Undefined, meaning to use the value in Equipment Model.
+    */
+    private char dataOrder;
 
-	// Executable data
-	private boolean _prepared;
+    // Executable data
+    private boolean _prepared;
 
-	// Format Label mode
-	private boolean labelIsCaseSensitive = false;
-	
-	/** The GUI will set this to true so that raw data positions and samples are tracked. */
-	public static boolean trackDecoding = false;
-	
-	/** if (trackDecoding) then this will store decoded samples after execution. */
-	private ArrayList<DecodedSample> decodedSamples = null;
-	
-	/**
-	 * New for 6.4, allows a script to call setMissing(xyz) to specify a special symbol
-	 * to signify a missing value. Example Campbell CX3000 sometimes uses 6998.
-	 */
-	private HashSet<String> missingSymbols = new HashSet<String>();
-	
-	private ArrayList<String> includePMs = null;
-	
-	/**
-	 * Constructor
-	 * @param name Name of this script.
-	 */
-	private DecodesScript(String name)
-	{
-		super(); // sets _id to Constants.undefinedId;
+    // Format Label mode
+    private boolean labelIsCaseSensitive = false;
 
-		DecodesSettings settings = DecodesSettings.instance();
-		if ( settings.decodesFormatLabelMode.equals("case-sensitive" ) )
-			labelIsCaseSensitive = true;	
-		scriptName = name;
-		scriptType = Constants.scriptTypeDecodes;
-		platformConfig = null;
-		scriptSensors = new Vector<ScriptSensor>();
-		formatStatements = new Vector<FormatStatement>();
-		dataOrder = Constants.dataOrderUndefined;
-		_prepared = false;
-	}
+    /** The GUI will set this to true so that raw data positions and samples are tracked. */
+    public static boolean trackDecoding = false;
 
-	/**
-	 * Construct with the owner PlatformConfig and a name.
-	 * @param platformConfig The config that owns this script.
-	 * @param name the name of the script.
-	 */
-	private DecodesScript(PlatformConfig platformConfig, String name)
-	{
-		this(name);
-		this.platformConfig = platformConfig;
-	}
+    /** if (trackDecoding) then this will store decoded samples after execution. */
+    private ArrayList<DecodedSample> decodedSamples = null;
 
-	/**
-	* Get a ScriptSensor by sensor number.
-	* If no sensor with a matching number is found, this returns null.
-	 * @param sensorNumber the sensor number
-	 * @return the ScriptSensor or null if not found.
-	 */
-	public ScriptSensor getScriptSensor(int sensorNumber)
-	{
-		for(Iterator<ScriptSensor> it = scriptSensors.iterator(); it.hasNext(); )
-		{
-			ScriptSensor ss = it.next();
-			if (ss.sensorNumber == sensorNumber)
-				return ss;
-		}
-		return null;
-	}
+    /**
+     * New for 6.4, allows a script to call setMissing(xyz) to specify a special symbol
+     * to signify a missing value. Example Campbell CX3000 sometimes uses 6998.
+     */
+    private HashSet<String> missingSymbols = new HashSet<String>();
 
-	/**
-	 *  Adds a script sensor at the correct position in the array.
-	 * @param newss the new script sensor to add.
-	 */
-	public void addScriptSensor(ScriptSensor newss)
-	{
-		ScriptSensor ss = getScriptSensor(newss.sensorNumber);
-		if (ss != null)
-			scriptSensors.remove(ss);
-		for(int i=0; i<scriptSensors.size(); i++)
-		{
-			ss = scriptSensors.elementAt(i);
-			if (ss.sensorNumber > newss.sensorNumber)
-			{
-				scriptSensors.insertElementAt(newss, i);
-				return;
-			}
-		}
-		scriptSensors.add(newss);
-	}
+    private ArrayList<String> includePMs = null;
 
-	/**
-	  Returns the data order for this script (one of values defined
-	  in Constants.java.
-	 * @return the data order for this script
-	 */
-	public char getDataOrder() { return dataOrder; }
+    /**
+     * Constructor
+     * @param name Name of this script.
+     */
+    private DecodesScript(String name)
+    {
+        super(); // sets _id to Constants.undefinedId;
 
-	/**
-	  Sets the data order for this script (must one of values defined
-	  in Constants.java.
-	 * @param order the data order.
-	 */
-	public void setDataOrder(char order) { dataOrder = order; }
+        DecodesSettings settings = DecodesSettings.instance();
+        if ( settings.decodesFormatLabelMode.equals("case-sensitive" ) )
+            labelIsCaseSensitive = true;
+        scriptName = name;
+        scriptType = Constants.scriptTypeDecodes;
+        platformConfig = null;
+        scriptSensors = new Vector<ScriptSensor>();
+        formatStatements = new Vector<FormatStatement>();
+        dataOrder = Constants.dataOrderUndefined;
+        _prepared = false;
+    }
 
-	/**
-	* This compares two DecodesScripts, and returns true if they can be
-	* considered equal.  Note that this doesn't check the SQL database
-	* ID number.  Two DecodesScripts are considered equal iff:
-	* <ul>
-	*   <li>the scriptName's are the same,</li>
-	*   <li>the scriptType's are the same,</li>
-	*   <li>they have the same number of scriptSensors,</li>
-	*   <li>they have the same number of formatStatements,</li>
-	*   <li>
-	*	 each ScriptSensor of one is "equal" to the corresponding
-	*	 ScriptSensor of the other, and
-	*   </li>
-	*   <li>
-	*	 each FormatStatement of one is "equal" to the corresponding
-	*	 FormatStatement of the other.
-	*   </li>
-	*   <li></li>
-	* </ul>
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
-	public boolean equals(Object ob)
-	{
-		if (!(ob instanceof DecodesScript))
-			return false;
-		DecodesScript ds = (DecodesScript)ob;
-		if (this == ds)
-			return true;
-		if (!scriptName.equals(ds.scriptName)
-		 || !scriptType.equals(ds.scriptType)
-		 || scriptSensors.size() != ds.scriptSensors.size()
-		 || formatStatements.size() != ds.formatStatements.size()
-		 || dataOrder != ds.dataOrder)
-			return false;
-		for (int i = 0; i < scriptSensors.size(); i++)
-		{
-			ScriptSensor ss1 = (ScriptSensor) scriptSensors.elementAt(i);
-			ScriptSensor ss2 = (ScriptSensor) ds.scriptSensors.elementAt(i);
-			if (!ss1.equals(ss2)) return false;
-		}
-		for (int i = 0; i < formatStatements.size(); i++)
-		{
-			FormatStatement fs1 =
-				(FormatStatement) formatStatements.elementAt(i);
-			FormatStatement fs2 =
-				(FormatStatement) ds.formatStatements.elementAt(i);
-			if (!fs1.equals(fs2)) return false;
-		}
-		return true;
-	}
+    /**
+     * Construct with the owner PlatformConfig and a name.
+     * @param platformConfig The config that owns this script.
+     * @param name the name of the script.
+     */
+    private DecodesScript(PlatformConfig platformConfig, String name)
+    {
+        this(name);
+        this.platformConfig = platformConfig;
+    }
 
-	/**
-	* This is inherited from the DatabaseObject interface.  This always
-	* returns "DecodesScript".
-	*/
-	public String getObjectType() {
-		return "DecodesScript";
-	}
+    /**
+    * Get a ScriptSensor by sensor number.
+    * If no sensor with a matching number is found, this returns null.
+     * @param sensorNumber the sensor number
+     * @return the ScriptSensor or null if not found.
+     */
+    public ScriptSensor getScriptSensor(int sensorNumber)
+    {
+        for(Iterator<ScriptSensor> it = scriptSensors.iterator(); it.hasNext(); )
+        {
+            ScriptSensor ss = it.next();
+            if (ss.sensorNumber == sensorNumber)
+                return ss;
+        }
+        return null;
+    }
 
-	/**
-	* Called from PlatformConfig.copy(), makes a new copy of this script
-	* for inclusion in the new config.
-	 * @param newPc The PlatformConfig that is to own the copy
-	 * @return the new DecodesScript object
-	 */
-	public DecodesScript copy(PlatformConfig newPc)
-	{
-		DecodesScript ret = noIdCopy(newPc);
-		try { ret.setId(getId()); }
-		catch(DatabaseException ex) {} // won't happen.
-		return ret;
-	}
+    /**
+     *  Adds a script sensor at the correct position in the array.
+     * @param newss the new script sensor to add.
+     */
+    public void addScriptSensor(ScriptSensor newss)
+    {
+        ScriptSensor ss = getScriptSensor(newss.sensorNumber);
+        if (ss != null)
+            scriptSensors.remove(ss);
+        for(int i=0; i<scriptSensors.size(); i++)
+        {
+            ss = scriptSensors.elementAt(i);
+            if (ss.sensorNumber > newss.sensorNumber)
+            {
+                scriptSensors.insertElementAt(newss, i);
+                return;
+            }
+        }
+        scriptSensors.add(newss);
+    }
 
-	/**
-	* Makes a copy of this script but without the ID.
-	* for inclusion in the new config.
-	 * @param newPc The PlatformConfig that is to own the copy
-	 * @return the new DecodesScript object
-	 */
-	public DecodesScript noIdCopy(PlatformConfig newPc)
-	{
-		DecodesScript ret = new DecodesScript(newPc, scriptName);
-		ret.scriptType = scriptType;
-		ret.dataOrder = dataOrder;
-		for(Iterator<ScriptSensor> it = scriptSensors.iterator(); it.hasNext(); )
-		{
-			ScriptSensor ss = it.next();
-			ScriptSensor newSs = new ScriptSensor(ret, ss.sensorNumber);
-			//newSs.unitConverterId = ss.unitConverterId;
-			if (ss.rawConverter != null)
-				newSs.rawConverter = ss.rawConverter.copy();
-			//newSs.rawConverter = ss.rawConverter;
-			ret.scriptSensors.add(newSs);
-		}
-		for(Iterator<FormatStatement> it = formatStatements.iterator(); it.hasNext(); )
-		{
-			FormatStatement fs = it.next();
-			FormatStatement newFs = new FormatStatement(ret, fs.sequenceNum);
-			newFs.label = fs.label;
-			newFs.format = fs.format;
-			ret.formatStatements.add(newFs);
-		}
-		return ret;
-	}
+    /**
+      Returns the data order for this script (one of values defined
+      in Constants.java.
+     * @return the data order for this script
+     */
+    public char getDataOrder() { return dataOrder; }
 
-	/**
-	From DatabaseObject interface, prepare script sensors and format
-	statements contained in this script.
-	*/
-	public void prepareForExec()
-		throws IncompleteDatabaseException, InvalidDatabaseException
-	{
-		for(Iterator<ScriptSensor> it = scriptSensors.iterator(); it.hasNext(); )
-		{
-			ScriptSensor ss = it.next();
-			ss.prepareForExec();
-		}
+    /**
+      Sets the data order for this script (must one of values defined
+      in Constants.java.
+     * @param order the data order.
+     */
+    public void setDataOrder(char order) { dataOrder = order; }
 
-		/*
-		  Need to concatenate the format strings for contiguous format
-		  statements that have the same label.
-		  The 'fullFormat' holds the concatenated format strings. This
-		  will be null for format statements that were added to the end
-		  of a previous format.
-		*/
-		// Initially, set fullFormat to null for all statements.
-		for(Iterator<FormatStatement> it = formatStatements.iterator(); it.hasNext(); )
-		{
-			FormatStatement fs = it.next();
-			fs.fullFormat = null;
-		}
+    /**
+    * This compares two DecodesScripts, and returns true if they can be
+    * considered equal.  Note that this doesn't check the SQL database
+    * ID number.  Two DecodesScripts are considered equal iff:
+    * <ul>
+    *   <li>the scriptName's are the same,</li>
+    *   <li>the scriptType's are the same,</li>
+    *   <li>they have the same number of scriptSensors,</li>
+    *   <li>they have the same number of formatStatements,</li>
+    *   <li>
+    *     each ScriptSensor of one is "equal" to the corresponding
+    *     ScriptSensor of the other, and
+    *   </li>
+    *   <li>
+    *     each FormatStatement of one is "equal" to the corresponding
+    *     FormatStatement of the other.
+    *   </li>
+    *   <li></li>
+    * </ul>
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    public boolean equals(Object ob)
+    {
+        if (!(ob instanceof DecodesScript))
+            return false;
+        DecodesScript ds = (DecodesScript)ob;
+        if (this == ds)
+            return true;
+        if (!scriptName.equals(ds.scriptName)
+         || !scriptType.equals(ds.scriptType)
+         || scriptSensors.size() != ds.scriptSensors.size()
+         || formatStatements.size() != ds.formatStatements.size()
+         || dataOrder != ds.dataOrder)
+            return false;
+        for (int i = 0; i < scriptSensors.size(); i++)
+        {
+            ScriptSensor ss1 = (ScriptSensor) scriptSensors.elementAt(i);
+            ScriptSensor ss2 = (ScriptSensor) ds.scriptSensors.elementAt(i);
+            if (!ss1.equals(ss2)) return false;
+        }
+        for (int i = 0; i < formatStatements.size(); i++)
+        {
+            FormatStatement fs1 =
+                (FormatStatement) formatStatements.elementAt(i);
+            FormatStatement fs2 =
+                (FormatStatement) ds.formatStatements.elementAt(i);
+            if (!fs1.equals(fs2)) return false;
+        }
+        return true;
+    }
 
-		// Loop through, doing concatenation.
-		FormatStatement execFmt = null;
-		for(Iterator<FormatStatement> it = formatStatements.iterator(); it.hasNext(); )
-		{
-			FormatStatement fs = it.next();
-			if (execFmt == null)
-			{
-				execFmt = fs; // starting new format
-				execFmt.fullFormat = execFmt.format;
-			}
-			else 
-			{
-				if ((labelIsCaseSensitive && execFmt.label.equals(fs.label))
-				 || (!labelIsCaseSensitive && execFmt.label.equalsIgnoreCase(fs.label)))
-				{
-					// concat this one to previous
-					execFmt.fullFormat = execFmt.fullFormat + fs.format;
-					fs.fullFormat = null;
-				}
-				else // labels different, finish-off execFmt & start new one.
-				{
-					execFmt.prepareForExec();
-					execFmt = fs;
-					execFmt.fullFormat = execFmt.format;
-				}
-			}
-		}
-		if (execFmt != null)
-			execFmt.prepareForExec();
-		
-		_prepared = true;
-	}
+    /**
+    * This is inherited from the DatabaseObject interface.  This always
+    * returns "DecodesScript".
+    */
+    public String getObjectType() {
+        return "DecodesScript";
+    }
 
-	/** From DatabaseObject interface.
-	 * @return true if script has been prepared previous.
-	 */
-	public boolean isPrepared()
-	{
-			return _prepared;
-	}
+    /**
+    * Called from PlatformConfig.copy(), makes a new copy of this script
+    * for inclusion in the new config.
+     * @param newPc The PlatformConfig that is to own the copy
+     * @return the new DecodesScript object
+     */
+    public DecodesScript copy(PlatformConfig newPc)
+    {
+        DecodesScript ret = noIdCopy(newPc);
+        try { ret.setId(getId()); }
+        catch(DatabaseException ex) {} // won't happen.
+        return ret;
+    }
 
-	/** From DatabaseObject interface; this does nothing.  */
-	public void validate()
-		throws IncompleteDatabaseException, InvalidDatabaseException
-	{
-	}
+    /**
+    * Makes a copy of this script but without the ID.
+    * for inclusion in the new config.
+     * @param newPc The PlatformConfig that is to own the copy
+     * @return the new DecodesScript object
+     */
+    public DecodesScript noIdCopy(PlatformConfig newPc)
+    {
+        DecodesScript ret = new DecodesScript(newPc, scriptName);
+        ret.scriptType = scriptType;
+        ret.dataOrder = dataOrder;
+        for(Iterator<ScriptSensor> it = scriptSensors.iterator(); it.hasNext(); )
+        {
+            ScriptSensor ss = it.next();
+            ScriptSensor newSs = new ScriptSensor(ret, ss.sensorNumber);
+            //newSs.unitConverterId = ss.unitConverterId;
+            if (ss.rawConverter != null)
+                newSs.rawConverter = ss.rawConverter.copy();
+            //newSs.rawConverter = ss.rawConverter;
+            ret.scriptSensors.add(newSs);
+        }
+        for(Iterator<FormatStatement> it = formatStatements.iterator(); it.hasNext(); )
+        {
+            FormatStatement fs = it.next();
+            FormatStatement newFs = new FormatStatement(ret, fs.sequenceNum);
+            newFs.label = fs.label;
+            newFs.format = fs.format;
+            ret.formatStatements.add(newFs);
+        }
+        return ret;
+    }
 
-	/**
-	* This overrides the DatabaseObject's read() method.
-	* This does nothing, since the I/O for this class is handled by
-	* PlatformConfig and TransportMedium.
-	*/
-	public void read()
-		throws DatabaseException
-	{
-	}
+    /**
+    From DatabaseObject interface, prepare script sensors and format
+    statements contained in this script.
+    */
+    public void prepareForExec()
+        throws IncompleteDatabaseException, InvalidDatabaseException
+    {
+        for(Iterator<ScriptSensor> it = scriptSensors.iterator(); it.hasNext(); )
+        {
+            ScriptSensor ss = it.next();
+            ss.prepareForExec();
+        }
 
-	/**
-	* This overrides the DatabaseObject's write() method.
-	* This does nothing, since the I/O for this class is handled by
-	* PlatformConfig and TransportMedium.
-	*/
-	public void write()
-		throws DatabaseException
-	{
-	}
+        /*
+          Need to concatenate the format strings for contiguous format
+          statements that have the same label.
+          The 'fullFormat' holds the concatenated format strings. This
+          will be null for format statements that were added to the end
+          of a previous format.
+        */
+        // Initially, set fullFormat to null for all statements.
+        for(Iterator<FormatStatement> it = formatStatements.iterator(); it.hasNext(); )
+        {
+            FormatStatement fs = it.next();
+            fs.fullFormat = null;
+        }
 
-	/**
-	* @return the format statement with the requested label, or null
-	* if label-not-found.
-	*/
-	public FormatStatement getFormatStatement(String label)
-	{
-		for(Iterator<FormatStatement> it = formatStatements.iterator(); it.hasNext(); )
-		{
-			FormatStatement fs = it.next();
-			if ( !labelIsCaseSensitive  ) {
-				if ( label.equalsIgnoreCase(fs.label))
-			  		return fs;
-			} else {	
-				if (label.equals(fs.label))
-					return fs;
-			}
-		}
-		return null;
-	}
+        // Loop through, doing concatenation.
+        FormatStatement execFmt = null;
+        for(Iterator<FormatStatement> it = formatStatements.iterator(); it.hasNext(); )
+        {
+            FormatStatement fs = it.next();
+            if (execFmt == null)
+            {
+                execFmt = fs; // starting new format
+                execFmt.fullFormat = execFmt.format;
+            }
+            else
+            {
+                if ((labelIsCaseSensitive && execFmt.label.equals(fs.label))
+                 || (!labelIsCaseSensitive && execFmt.label.equalsIgnoreCase(fs.label)))
+                {
+                    // concat this one to previous
+                    execFmt.fullFormat = execFmt.fullFormat + fs.format;
+                    fs.fullFormat = null;
+                }
+                else // labels different, finish-off execFmt & start new one.
+                {
+                    execFmt.prepareForExec();
+                    execFmt = fs;
+                    execFmt.fullFormat = execFmt.format;
+                }
+            }
+        }
+        if (execFmt != null)
+            execFmt.prepareForExec();
 
-	/** 
-	 * Executes this decodes script on the passed message data.
-	 * @param rawmsg the RawMessage to decode
-	 * @return the DecodedMessage containing the raw message and decoded time series.
-	 */
-	public synchronized DecodedMessage decodeMessage(RawMessage rawmsg)
-		throws DecoderException, UnknownPlatformException,
-			IncompleteDatabaseException, InvalidDatabaseException
-	{
-		if (!isPrepared())
-			prepareForExec();
+        _prepared = true;
+    }
 
-		if (trackDecoding)
-			decodedSamples = new ArrayList<DecodedSample>();
-		
-		if (formatStatements.size() == 0)
-			throw new DecoderException("No format statements");
-		
-		FormatStatement fs = formatStatements.elementAt(0);
-		DecodedMessage decmsg = new DecodedMessage(rawmsg);
-		DataOperations dops = new DataOperations(rawmsg);
-		while(fs != null)
-		{
-			try
-			{
-				fs.execute(dops, decmsg);
-				fs = null;
-			}
-			catch(EndOfDataException ex)
-			{
-				Logger.instance().log(Logger.E_DEBUG1,
-				"Format statements attempted to read past the end of message.");
-				fs = null;
-			}
-			catch(SwitchFormatException ex)
-			{
-				Logger.instance().debug3(ex.toString());
-				fs = ex.getNewFormat();
-			}
-			catch(FieldParseException ex)
-			{
-				Logger.instance().log(Logger.E_DEBUG1, ex.toString());
-				fs = getFormatStatement("ERROR");
-				if (fs == null)
-				{
-					Logger.instance().log(Logger.E_WARNING, 
-						"No ERROR statement, terminating script: "
-						+ ex.toString());
-					throw ex;
-				}
-			}
-			catch(EndlessLoopException ex )
-			{
-				Logger.instance().log(Logger.E_WARNING,
-						"Platform Config: "+ platformConfig.getName()+", script <"+scriptName+"> in endless loop  -- terminated: " + ex);
-				throw new DecoderException("Platform Config: "+ platformConfig.getName()+", script <"+scriptName+"> in endless loop  -- terminated.");
-			}
-			// All other decoding exception will cause failure.
-		}
+    /** From DatabaseObject interface.
+     * @return true if script has been prepared previous.
+     */
+    public boolean isPrepared()
+    {
+            return _prepared;
+    }
 
-		// Added for HDB 934. Routing spec can define property 'includePMs' to cause
-		// performance measurements to be set as sensors. Do it here so that the sensor
-		// interval and offset can be used for proper timing.
-		if (includePMs != null && includePMs.size() > 0)
-			addPMs(decmsg);
+    /** From DatabaseObject interface; this does nothing.  */
+    public void validate()
+        throws IncompleteDatabaseException, InvalidDatabaseException
+    {
+    }
 
-		decmsg.finishMessage();
-		decmsg.applyInitialEuConversions();
-		return decmsg;
-	}
-	
-	/**
-	 * Called from a DECODES operation after a sample is successfully decoded.
-	 * @param decodedSample structure containing location within raw message, decoded, data, etc.
-	 */
-	public void addDecodedSample(DecodedSample decodedSample)
-	{
-		if (decodedSamples != null)
-			decodedSamples.add(decodedSample);
-	}
+    /**
+    * This overrides the DatabaseObject's read() method.
+    * This does nothing, since the I/O for this class is handled by
+    * PlatformConfig and TransportMedium.
+    */
+    public void read()
+        throws DatabaseException
+    {
+    }
 
-	/**
-	 * Get the list of decoded samples populated after a successful decode.
-	 * @return the list of decoded samples.
-	 */
-	public ArrayList<DecodedSample> getDecodedSamples()
-	{
-		return decodedSamples;
-	}
-	
-	/**
-	 * Parse the header type out of the script type
-	 * @return the header type or null if none defined.
-	 */
-	public String getHeaderType()
-	{
-		int idx = scriptType.indexOf(':');
-		if (idx < 0 || scriptType.length() <= idx+1)
-			return null;
-		return scriptType.substring(idx+1);
-	}
-	
-	public void addMissing(String symbol)
-	{
-		missingSymbols.add(symbol);
-	}
-	
-	public boolean isMissingSymbol(String symbol)
-	{
+    /**
+    * This overrides the DatabaseObject's write() method.
+    * This does nothing, since the I/O for this class is handled by
+    * PlatformConfig and TransportMedium.
+    */
+    public void write()
+        throws DatabaseException
+    {
+    }
+
+    /**
+    * @return the format statement with the requested label, or null
+    * if label-not-found.
+    */
+    public FormatStatement getFormatStatement(String label)
+    {
+        for(Iterator<FormatStatement> it = formatStatements.iterator(); it.hasNext(); )
+        {
+            FormatStatement fs = it.next();
+            if ( !labelIsCaseSensitive  ) {
+                if ( label.equalsIgnoreCase(fs.label))
+                      return fs;
+            } else {
+                if (label.equals(fs.label))
+                    return fs;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Executes this decodes script on the passed message data.
+     * @param rawmsg the RawMessage to decode
+     * @return the DecodedMessage containing the raw message and decoded time series.
+     */
+    public synchronized DecodedMessage decodeMessage(RawMessage rawmsg)
+        throws DecoderException, UnknownPlatformException,
+            IncompleteDatabaseException, InvalidDatabaseException
+    {
+        if (!isPrepared())
+            prepareForExec();
+
+        if (trackDecoding)
+            decodedSamples = new ArrayList<DecodedSample>();
+
+        if (formatStatements.size() == 0)
+            throw new DecoderException("No format statements");
+
+        FormatStatement fs = formatStatements.elementAt(0);
+        DecodedMessage decmsg = new DecodedMessage(rawmsg);
+        DataOperations dops = new DataOperations(rawmsg);
+        while(fs != null)
+        {
+            try
+            {
+                fs.execute(dops, decmsg);
+                fs = null;
+            }
+            catch(EndOfDataException ex)
+            {
+                Logger.instance().log(Logger.E_DEBUG1,
+                "Format statements attempted to read past the end of message.");
+                fs = null;
+            }
+            catch(SwitchFormatException ex)
+            {
+                Logger.instance().debug3(ex.toString());
+                fs = ex.getNewFormat();
+            }
+            catch(FieldParseException ex)
+            {
+                Logger.instance().log(Logger.E_DEBUG1, ex.toString());
+                fs = getFormatStatement("ERROR");
+                if (fs == null)
+                {
+                    Logger.instance().log(Logger.E_WARNING,
+                        "No ERROR statement, terminating script: "
+                        + ex.toString());
+                    throw ex;
+                }
+            }
+            catch(EndlessLoopException ex )
+            {
+                Logger.instance().log(Logger.E_WARNING,
+                        "Platform Config: "+ platformConfig.getName()+", script <"+scriptName+"> in endless loop  -- terminated: " + ex);
+                throw new DecoderException("Platform Config: "+ platformConfig.getName()+", script <"+scriptName+"> in endless loop  -- terminated.");
+            }
+            // All other decoding exception will cause failure.
+        }
+
+        // Added for HDB 934. Routing spec can define property 'includePMs' to cause
+        // performance measurements to be set as sensors. Do it here so that the sensor
+        // interval and offset can be used for proper timing.
+        if (includePMs != null && includePMs.size() > 0)
+            addPMs(decmsg);
+
+        decmsg.finishMessage();
+        decmsg.applyInitialEuConversions();
+        return decmsg;
+    }
+
+    /**
+     * Called from a DECODES operation after a sample is successfully decoded.
+     * @param decodedSample structure containing location within raw message, decoded, data, etc.
+     */
+    public void addDecodedSample(DecodedSample decodedSample)
+    {
+        if (decodedSamples != null)
+            decodedSamples.add(decodedSample);
+    }
+
+    /**
+     * Get the list of decoded samples populated after a successful decode.
+     * @return the list of decoded samples.
+     */
+    public ArrayList<DecodedSample> getDecodedSamples()
+    {
+        return decodedSamples;
+    }
+
+    /**
+     * Parse the header type out of the script type
+     * @return the header type or null if none defined.
+     */
+    public String getHeaderType()
+    {
+        int idx = scriptType.indexOf(':');
+        if (idx < 0 || scriptType.length() <= idx+1)
+            return null;
+        return scriptType.substring(idx+1);
+    }
+
+    public void addMissing(String symbol)
+    {
+        missingSymbols.add(symbol);
+    }
+
+    public boolean isMissingSymbol(String symbol)
+    {
 //Logger.instance().debug3("script.isMissingSymbol '" + symbol + "' checking against " + missingSymbols.size()
-//	+ " defined symbols.");
-		return missingSymbols.contains(symbol);
-//		for(String s : missingSymbols)
-//			if (s.equals(symbol))
-//				return true;
+//    + " defined symbols.");
+        return missingSymbols.contains(symbol);
+//        for(String s : missingSymbols)
+//            if (s.equals(symbol))
+//                return true;
 //else Logger.instance().debug3("   doesn't equal '" + s + "'");
-//		return false;
-	}
+//        return false;
+    }
 
-	public void setIncludePMs(ArrayList<String> includePMs)
-	{
-		this.includePMs = includePMs;
-		if (includePMs != null && includePMs.size() == 0)
-			this.includePMs = null;
-if (this.includePMs != null) Logger.instance().debug1("setIncludePMs: includePMs has " 
+    public void setIncludePMs(ArrayList<String> includePMs)
+    {
+        this.includePMs = includePMs;
+        if (includePMs != null && includePMs.size() == 0)
+            this.includePMs = null;
+if (this.includePMs != null) Logger.instance().debug1("setIncludePMs: includePMs has "
 + includePMs.size() + " strings. [0]=" + includePMs.get(0));
-	}
-	
-	/**
-	 * Add the PMs as sensor values.
-	 */
-	private void addPMs(DecodedMessage decodedMessage)
-	{
-		RawMessage rm = decodedMessage.getRawMessage();
-		if (rm == null)
-			return;
-		Platform p = null;
-		try { p = rm.getPlatform(); }
-		catch(UnknownPlatformException ex) { return; }
-		if (p == null)
-			return;
-		PlatformConfig pc = p.getConfig();
-		if (pc == null)
-			return;
-	  nextPM:
-		for(String pmname : includePMs)
-		{
+    }
+
+    /**
+     * Add the PMs as sensor values.
+     */
+    private void addPMs(DecodedMessage decodedMessage)
+    {
+        RawMessage rm = decodedMessage.getRawMessage();
+        if (rm == null)
+            return;
+        Platform p = null;
+        try { p = rm.getPlatform(); }
+        catch(UnknownPlatformException ex) { return; }
+        if (p == null)
+            return;
+        PlatformConfig pc = p.getConfig();
+        if (pc == null)
+            return;
+      nextPM:
+        for(String pmname : includePMs)
+        {
 Logger.instance().debug1("addPMs looking for '" + pmname + "'");
-			Variable v = rm.getPM(pmname);
-			if (v == null)
-			{
-				Logger.instance().info(
-					"addPMs: Message for '" + new String(rm.getHeader()) 
-					+ "' does not have requested performance measurement '" + pmname + "' -- ignored.");
-				continue;
-			}
-			for (ConfigSensor cs : pc.getSensorVec())
-			{
-				if (cs.sensorName.equalsIgnoreCase(pmname))
-				{
-					decodedMessage.addSample(cs.sensorNumber, v, 0);
+            Variable v = rm.getPM(pmname);
+            if (v == null)
+            {
+                Logger.instance().info(
+                    "addPMs: Message for '" + new String(rm.getHeader())
+                    + "' does not have requested performance measurement '" + pmname + "' -- ignored.");
+                continue;
+            }
+            for (ConfigSensor cs : pc.getSensorVec())
+            {
+                if (cs.sensorName.equalsIgnoreCase(pmname))
+                {
+                    decodedMessage.addSample(cs.sensorNumber, v, 0);
 Logger.instance().debug1("addPM: added pm '" + pmname + "' to sensor " + cs.sensorNumber + " with value '" + v.toString() + "'");
-					continue nextPM;
-				}
-			}
-			// Fell through, no matching sensor:
-			Logger.instance().info("addPMs: The platform config for '" + new String(rm.getHeader()) 
-				+ "' does not have a sensor named '" + pmname + "' -- discarded.");
-		}
-	}
+                    continue nextPM;
+                }
+            }
+            // Fell through, no matching sensor:
+            Logger.instance().info("addPMs: The platform config for '" + new String(rm.getHeader())
+                + "' does not have a sensor named '" + pmname + "' -- discarded.");
+        }
+    }
 
-	public static DecodesScriptBuilder from(final DecodesScriptReader scriptReader)
-	{
-		DecodesScriptBuilder builder = new DecodesScriptBuilder(scriptReader);
-		return builder;
-	}
+    public static DecodesScriptBuilder from(final DecodesScriptReader scriptReader)
+    {
+        DecodesScriptBuilder builder = new DecodesScriptBuilder(scriptReader);
+        return builder;
+    }
 
-	public static DecodesScriptBuilder empty()
-	{
-		return from(EMPTY_SCRIPT);
-	}
+    public static DecodesScriptBuilder empty()
+    {
+        return from(EMPTY_SCRIPT);
+    }
 
-	public Vector<FormatStatement> getFormatStatements()
-	{
+    public Vector<FormatStatement> getFormatStatements()
+    {
         return this.formatStatements;
     }
 
-	public static class DecodesScriptBuilder
-	{
-		private DecodesScript script;
-		private DecodesScriptReader scriptReader;
+    public static class DecodesScriptBuilder
+    {
+        private DecodesScript script;
+        private DecodesScriptReader scriptReader;
 
-		public DecodesScriptBuilder(DecodesScriptReader reader)
-		{
-			this.scriptReader = reader;
-			script = new DecodesScript("");
-		}
+        public DecodesScriptBuilder(DecodesScriptReader reader)
+        {
+            this.scriptReader = reader;
+            script = new DecodesScript("");
+        }
 
-		public DecodesScript build() throws DecodesScriptException, IOException
-		{
-			try
-			{
-				FormatStatement fs = null;
-				while ((fs = scriptReader.nextStatement(script)) != null)
-				{
-					script.formatStatements.add(fs);
-				}
-				script.prepareForExec();
-				return script;
-			}
-			catch(Exception ex)
-			{
-				throw new DecodesScriptException("Unable to finalize Decodes Script (" + script.scriptName + ") for use.");
-			}
-		}
+        public DecodesScript build() throws DecodesScriptException, IOException
+        {
+            try
+            {
+                FormatStatement fs = null;
+                while ((fs = scriptReader.nextStatement(script)) != null)
+                {
+                    script.formatStatements.add(fs);
+                }
+                script.prepareForExec();
+                return script;
+            }
+            catch(Exception ex)
+            {
+                throw new DecodesScriptException("Unable to finalize Decodes Script (" + script.scriptName + ") for use.");
+            }
+        }
 
-		public DecodesScriptBuilder platformConfig(PlatformConfig pc)
-		{
-			script.platformConfig = pc;
-			return this;
-		}
+        public DecodesScriptBuilder platformConfig(PlatformConfig pc)
+        {
+            script.platformConfig = pc;
+            return this;
+        }
 
-		public DecodesScriptBuilder scriptName(String name)
-		{
-			script.scriptName = name;
-			return this;
-		}
-	}
+        public DecodesScriptBuilder scriptName(String name)
+        {
+            script.scriptName = name;
+            return this;
+        }
+    }
 }

--- a/src/main/java/decodes/db/DecodesScriptException.java
+++ b/src/main/java/decodes/db/DecodesScriptException.java
@@ -1,0 +1,14 @@
+package decodes.db;
+
+public class DecodesScriptException extends Exception
+{
+    public DecodesScriptException(String msg)
+    {
+        super(msg);
+    }
+
+    public DecodesScriptException(String msg, Throwable cause)
+    {
+        super(msg,cause);
+    }
+}

--- a/src/main/java/decodes/db/DecodesScriptException.java
+++ b/src/main/java/decodes/db/DecodesScriptException.java
@@ -1,12 +1,25 @@
 package decodes.db;
 
+/**
+ * Any errors processing DecodesScript information getting it ready for use.
+ * @since 2022-11-05
+ */
 public class DecodesScriptException extends Exception
 {
+    /**
+     * Message only constructor
+     * @param msg description of the error
+     */
     public DecodesScriptException(String msg)
     {
         super(msg);
     }
 
+    /**
+     * Message with cause
+     * @param msg description of why this cause happened
+     * @param cause additional information about the error
+     */
     public DecodesScriptException(String msg, Throwable cause)
     {
         super(msg,cause);

--- a/src/main/java/decodes/db/DecodesScriptReader.java
+++ b/src/main/java/decodes/db/DecodesScriptReader.java
@@ -2,7 +2,20 @@ package decodes.db;
 
 import java.io.IOException;
 
+/**
+ * Provide format statements to a DecodesScriptBuilder
+ * during the final creation of the DecodesScriptObject
+ * @since 2022-11-05
+ */
 public interface DecodesScriptReader
 {
+    /**
+     * Create a new FormatStatement for a given script.
+     * 
+     * @param script decodes script that the BuilderCreates, traditionally 
+     *               passed into the FormatStatement constructor
+     * @return a new FormatStatement or null when all statements have been read in
+     * @throws IOException any error retrieving a statement from a source
+     */
     public FormatStatement nextStatement(DecodesScript script) throws IOException;
 }

--- a/src/main/java/decodes/db/DecodesScriptReader.java
+++ b/src/main/java/decodes/db/DecodesScriptReader.java
@@ -1,0 +1,8 @@
+package decodes.db;
+
+import java.io.IOException;
+
+public interface DecodesScriptReader
+{
+    public FormatStatement nextStatement(DecodesScript script) throws IOException;
+}

--- a/src/main/java/decodes/db/EmptyDecodesScriptReader.java
+++ b/src/main/java/decodes/db/EmptyDecodesScriptReader.java
@@ -2,6 +2,13 @@ package decodes.db;
 
 import java.io.IOException;
 
+/**
+ * A reader that provides no actual data.
+ * Primarily for use with editors for starting new scripts
+ * 
+ * NOTE: At least until the editors can be moved to using their own "reader" implementation
+ * @since 2022-11-05
+ */
 public class EmptyDecodesScriptReader implements DecodesScriptReader
 {
 

--- a/src/main/java/decodes/db/EmptyDecodesScriptReader.java
+++ b/src/main/java/decodes/db/EmptyDecodesScriptReader.java
@@ -1,0 +1,14 @@
+package decodes.db;
+
+import java.io.IOException;
+
+public class EmptyDecodesScriptReader implements DecodesScriptReader
+{
+
+    @Override
+    public FormatStatement nextStatement(DecodesScript script) throws IOException
+    {
+        return null;
+    }
+    
+}

--- a/src/main/java/decodes/db/StreamDecodesScriptReader.java
+++ b/src/main/java/decodes/db/StreamDecodesScriptReader.java
@@ -1,0 +1,43 @@
+package decodes.db;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+/**
+ * Read a decodes script from a text file.
+ * Primarily used for testing decodes scripts.
+ */
+public class StreamDecodesScriptReader implements DecodesScriptReader
+{
+    private int lineNumber = 1;
+    private BufferedReader reader = null;
+
+    public StreamDecodesScriptReader(InputStream stream)
+    {
+        reader = new BufferedReader(new InputStreamReader(stream));
+    }
+
+    @Override
+    public FormatStatement nextStatement(DecodesScript script) throws IOException
+    {
+        FormatStatement fs = null;
+        String line = reader.readLine();
+        if ( line != null)
+        {
+            int firstColon = line.indexOf(":");
+            if (firstColon < 0 )
+            {
+                throw new IOException("Statement on line " + lineNumber + " is not a label separated by a colon.");
+            }
+            String label = line.substring(0, firstColon);
+            String statement = line.substring(firstColon+1);
+            fs = new FormatStatement(script, lineNumber);
+            lineNumber++;
+            fs.label = label;
+            fs.format = statement.trim();
+        }
+        return fs;
+    }
+}

--- a/src/main/java/decodes/dbeditor/DecodesScriptEditPanel.java
+++ b/src/main/java/decodes/dbeditor/DecodesScriptEditPanel.java
@@ -1259,7 +1259,7 @@ class FormatStatementTableModel extends AbstractTableModel
 
 	public int getRowCount()
 	{
-		return theScript == null ? 0 : theScript.formatStatements.size();
+		return theScript == null ? 0 : theScript.getFormatStatements().size();
 	}
 
 	public int getColumnCount()
@@ -1276,7 +1276,7 @@ class FormatStatementTableModel extends AbstractTableModel
 	{
 		if (r < 0 || r >= getRowCount())
 			return null;
-		return theScript.formatStatements.elementAt(r);
+		return theScript.getFormatStatements().elementAt(r);
 	}
 
 	public Object getValueAt(int r, int c)
@@ -1299,14 +1299,14 @@ class FormatStatementTableModel extends AbstractTableModel
 	void add(FormatStatement ob)
 	{
 		if (theScript != null)
-			theScript.formatStatements.add(ob);
+			theScript.getFormatStatements().add(ob);
 		fireTableDataChanged();
 	}
 
 	void remove(FormatStatement ob)
 	{
 		if (theScript != null)
-			theScript.formatStatements.remove(ob);
+			theScript.getFormatStatements().remove(ob);
 		fireTableDataChanged();
 	}
 
@@ -1339,20 +1339,20 @@ class FormatStatementTableModel extends AbstractTableModel
 	{
 		if (r <= 0)
 			return;
-		FormatStatement tmp = theScript.formatStatements.elementAt(r - 1);
-		theScript.formatStatements.setElementAt(ob, r - 1);
-		theScript.formatStatements.setElementAt(tmp, r);
+		FormatStatement tmp = theScript.getFormatStatements().elementAt(r - 1);
+		theScript.getFormatStatements().setElementAt(ob, r - 1);
+		theScript.getFormatStatements().setElementAt(tmp, r);
 		fireTableDataChanged();
 	}
 
 	void moveDown(FormatStatement ob, int r)
 	{
-		int n = theScript.formatStatements.size();
+		int n = theScript.getFormatStatements().size();
 		if (r >= n - 1)
 			return;
-		FormatStatement tmp = theScript.formatStatements.elementAt(r + 1);
-		theScript.formatStatements.setElementAt(ob, r + 1);
-		theScript.formatStatements.setElementAt(tmp, r);
+		FormatStatement tmp = theScript.getFormatStatements().elementAt(r + 1);
+		theScript.getFormatStatements().setElementAt(ob, r + 1);
+		theScript.getFormatStatements().setElementAt(tmp, r);
 		fireTableDataChanged();
 	}
 

--- a/src/main/java/decodes/dbimport/EmitImport.java
+++ b/src/main/java/decodes/dbimport/EmitImport.java
@@ -255,24 +255,36 @@ public class EmitImport
 
 		em.equipmentType = Constants.eqType_dcp;
 		String type = line.substring(12, 12+3).trim();
-
-		if (type.length() == 0 || type.equalsIgnoreCase("DCP"))
+		try
 		{
-			selfTimedScript = 
-				new DecodesScript(platformConfig,Constants.script_ST);
-			selfTimedScript.setDataOrder(dataOrderST);
-			randomScript = 
-				new DecodesScript(platformConfig,Constants.script_RD);
-			randomScript.setDataOrder(dataOrderRD);
-			edlScript = null;
+			if (type.length() == 0 || type.equalsIgnoreCase("DCP"))
+			{
+				selfTimedScript = DecodesScript.empty()
+											.platformConfig(platformConfig)
+											.scriptName(Constants.script_ST)
+											.build();
+				selfTimedScript.setDataOrder(dataOrderST);
+				randomScript = DecodesScript.empty()
+											.platformConfig(platformConfig)
+											.scriptName(Constants.script_RD)
+											.build();
+				randomScript.setDataOrder(dataOrderRD);
+				edlScript = null;
+			}
+			else if (type.equalsIgnoreCase("EDL"))
+			{
+				edlScript = DecodesScript.empty()
+										.platformConfig(platformConfig)
+										.scriptName(Constants.script_EDL)
+										.build();
+				edlScript.setDataOrder('A');
+				selfTimedScript = randomScript = null;
+			}
 		}
-		else if (type.equalsIgnoreCase("EDL"))
+		catch( DecodesScriptException | IOException ex)
 		{
-			edlScript = new DecodesScript(platformConfig,Constants.script_EDL);
-			edlScript.setDataOrder('A');
-			selfTimedScript = randomScript = null;
+			throw new RuntimeException("Unable to prepare Decodes Scripts",ex);
 		}
-
 		formats.clear();
 		currentFormat = null;
 
@@ -731,7 +743,7 @@ public class EmitImport
 					FormatStatement fs = new FormatStatement(selfTimedScript,j);
 					fs.label = sp.first;
 					fs.format = sp.second;
-					selfTimedScript.formatStatements.add(fs);
+					selfTimedScript.getFormatStatements().add(fs);
 				}
 			}
 			if (randomScript != null)
@@ -742,7 +754,7 @@ public class EmitImport
 					FormatStatement fs = new FormatStatement(randomScript, j);
 					fs.label = sp.first;
 					fs.format = sp.second;
-					randomScript.formatStatements.add(fs);
+					randomScript.getFormatStatements().add(fs);
 				}
 			}
 			if (edlScript != null)
@@ -750,7 +762,7 @@ public class EmitImport
 				FormatStatement fs = new FormatStatement(edlScript, j);
 				fs.label = sp.first;
 				fs.format = sp.second;
-				edlScript.formatStatements.add(fs);
+				edlScript.getFormatStatements().add(fs);
 			}
 		}
 		if (selfTimedScript != null)

--- a/src/main/java/decodes/platwiz/PanelException.java
+++ b/src/main/java/decodes/platwiz/PanelException.java
@@ -19,4 +19,9 @@ public class PanelException extends Exception
 	{
 		super(msg);
 	}
+
+	public PanelException(String msg, Throwable cause)
+	{
+		super(msg,cause);
+	}
 }

--- a/src/main/java/decodes/platwiz/SavePanel.java
+++ b/src/main/java/decodes/platwiz/SavePanel.java
@@ -294,7 +294,7 @@ public class SavePanel extends JPanel
 			{
 				DecodesScript ds = (DecodesScript)pc.getScript("ST");
 				if (ds != null
-				 && ds.formatStatements.size() == 0)
+				 && ds.getFormatStatements().size() == 0)
 					summaryArea.append(LoadResourceBundle.sprintf(
 						platwizLabels.getString("SavePanel.noScriptFSErr"),
 						ds.scriptName));
@@ -303,7 +303,7 @@ public class SavePanel extends JPanel
 			{
 				DecodesScript ds = (DecodesScript)pc.getScript("RD");
 				if (ds != null
-				 && ds.formatStatements.size() == 0)
+				 && ds.getFormatStatements().size() == 0)
 					summaryArea.append(LoadResourceBundle.sprintf(
 							platwizLabels.getString("SavePanel.noScriptFSErr"),
 							ds.scriptName));
@@ -312,7 +312,7 @@ public class SavePanel extends JPanel
 			{
 				DecodesScript ds = (DecodesScript)pc.getScript("EDL");
 				if (ds != null
-				 && ds.formatStatements.size() == 0)
+				 && ds.getFormatStatements().size() == 0)
 					summaryArea.append(LoadResourceBundle.sprintf(
 							platwizLabels.getString("SavePanel.noScriptFSErr"),
 							ds.scriptName));

--- a/src/main/java/decodes/platwiz/ScriptEditPanel.java
+++ b/src/main/java/decodes/platwiz/ScriptEditPanel.java
@@ -4,6 +4,7 @@ import java.awt.*;
 import javax.swing.*;
 import javax.swing.border.*;
 import java.awt.event.*;
+import java.io.IOException;
 import java.util.ResourceBundle;
 import java.util.Iterator;
 
@@ -14,6 +15,7 @@ import decodes.db.PlatformConfig;
 import decodes.db.PlatformSensor;
 import decodes.db.ConfigSensor;
 import decodes.db.DecodesScript;
+import decodes.db.DecodesScriptException;
 import decodes.db.ScriptSensor;
 import decodes.db.TransportMedium;
 import decodes.dbeditor.DecodesScriptEditPanel;
@@ -140,15 +142,25 @@ public class ScriptEditPanel extends JPanel
 		DecodesScript ds = pc.getScript(name);
 		if (ds == null)
 		{
-			ds = new DecodesScript(pc, name);
-			int numberOfSensors = pc.getNumSensors();
-			PlatformSensor ps;
-			int i = 0;
-			for(Iterator it = pc.getSensors(); it.hasNext(); ) {
-				ConfigSensor cs = (ConfigSensor)it.next();
-				ds.addScriptSensor(new ScriptSensor(ds, cs.sensorNumber));
+			try
+			{
+				ds = DecodesScript.empty()
+								.platformConfig(pc)
+								.scriptName(name)
+								.build();
+				int numberOfSensors = pc.getNumSensors();
+				PlatformSensor ps;
+				int i = 0;
+				for(Iterator it = pc.getSensors(); it.hasNext(); ) {
+					ConfigSensor cs = (ConfigSensor)it.next();
+					ds.addScriptSensor(new ScriptSensor(ds, cs.sensorNumber));
+				}
+				pc.addScript(ds);
 			}
-			pc.addScript(ds);
+			catch (DecodesScriptException | IOException ex)
+			{
+				throw new PanelException("Unable to create initial empty script.",ex);
+			}
 		}
 
 		decodingScriptEditPanel.setDecodesScript(ds);

--- a/src/main/java/decodes/sql/ConfigListIO.java
+++ b/src/main/java/decodes/sql/ConfigListIO.java
@@ -815,19 +815,18 @@ public class ConfigListIO extends SqlDbObjIo
 			if (s != null && s.length() > 0)
 				dataOrder = s.charAt(0);
 		}
-		try
+		try(SQLDecodesScriptReader reader = new SQLDecodesScriptReader(connection(), id))
 		{
-			DecodesScript ds = DecodesScript.from(new SQLDecodesScriptReader(connection(), id))
+			DecodesScript ds = DecodesScript.from(reader)
 											.scriptName(name)
 											.build();
 			ds.setDataOrder(dataOrder);
 			ds.setId(id);
-			//readFormatStatements(ds);
 			readScriptSensors(ds);
 			ds.scriptType = type;
 			pc.addScript(ds);
 		}
-		catch (DecodesScriptException | IOException ex)
+		catch (Exception ex)
 		{
 			throw new DatabaseException("Unable to read decodes script (" + name + ") from database", ex);
 		}

--- a/src/main/java/decodes/sql/SQLDecodesScriptReader.java
+++ b/src/main/java/decodes/sql/SQLDecodesScriptReader.java
@@ -1,0 +1,70 @@
+package decodes.sql;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+
+import decodes.db.DecodesScript;
+import decodes.db.DecodesScriptReader;
+import decodes.db.FormatStatement;
+
+public class SQLDecodesScriptReader implements DecodesScriptReader, AutoCloseable
+{
+    ResultSet rs = null;
+    PreparedStatement query = null;
+    
+    public SQLDecodesScriptReader(Connection conn, DbKey id) throws SQLException
+    {
+        query = conn.prepareStatement("SELECT decodesScriptId, sequenceNum, " +
+                                      "       label, format " +
+                                      "       FROM FormatStatement " +
+                                      "       WHERE DecodesScriptId = ?" +
+                                      "       ORDER BY SequenceNum");
+        query.setLong(1, id.getValue());
+        rs = query.executeQuery();
+    }
+
+    @Override
+    public FormatStatement nextStatement(DecodesScript script) throws IOException {        
+        try
+        {
+            if(rs.next())
+            {
+                return fromRS(rs,script);
+            }
+            return null;
+        }
+        catch(SQLException ex)
+        {
+            throw new IOException("Unable to read row or element for DecodesScript",ex);
+        }
+    }
+    
+    private static FormatStatement fromRS(ResultSet rs, DecodesScript script) throws SQLException
+    {
+        int seqNum = rs.getInt("sequenceNum");
+        String label = rs.getString("label");
+        String format = rs.getString("format");
+        if (format == null) format = "";
+
+        FormatStatement fmt = new FormatStatement(script, seqNum);
+        fmt.label = label;
+        fmt.format = format;
+        return fmt;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if(rs != null)
+        {
+            rs.close();
+        }        
+        if (query != null)
+        {
+            query.close();
+        }
+    }
+}

--- a/src/main/java/decodes/sql/SQLDecodesScriptReader.java
+++ b/src/main/java/decodes/sql/SQLDecodesScriptReader.java
@@ -11,11 +11,25 @@ import decodes.db.DecodesScript;
 import decodes.db.DecodesScriptReader;
 import decodes.db.FormatStatement;
 
+/**
+ * Retrieves DecodesScript format statements from a database.
+ * 
+ * Instances of SQLDecodesScriptReader should be closed to avoid resource leaks.
+ * 
+ * @since 2022-11-05
+ */
 public class SQLDecodesScriptReader implements DecodesScriptReader, AutoCloseable
 {
     ResultSet rs = null;
     PreparedStatement query = null;
     
+    /**
+     * Create a new SQLDecodesScriptReader. The constructor will prepare the sql statement
+     * and call executeQuery.
+     * @param conn An opened java.sql.Connection. This call will not close it.
+     * @param id SQL Id of the script to retrieve
+     * @throws SQLException errors either preparing the statement, setting the ID parameter, or executing the query.
+     */
     public SQLDecodesScriptReader(Connection conn, DbKey id) throws SQLException
     {
         query = conn.prepareStatement("SELECT decodesScriptId, sequenceNum, " +
@@ -27,6 +41,9 @@ public class SQLDecodesScriptReader implements DecodesScriptReader, AutoCloseabl
         rs = query.executeQuery();
     }
 
+    /**
+     * Returns the next statemetn from the query result.
+     */
     @Override
     public FormatStatement nextStatement(DecodesScript script) throws IOException {        
         try
@@ -43,6 +60,13 @@ public class SQLDecodesScriptReader implements DecodesScriptReader, AutoCloseabl
         }
     }
     
+    /**
+     * Turn the row into a FormatStatement
+     * @param rs valid ResultSet
+     * @param script DecodesScript this format will be associated with.
+     * @return a valid format Statement
+     * @throws SQLException any errors retrieving columns
+     */
     private static FormatStatement fromRS(ResultSet rs, DecodesScript script) throws SQLException
     {
         int seqNum = rs.getInt("sequenceNum");
@@ -56,6 +80,9 @@ public class SQLDecodesScriptReader implements DecodesScriptReader, AutoCloseabl
         return fmt;
     }
 
+    /**
+     * Close the ResultSet and PreparedStatement.
+     */
     @Override
     public void close() throws Exception {
         if(rs != null)

--- a/src/main/java/decodes/xml/DecodesScriptParser.java
+++ b/src/main/java/decodes/xml/DecodesScriptParser.java
@@ -46,6 +46,8 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Vector;
+
 import decodes.db.*;
 import ilex.util.TextUtil;
 import ilex.util.Logger;
@@ -114,9 +116,9 @@ public class DecodesScriptParser implements XmlObjectParser, XmlObjectWriter, Ta
 				throw new SAXException(XmlDbTags.FormatStatement_el + 
 					" without " + XmlDbTags.label_at +" attribute");
 			tmpFmt = new FormatStatement(decodesScript, 
-				decodesScript.formatStatements.size());
+				decodesScript.getFormatStatements().size());
 			tmpFmt.label = nm;
-			decodesScript.formatStatements.add(tmpFmt);
+			decodesScript.getFormatStatements().add(tmpFmt);
 
 			hier.pushObjectParser(new TaggedStringSetter(this, 
 				formatStatementTag));
@@ -231,11 +233,10 @@ public class DecodesScriptParser implements XmlObjectParser, XmlObjectWriter, Ta
 		if (decodesScript.getDataOrder() != Constants.dataOrderUndefined)
 			xos.writeElement(XmlDbTags.dataOrder_el,
 				"" + decodesScript.getDataOrder());
-
-		for(int i = 0; i < decodesScript.formatStatements.size(); i++)
+		Vector<FormatStatement> formatStatements = decodesScript.getFormatStatements();
+		for(int i = 0; i < formatStatements.size(); i++)
 		{
-			FormatStatement fs = 
-				decodesScript.formatStatements.elementAt(i);
+			FormatStatement fs = formatStatements.elementAt(i);
 			xos.writeElement(XmlDbTags.FormatStatement_el, 
 				XmlDbTags.label_at, fs.label, fs.format);
 		}

--- a/src/main/java/decodes/xml/PlatformConfigParser.java
+++ b/src/main/java/decodes/xml/PlatformConfigParser.java
@@ -98,11 +98,22 @@ public class PlatformConfigParser implements XmlObjectParser, XmlObjectWriter, T
 				throw new SAXException(XmlDbTags.DecodesScript_el + " without "
 					+ XmlDbTags.DecodesScript_scriptName_at +" attribute");
 
-            DecodesScript ds = new DecodesScript(platformConfig, nm);
+			try
+			{
+				// TODO: move this to build the script after creating an XML reader
+				DecodesScript ds = DecodesScript.empty()
+											.platformConfig(platformConfig)
+											.scriptName(nm)
+											.build();
 
-			platformConfig.addScript(ds);
+				platformConfig.addScript(ds);
 
-			hier.pushObjectParser(new DecodesScriptParser(ds));
+				hier.pushObjectParser(new DecodesScriptParser(ds));
+			}
+			catch( DecodesScriptException | IOException ex)
+			{
+				throw new SAXException("Failed to load Decodes Script",ex);
+			}
 		}
 		else
 		{

--- a/src/test/java/decodes/db/DecodesScriptSampleTest.java
+++ b/src/test/java/decodes/db/DecodesScriptSampleTest.java
@@ -34,7 +34,7 @@ final class DecodesScriptSampleTest {
                                      .scriptName("WEB")
                                      .build();;
 
-        assertFalse(decodesScript.formatStatements.isEmpty());
+        assertFalse(decodesScript.getFormatStatements().isEmpty());
         decodesScript.scriptName = "WEB";
         ScriptSensor stage = new ScriptSensor(decodesScript, 1);
         stage.rawConverter = new UnitConverterDb("raw", "ft");

--- a/src/test/resources/decodes/db/WEB.decodescript
+++ b/src/test/resources/decodes/db/WEB.decodescript
@@ -1,0 +1,5 @@
+skip_header: C('#', col_labels), /, >skip_header
+col_labels: 2/, >timezone
+timezone: 3(S(30,'\t',data), w), F(TZ,A,9D'\t'), 1P, >datetime
+datetime: 2(S(30,'\t',data), w), F(D,A,10,1), w, F(T,A,5), w, S(30,'\t',data), w, >data
+data: setMissing(Ssn), F(S,A,5d' \t',1), /, >timezone


### PR DESCRIPTION
## Problem Description

After looking through the Decodes code there wasn't a great separation of concerns. This begins the slow march towards
the slow march towards making DecodesScripts easier to expand with future needs.

Additionally looking at the test in #121 that is just way too much boiler plate to run a simple test.

DecodesScriptProvider or just "FormatStatementProvider/Reader" might be a better name than DecidesScriptReader. I'm not opposed to changing it.

## Solution

- Created a DecodesScriptReader interface and some baseline implementations (some still to do)
- Created a builder class that handles getting other information set
- Made formatStatements private
   - This exposed several places that took it upon themselves to add FormatStatements (not changed in this PR, more investigation required.)


## how you tested the change

Automated test now uses the StreamDecodesReader.
The configIO now uses a newly implemented SQLDecodesScriptReader.
Test both reading and existing script in DBEdit and writing a new script for a config. Ran rs with Platform/RoutingSpec that was able to retrieve and use the script.

## Where the following done:

- [x] Tests. Check all that apply:
   - [x] Unit tests that run during ant test
   - [NA] Test procedure descriptions
- [NA] Was relevant documentation updated?
- [NA] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
