### PR TITLE
Make sure Keygenerator is initialized.

### DIFF
--- a/docs/source/dev-docs.rst
+++ b/docs/source/dev-docs.rst
@@ -1,0 +1,48 @@
+##################
+Installation Guide
+##################
+
+This Document is part of the OpenDCS Software Suite for environmental
+data acquisition and processing. The project home is:
+https://github.com/opendcs/opendcs
+
+See INTENT.md at the project home for information on licensing.
+
+.. contents. Table of Contents
+   :depth: 3
+
+
+Overview
+========
+
+This is the initial start of the documentation and thus it's still quite empty
+If you are working on OpenDCS and think of something that should be in this section
+help expanding the docs are greatly appreciated.
+
+
+MBeans
+======
+
+We have started implementing JMX MBeans for components within OpenDCS. You can connect to the process
+using the jconsole application provided with your JDK to view the information.
+
+CWMS
+====
+
+MBeans
+------
+
+The cwms connection pool implements the ConnectionPool Mbean. This MBean provides a view into the connections 
+outstanding and available. Additional each Connection returned implements a WrappedConnectionMBean that shows
+the current lifetime and can show where the connection pool was opened from.
+
+Connection pool
+---------------
+
+CwmsDb using a connection pool mechanism. Leaks are a concern, if you working against a CWMS
+system you can turn pool tracing on for an application with the following java flags:
+
+    DECJ_MAXHEAP="-Dcwms.connection.pool.trace=true" routsched ...
+
+With tracing on the WrappedConnectionMBean will show where a connection was created from. This useful for identifing 
+what code to fix for connection pool leaks.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,4 +27,5 @@ Contents
    TimeSeriesDatabase <./tsdb.rst>
    Alarms <./alarms.rst>
    CWMS Interface <./cwms-interface.rst>
+   Developer Documentation <./dev-docs.rst>
    

--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
@@ -859,6 +859,9 @@ public class CwmsTimeSeriesDb
 				+ " with officeID=" + dbOfficeId);
 
 				postConnectInit(appName, conn); // Make sure the versions and such are set
+				setConnection(conn);
+				setupKeyGenerator(); // TODO: this should take the connection as a parameter
+				setConnection(null);
 
 				cgl.setLoginSuccess(true);
 

--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
@@ -859,9 +859,7 @@ public class CwmsTimeSeriesDb
 				+ " with officeID=" + dbOfficeId);
 
 				postConnectInit(appName, conn); // Make sure the versions and such are set
-				setConnection(conn);
-				setupKeyGenerator(); // TODO: this should take the connection as a parameter
-				setConnection(null);
+				setupKeyGenerator(conn);
 
 				cgl.setLoginSuccess(true);
 

--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
@@ -859,7 +859,7 @@ public class CwmsTimeSeriesDb
 				+ " with officeID=" + dbOfficeId);
 
 				postConnectInit(appName, conn); // Make sure the versions and such are set
-				setupKeyGenerator(conn);
+				setupKeyGenerator();
 
 				cgl.setLoginSuccess(true);
 

--- a/src/main/java/decodes/sql/KeyGeneratorFactory.java
+++ b/src/main/java/decodes/sql/KeyGeneratorFactory.java
@@ -49,10 +49,9 @@ public class KeyGeneratorFactory
 	 * Makes & returns a key generator, given a class name.
 	 * Also calls the generator's init method with the passed connection object.
 	 * @param clsname the class name.
-	 * @param con the database connection
 	 * @return the key generator object.
 	 */
-	public static KeyGenerator makeKeyGenerator(String clsname, Connection con)
+	public static KeyGenerator makeKeyGenerator(String clsname)
 		throws DatabaseException
 	{
 		Logger.instance().debug3("Making KeyGenerator for class '" + clsname + "'");

--- a/src/main/java/decodes/sql/KeyGeneratorFactory.java
+++ b/src/main/java/decodes/sql/KeyGeneratorFactory.java
@@ -74,14 +74,14 @@ public class KeyGeneratorFactory
 		catch(InstantiationException ex)
 		{
 			String err = "Cannot instantiate KeyGenerator of type '"
-			  + clsname + "': (Check configuration and CLASSPATH setting) + ex";
+			  + clsname + "': (Check configuration and CLASSPATH setting) ex" + ex;
 			Logger.instance().failure(err);
 			throw new DatabaseException(err);
 		}
 		catch(IllegalAccessException ex)
 		{
 			String err = "Cannot instantiate KeyGenerator of type '"
-			  + clsname + "': (Does class have public no-arg constructor?)+ex"; 
+			  + clsname + "': (Does class have public no-arg constructor?)" + ex; 
 			Logger.instance().failure(err);
 			throw new DatabaseException(err);
 		}

--- a/src/main/java/decodes/sql/SqlDatabaseIO.java
+++ b/src/main/java/decodes/sql/SqlDatabaseIO.java
@@ -280,7 +280,7 @@ public class SqlDatabaseIO
 
 		connectToDatabase(sqlDbLocation);
 		keyGenerator = KeyGeneratorFactory.makeKeyGenerator(
-			DecodesSettings.instance().sqlKeyGenerator, _conn);
+			DecodesSettings.instance().sqlKeyGenerator);
 	}
 
 	/**

--- a/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -602,7 +602,10 @@ public abstract class TimeSeriesDb
 	public void setConnection(Connection conn)
 	{
 		this.conn = conn;
-		determineTsdbVersion(getConnection(), this);
+		if (conn != null)
+		{
+			determineTsdbVersion(conn, this);
+		}
 	}
 
 	public KeyGenerator getKeyGenerator() { return keyGenerator; }

--- a/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -614,14 +614,14 @@ public abstract class TimeSeriesDb
 	 * Uses the class in DecodesSettings to create a key generator.
 	 * @throws BadConnectException on any error.
 	 */
-	protected void setupKeyGenerator()
+	protected void setupKeyGenerator(Connection providedConn)
 		throws BadConnectException
 	{
 		String keyGenClass = DecodesSettings.instance().sqlKeyGenerator;
 		try
 		{
 			keyGenerator = KeyGeneratorFactory.makeKeyGenerator(
-				keyGenClass, conn);
+				keyGenClass, providedConn);
 		}
 		catch (Exception ex)
 		{

--- a/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -614,14 +614,14 @@ public abstract class TimeSeriesDb
 	 * Uses the class in DecodesSettings to create a key generator.
 	 * @throws BadConnectException on any error.
 	 */
-	protected void setupKeyGenerator(Connection providedConn)
+	protected void setupKeyGenerator()
 		throws BadConnectException
 	{
 		String keyGenClass = DecodesSettings.instance().sqlKeyGenerator;
 		try
 		{
 			keyGenerator = KeyGeneratorFactory.makeKeyGenerator(
-				keyGenClass, providedConn);
+				keyGenClass);
 		}
 		catch (Exception ex)
 		{

--- a/src/main/java/lrgs/db/LrgsDatabase.java
+++ b/src/main/java/lrgs/db/LrgsDatabase.java
@@ -412,7 +412,7 @@ public class LrgsDatabase
 		try
 		{
 			keyGenerator = KeyGeneratorFactory.makeKeyGenerator(
-				keyGeneratorClass, conn);
+				keyGeneratorClass);
 		}
 		catch (Exception ex) 
 		{

--- a/src/main/java/opendcs/opentsdb/OpenTsdb.java
+++ b/src/main/java/opendcs/opentsdb/OpenTsdb.java
@@ -118,7 +118,7 @@ public class OpenTsdb extends TimeSeriesDb
 			setConnection(
 				DriverManager.getConnection(dbUri, username, password));
 		
-			setupKeyGenerator();
+			setupKeyGenerator(getConnection());
 
 			// MJM 2018-2/21 Force autoCommit on.
 			try { getConnection().setAutoCommit(true); }

--- a/src/main/java/opendcs/opentsdb/OpenTsdb.java
+++ b/src/main/java/opendcs/opentsdb/OpenTsdb.java
@@ -118,7 +118,7 @@ public class OpenTsdb extends TimeSeriesDb
 			setConnection(
 				DriverManager.getConnection(dbUri, username, password));
 		
-			setupKeyGenerator(getConnection());
+			setupKeyGenerator();
 
 			// MJM 2018-2/21 Force autoCommit on.
 			try { getConnection().setAutoCommit(true); }


### PR DESCRIPTION
Additionally discovered exception wasn't actually logged in a few places.

## Problem Description

Missed a stop in the connection pool fix which caused compimport to fail.

## Solution

Make sure the KeyGenerator is initialized.

## how you tested the change

Ran compimport. Currently letting other processes run (routsched,depends, comproc)

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests that run during ant test
   - [ ] Test procedure descriptions
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
