### PR TITLE
Fixes #123 via additional Oracle conditional

### DIFF
--- a/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -999,6 +999,7 @@ public abstract class TimeSeriesDb
 		// Oracle was providing things in the wrong timestamp using current_timestamp.
 		// TODO: needs to be checked against Postgres
 		String curTime = this.isOracle() ? "sysdate" : "current_timestamp" ;
+		String inter = this.isOracle() ? " ?/24 )" : " ? * INTERVAL '1' hour )" ; // Oracle datemath
 		Connection tcon = getConnection();
 		try(
 			PreparedStatement deleteNormal = tcon.prepareStatement("delete from CP_COMP_TASKLIST where RECORD_NUM = ?");
@@ -1006,10 +1007,10 @@ public abstract class TimeSeriesDb
 					  "delete from CP_COMP_TASKLIST "
 					+ "where RECORD_NUM = ? " // failRecList
 					+ "and ((" + curTime + " - DATE_TIME_LOADED) > " // curTimeName
-					+ "INTERVAL '? hour')" ); //String.format(maxCompRetryTimeFrmt, maxRetries) + ")"); //
+					+ inter ); //String.format(maxCompRetryTimeFrmt, maxRetries) + ")"); //
 			PreparedStatement updateFailedRetry = tcon.prepareStatement(
 				"update CP_COMP_TASKLIST set FAIL_TIME = ? where RECORD_NUM = ? and "
-			+	"( (" + curTime + " - DATE_TIME_LOADED) <= INTERVAL '? hour')");
+			+	"( (" + curTime + " - DATE_TIME_LOADED) <= " + inter);
 			PreparedStatement updateFailTime = tcon.prepareStatement(
 				"UPDATE CP_COMP_TASKLIST "
 			+	" SET FAIL_TIME = " + curTime


### PR DESCRIPTION
Syntax verified in both Postgres and Oracle

Signed-off-by: Andrew Gilmore <andrew@precisionwre.com>

## how you tested the change

Sample SQL statements run in both Oracle and Postgres

## Where the following done:
Unit Test dependencies failed: 
"/home/agilmore/workspace/opendcs/build.xml:241: java.lang.NoClassDefFoundError: org/junit/platform/launcher/core/LauncherFactory"
even though the test.dependencies target worked.
