### PR TITLE
convert domsat tests to JUnit5 integration tests

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -1,7 +1,7 @@
 
 
 <ivy-module version="2.0" xmlns:e="https//ant.apache.org/ivy/extra">
-    <info organisation="com.opendcs" 
+    <info organisation="com.opendcs"
           module="opendcs"
           revision="${version}"
           e:snapshot="a${snapshot.time}"/>
@@ -76,26 +76,26 @@
 
 
         <!-- test dependencies -->
-        
+
         <dependency org="org.junit.platform" name="junit-platform-launcher" rev="1.8.2" conf="test_platform->default"/>
         <dependency org="org.junit.platform" name="junit-platform-engine" rev="1.8.2" conf="test_platform->default"/>
         <dependency org="org.junit.platform" name="junit-platform-commons" rev="1.8.2" conf="test_platform->default"/>
-        <dependency org="org.junit.jupiter" name="junit-jupiter-api" rev="5.8.1" conf="test->default"/>
-        <dependency org="org.junit.jupiter" name="junit-jupiter-engine" rev="5.8.1" conf="test->default"/>
-        <dependency org="org.junit.jupiter" name="junit-jupiter-params" rev="5.8.1" conf="test->default"/>
+        <dependency org="org.junit.jupiter" name="junit-jupiter-api" rev="5.9.1" conf="test->default"/>
+        <dependency org="org.junit.jupiter" name="junit-jupiter-engine" rev="5.9.1" conf="test->default"/>
+        <dependency org="org.junit.jupiter" name="junit-jupiter-params" rev="5.9.1" conf="test->default"/>
         <dependency org="commons-io" name="commons-io" rev="2.11.0" conf="test->default"/>
         <dependency org="org.apache.derby" name="derby" rev="10.14.2.0" conf="test->default"/>
         <!-- izpack -->
         <dependency org="org.codehaus.izpack" name="izpack-standalone-compiler" rev="4.3.5" conf="izpack->default"/>
 
-        <!-- groovy deps for biuld script -->
+        <!-- groovy deps for build script -->
         <dependency org="org.codehaus.groovy" name="groovy-ant" rev="3.0.10" conf="groovy->default"/>
         <dependency org="org.codehaus.groovy" name="groovy" rev="3.0.10" conf="groovy->default"/>
         <dependency org="org.codehaus.groovy" name="groovy-xml" rev="3.0.10" conf="groovy->default"/>
 
         <!-- other build dependencies -->
         <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" conf="build->default"/>
-        <!-- for some reason the github action build requires classes built for java 8 but my local environment 
+        <!-- for some reason the github action build requires classes built for java 8 but my local environment
             does not. Downgrade for now to people can review.-->
         <dependency org="com.puppycrawl.tools" name="checkstyle" rev="9.3" conf="build->default"/>
         <!-- keep unused transient dependencies out -->
@@ -108,7 +108,7 @@
         <exclude org="com.sun.media"/>
         <exclude org="log4j"/>
 
-        
+
 
     </dependencies>
 </ivy-module>

--- a/src/main/java/lrgs/domsatrecv/DomsatDpc.java
+++ b/src/main/java/lrgs/domsatrecv/DomsatDpc.java
@@ -262,14 +262,6 @@ public class DomsatDpc
 	{
 		return errMsg;
 	}
-
-//	public void reset()
-//	{
-//		Logger.instance().info(DomsatRecv.module
-//			+ " Resetting DOMSAT DPC.");
-//		setEnabled(false);
-//		setEnabled(true);
-//	}
 	
 	public void timeout()
 	{
@@ -279,80 +271,4 @@ public class DomsatDpc
 		setEnabled(true);
 	}
 
-	/**
-	 * Test main method continually receives frames and sends them to stdout.
-	 * Usage: lrgsj lrgs.domsatrecv.DomsatDpc [host [port]]
-	 */
-	public static void main(String args[])
-		throws Exception
-	{
-		DpcDomsatTest dt = new DpcDomsatTest();
-		if (args.length > 0)
-			dt.host = args[0];
-		if (args.length > 1)
-			dt.port = Integer.parseInt(args[1]);
-		dt.start();
-	}
 }
-
-class DpcDomsatTest
-	extends Thread
-{
-	String host = "localhost";
-	int port = 9000;
-	public void run()
-	{
-		try
-		{
-			DomsatDpc ds = new DomsatDpc();
-			LrgsConfig.instance().dpcHost = host;
-			LrgsConfig.instance().dpcPort = port;
-			
-			ds.init();
-			if (!ds.setEnabled(true))
-			{
-				System.out.println("Enable failed -- see log messages.");
-				System.exit(1);
-			}
-			byte packet[] = new byte[1024];
-			while(true)
-			{
-				int len = ds.getPacket(packet);
-				if (len == 0)
-					System.out.println("Timeout");
-				else if (len == -1)
-					System.out.println("Recoverable Error: " + ds.getErrorMsg());
-				else if (len == -2)
-				{
-					System.out.println("Fatal Error: " + ds.getErrorMsg());
-					break;
-				}
-				else if (len == -3)
-				{
-					try { Thread.sleep(100L); } catch(Exception ex) {}
-				}
-				else
-				{
-					System.out.println("Frame received, len=" + len);
-					System.out.println(" "
-						+ Integer.toHexString((int)packet[0] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[1] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[2] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[3] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[4] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[5] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[6] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[7] & 0xff) + ", ... "
-						+ Integer.toHexString((int)packet[len-2] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[len-1] & 0xff));
-				}
-			}
-			ds.shutdown();
-		}
-		catch(Exception ex)
-		{
-			System.err.println("Exception in get-thread: " + ex);
-		}
-	}
-}
-

--- a/src/main/java/lrgs/domsatrecv/DomsatFranklin.java
+++ b/src/main/java/lrgs/domsatrecv/DomsatFranklin.java
@@ -183,77 +183,8 @@ public class DomsatFranklin
 		}
 	}
 
-	/**
-	 * Test main method continually receives frames and sends them to stdout.
-	 */
-	public static void main(String args[])
-		throws Exception
-	{
-		DomsatFranklinTest dt = new DomsatFranklinTest();
-		dt.start();
-	}
-
-//	/* (non-Javadoc)
-//     * @see lrgs.domsatrecv.DomsatHardware#reset()
-//     */
-//    @Override
-//    public void reset()
-//    {
-//    }
 	public void timeout()
 	{
-	}
-}
-
-class DomsatFranklinTest
-	extends Thread
-{
-	public void run()
-	{
-		try
-		{
-			DomsatFranklin ds = new DomsatFranklin();
-			ds.init();
-			if (!ds.setEnabled(true))
-			{
-				System.out.println("Enable failed -- see log messages.");
-				System.exit(1);
-			}
-			byte packet[] = new byte[1024];
-			while(true)
-			{
-				int len = ds.getPacket(packet);
-				if (len == 0)
-					System.out.println("Timeout");
-				else if (len == -1)
-					System.out.println("Recoverable Error: " + ds.getErrorMsg());
-				else if (len == -2)
-				{
-					System.out.println("Fatal Error: " + ds.getErrorMsg());
-					break;
-				}
-				else
-				{
-					System.out.println("Frame received, len=" + len);
-					System.out.println(" "
-						+ Integer.toHexString((int)packet[0] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[1] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[2] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[3] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[4] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[5] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[6] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[7] & 0xff) + ", ... "
-						+ Integer.toHexString((int)packet[len-2] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[len-1] & 0xff));
-				}
-			}
-			ds.shutdown();
-		}
-		catch(Exception ex)
-		{
-			System.err.println("Exception in get-thread: " + ex);
-		}
 	}
 }
 

--- a/src/main/java/lrgs/domsatrecv/DomsatSangoma.java
+++ b/src/main/java/lrgs/domsatrecv/DomsatSangoma.java
@@ -209,80 +209,8 @@ public class DomsatSangoma
 			return "unknown";
 		}
 	}
-
-
-	/**
-	 * Test main method continually receives frames and sends them to stdout.
-	 */
-	public static void main(String args[])
-		throws Exception
-	{
-		DomsatTest dt = new DomsatTest();
-		dt.start();
-	}
-
-//	/* (non-Javadoc)
-//     * @see lrgs.domsatrecv.DomsatHardware#reset()
-//     */
-//    @Override
-//    public void reset()
-//    {
-//    }
     
 	public void timeout()
 	{
 	}
 }
-
-class DomsatTest
-	extends Thread
-{
-	public void run()
-	{
-		try
-		{
-			DomsatSangoma ds = new DomsatSangoma();
-			ds.init();
-			if (!ds.setEnabled(true))
-			{
-				System.out.println("Enable failed -- see log messages.");
-				System.exit(1);
-			}
-			byte packet[] = new byte[1024];
-			while(true)
-			{
-				int len = ds.getPacket(packet);
-				if (len == 0)
-					System.out.println("Timeout");
-				else if (len == -1)
-					System.out.println("Recoverable Error: " + ds.getErrorMsg());
-				else if (len == -2)
-				{
-					System.out.println("Fatal Error: " + ds.getErrorMsg());
-					break;
-				}
-				else
-				{
-					System.out.println("Frame received, len=" + len);
-					System.out.println(" "
-						+ Integer.toHexString((int)packet[0] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[1] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[2] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[3] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[4] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[5] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[6] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[7] & 0xff) + ", ... "
-						+ Integer.toHexString((int)packet[len-2] & 0xff) + ", "
-						+ Integer.toHexString((int)packet[len-1] & 0xff));
-				}
-			}
-			ds.shutdown();
-		}
-		catch(Exception ex)
-		{
-			System.err.println("Exception in get-thread: " + ex);
-		}
-	}
-}
-

--- a/src/test/java/integration/lrgs/domsatrecv/TestDomsat.java
+++ b/src/test/java/integration/lrgs/domsatrecv/TestDomsat.java
@@ -1,0 +1,66 @@
+package integration.lrgs.domsatrecv;
+
+import java.util.logging.Logger;
+
+import lrgs.domsatrecv.DomsatDpc;
+import lrgs.lrgsmain.LrgsConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Disabled("Requires DOMSAT DPC installed on localhost")
+final class TestDomsat
+{
+	private static final Logger LOGGER = Logger.getLogger(TestDomsat.class.getName());
+	private static DomsatDpc ds;
+
+	@BeforeAll
+	public static void setup()
+	{
+		String host = System.getProperty("domsat.dpc.test.host", "localhost");
+		int port = Integer.getInteger("domsat.dpc.test.post", 9000);
+		LrgsConfig.instance().dpcHost = host;
+		LrgsConfig.instance().dpcPort = port;
+		ds = new DomsatDpc();
+		ds.init();
+		assertTrue(ds.setEnabled(true), () -> "Enable failed -- see log messages.");
+	}
+
+	@AfterAll
+	public static void tearDown()
+	{
+		ds.shutdown();
+	}
+
+	@RepeatedTest(value = 20, name = RepeatedTest.LONG_DISPLAY_NAME)
+	void dpcDomsat() throws Exception
+	{
+		byte packet[] = new byte[1024];
+		int len = ds.getPacket(packet);
+
+		assertNotEquals(0, len, () -> "Timeout");
+		assertNotEquals(-1, len, () -> "Recoverable Error: " + ds.getErrorMsg());
+		assertNotEquals(-2, len, () -> "Fatal Error: " + ds.getErrorMsg());
+		while(len == -3)
+		{
+			Thread.sleep(100L);
+			len = ds.getPacket(packet);
+		}
+		LOGGER.info("Frame received, len=" + len);
+		LOGGER.info(" "
+				+ Integer.toHexString((int) packet[0] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[1] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[2] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[3] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[4] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[5] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[6] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[7] & 0xff) + ", ... "
+				+ Integer.toHexString((int) packet[len - 2] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[len - 1] & 0xff));
+	}
+}

--- a/src/test/java/integration/lrgs/domsatrecv/TestDomsatFranklin.java
+++ b/src/test/java/integration/lrgs/domsatrecv/TestDomsatFranklin.java
@@ -1,0 +1,55 @@
+package integration.lrgs.domsatrecv;
+
+import java.util.logging.Logger;
+
+import lrgs.domsatrecv.DomsatFranklin;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Disabled("Requires domsat.win on java.library.path")
+final class TestDomsatFranklin extends Thread
+{
+	private static final Logger LOGGER = Logger.getLogger(TestDomsatFranklin.class.getName());
+	private static DomsatFranklin ds;
+
+	@BeforeAll
+	public static void setup()
+	{
+		ds = new DomsatFranklin();
+		ds.init();
+		assertTrue(ds.setEnabled(true), () -> "Enable failed -- see log messages.");
+	}
+
+	@AfterAll
+	public static void tearDown()
+	{
+		ds.shutdown();
+	}
+
+	@RepeatedTest(value = 20, name = RepeatedTest.LONG_DISPLAY_NAME)
+	void domsatFranklin()
+	{
+		byte[] packet = new byte[1024];
+		int len = ds.getPacket(packet);
+		assertNotEquals(0, len, () -> "Timeout");
+		assertNotEquals(-1, len, () -> "Recoverable Error: " + ds.getErrorMsg());
+		assertNotEquals(-2, len, () -> "Fatal Error: " + ds.getErrorMsg());
+		LOGGER.info("Frame received, len=" + len);
+		LOGGER.info(" "
+				+ Integer.toHexString((int) packet[0] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[1] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[2] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[3] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[4] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[5] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[6] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[7] & 0xff) + ", ... "
+				+ Integer.toHexString((int) packet[len - 2] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[len - 1] & 0xff));
+	}
+}

--- a/src/test/java/integration/lrgs/domsatrecv/TestDomstatSangoma.java
+++ b/src/test/java/integration/lrgs/domsatrecv/TestDomstatSangoma.java
@@ -1,0 +1,53 @@
+package integration.lrgs.domsatrecv;
+
+import lrgs.domsatrecv.DomsatSangoma;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Disabled("Requires WinDomsatSangoma.dll on java.library.path")
+final class TestDomstatSangoma
+{
+
+	private static DomsatSangoma ds;
+
+	@BeforeAll
+	public static void setup()
+	{
+		ds = new DomsatSangoma();
+		ds.init();
+		assertTrue(ds.setEnabled(true), () -> "Enable failed -- see log messages.");
+	}
+
+	@AfterAll
+	public static void tearDown()
+	{
+		ds.shutdown();
+	}
+
+	@RepeatedTest(value = 20, name = RepeatedTest.LONG_DISPLAY_NAME)
+	void domsatFranklin()
+	{
+		byte[] packet = new byte[1024];
+		int len = ds.getPacket(packet);
+		assertNotEquals(0, len, () -> "Timeout");
+		assertNotEquals(-1, len, () -> "Recoverable Error: " + ds.getErrorMsg());
+		assertNotEquals(-2, len, () -> "Fatal Error: " + ds.getErrorMsg());
+		System.out.println("Frame received, len=" + len);
+		System.out.println(" "
+				+ Integer.toHexString((int) packet[0] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[1] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[2] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[3] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[4] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[5] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[6] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[7] & 0xff) + ", ... "
+				+ Integer.toHexString((int) packet[len - 2] & 0xff) + ", "
+				+ Integer.toHexString((int) packet[len - 1] & 0xff));
+	}
+}


### PR DESCRIPTION
## Problem Description

Test classes are within production class packages with no automated mechanism to run them.

Fixes https://github.com/opendcs/opendcs/issues/25.

## Solution

Migrate test classes into parent test directory, splitting out unit, integration, and exploratory tests with best judgement. Automate as many tests as I can to be run alongside the GitHub Actions build.

This PR specifically covers the start of the integration Domsat tests. 

## how you tested the change

Ran the existing main methods to discover functionalities and implemented basic tests of functionality.

## Where the following done:

- [X] Tests. Check all that apply:
   - [ ] Unit tests that run during ant test
   - [ ] Test procedure descriptions
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate
