### PR TITLE
Note about the eclipse IDE target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ To build the file opendcs.jar run the following
 If you want to build the installer run
 
 `ant opendcs`
+
+# IDE integration
+
+For the purposes of setting up the project VS Code or Eclipse you can run the following task:
+
+`ant eclipse-ide-files`
+
+This will create the appropriate .project and .classpath files for code completion and following.


### PR DESCRIPTION
## Problem Description

After a converstation where a developer complained about not having intellisense and other useful java IDE integration working I realized the task to generate the project files wasn't documented properly.

## Solution

Added thing to end of readme.

## how you tested the change

N/A

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests that run during ant test
   - [ ] Test procedure descriptions
- [X] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
