### PR TITLE
Bugfix/loadable lrgs interface msg archive

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -85,7 +85,8 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
             includes="lrgs/gui/LrgsBuild.java">
             <src path="${build.classes}"/>
             <classpath refid="runtime.classpath"/>
-        </javac>
+			<compilerarg value="-parameters"/>
+		</javac>
 
         <javac debug="true" destdir="${build.classes}"
             target="1.8" source="1.8"
@@ -95,7 +96,8 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
             excludes="lrgs/gui/LrgsBuild.java">
             <src path="${src.dir}"/>
             <classpath refid="runtime.classpath"/>
-        </javac>
+			<compilerarg value="-parameters"/>
+		</javac>
 
     </target>
 

--- a/src/main/java/lrgs/lrgsmain/LoadableLrgsInputInterface.java
+++ b/src/main/java/lrgs/lrgsmain/LoadableLrgsInputInterface.java
@@ -21,7 +21,7 @@ public interface LoadableLrgsInputInterface extends LrgsInputInterface
 
 	/**
 	 * Allow interaction with the message archive.
-	 * 
+	 *
 	 * @param archive The message archive to store what we've received.
 	 */
 	public void setMsgArchive(MsgArchive archive);

--- a/src/main/java/lrgs/lrgsmain/LoadableLrgsInputInterface.java
+++ b/src/main/java/lrgs/lrgsmain/LoadableLrgsInputInterface.java
@@ -1,5 +1,7 @@
 package lrgs.lrgsmain;
 
+import lrgs.archive.MsgArchive;
+
 public interface LoadableLrgsInputInterface extends LrgsInputInterface
 {
 	/**
@@ -16,5 +18,11 @@ public interface LoadableLrgsInputInterface extends LrgsInputInterface
 	 * @param value the param value
 	 */
 	public void setConfigParam(String name, String value);
-	
+
+	/**
+	 * Allow interaction with the message archive.
+	 * 
+	 * @param archive The message archive to store what we've received.
+	 */
+	public void setMsgArchive(MsgArchive archive);
 }

--- a/src/main/java/lrgs/lrgsmain/LrgsInputException.java
+++ b/src/main/java/lrgs/lrgsmain/LrgsInputException.java
@@ -26,4 +26,9 @@ public class LrgsInputException extends Exception
 	{
 		super(msg);
 	}
+
+	public LrgsInputException(String msg, Throwable cause)
+	{
+		super(msg,cause);
+	}
 }

--- a/src/main/java/lrgs/lrgsmain/LrgsMain.java
+++ b/src/main/java/lrgs/lrgsmain/LrgsMain.java
@@ -18,7 +18,9 @@ import java.io.IOException;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.TimeZone;
+import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Set;
 import java.net.InetAddress;
 
 import opendcs.dai.LoadingAppDAI;
@@ -65,6 +67,7 @@ Main class for LRGS process.
 public class LrgsMain
 	implements Runnable, ServerLockable, SignalHandler, ProcWaiterCallback
 {
+	private static final Logger logger = Logger.instance();
 	public static final String module = "LrgsMain";
 
 	public static final int EVT_TIMEOUT = 1;
@@ -588,74 +591,60 @@ public class LrgsMain
 		// Note that each input interface must have a unique name and must not
 		// clash with any of the standard interface type-names defined in
 		// LrgsInputInterface.java
-		HashMap<String, LoadableLrgsInputInterface> nm2if = 
-			new HashMap<String,LoadableLrgsInputInterface>();
-		Properties props = cfg.getOtherProps();
-		for(Enumeration<Object> kenum = props.keys(); kenum.hasMoreElements(); )
-		{
-			String key = (String)kenum.nextElement();
-			if (TextUtil.startsWithIgnoreCase(key, "LrgsInput.")
-			 && TextUtil.endsWithIgnoreCase(key, ".class"))
+		
+		final HashMap<String, Properties> loadableInterfaces = new HashMap<>();
+		cfg.getOtherProps()
+		   .forEach((key,val) -> {
+				if (((String)key).startsWith("LrgsInput."))
+				{
+					final String keyParts[] = ((String)key).split("\\.");
+					final String name = keyParts[1];
+					final String var = keyParts[2]; // NOTE: consider possible extra hierarchy
+					if (!loadableInterfaces.containsKey(name))
+					{
+						loadableInterfaces.put(name,new Properties());
+					}
+					final Properties props = loadableInterfaces.get(name);
+					props.put(var,val);
+				}
+			});
+
+		loadableInterfaces.forEach((loadableName,props)-> {
+			try
 			{
-				// Isolate the name between "LrgsInput." and ".class"
-				String nm = key.substring(10);
-				int idx = nm.indexOf('.');
-				nm = nm.substring(0, idx);
-				
-				String clsName = props.getProperty(key);
-				try
-				{
-					Class<?> inputClass = Class.forName(clsName);
-					LoadableLrgsInputInterface input = 
-						(LoadableLrgsInputInterface)inputClass.newInstance();
-					input.setInterfaceName(nm);
-					addInput(input);
-					nm2if.put(nm, input);
-					input.initLrgsInput();
-					input.setMsgArchive(msgArchive);
-				}
-				catch (Exception ex)
-				{
-					Logger.instance().warning(module 
-						+ " Cannot instantiate LrgsInput class '"
-						+ clsName + "': " + ex);
-				}
+				Class<?> inputClass = Class.forName(props.getProperty("class"));
+				LoadableLrgsInputInterface input = 
+					(LoadableLrgsInputInterface)inputClass.newInstance();
+				input.setInterfaceName(loadableName);
+				input.setMsgArchive(msgArchive);
+				addInput(input);				
+
+				props.entrySet()
+						.stream()
+						.filter((k_v)  -> !(((String)k_v.getKey()).equalsIgnoreCase("enable")
+											||
+											((String)k_v.getKey()).equalsIgnoreCase("enabled")
+						))
+						.forEach((k_v) -> {
+							input.setConfigParam((String)k_v.getKey(),(String)k_v.getValue());
+						}
+				);
+				input.initLrgsInput();
+				input.enableLrgsInput(Boolean.parseBoolean(props.getProperty("enable",
+														   props.getProperty("enabled",
+														   "false"))));
 			}
-		}
-		// Now process enabled and other properties.
-		for(Enumeration<Object> kenum = props.keys(); kenum.hasMoreElements(); )
-		{
-			String key = (String)kenum.nextElement();
-			if (TextUtil.startsWithIgnoreCase(key, "LrgsInput."))
+			catch (IllegalAccessException | InstantiationException | ClassNotFoundException | ClassCastException ex)
 			{
-				String ifName = key.substring(10);
-				int idx = ifName.indexOf('.');
-				if (idx == -1 || idx == ifName.length())
-					continue;
-				String param = ifName.substring(idx+1);
-				if (param.equalsIgnoreCase("class"))
-					continue;
-				ifName = ifName.substring(0, idx);
-				LoadableLrgsInputInterface input = nm2if.get(ifName);
-				if (input == null)
-				{
-					Logger.instance().warning(module 
-						+ " Config param '" + key + "' is for unknown input interface '"
-						+ ifName + "'. Did you forget the '.class' param?");
-					continue;
-				}
-				if (param.equalsIgnoreCase("enable") || param.equalsIgnoreCase("enabled"))
-				{
-					// Set the input to enabled true/false value
-					input.enableLrgsInput(TextUtil.str2boolean(props.getProperty(key)));
-				}
-				else
-				{
-					// Set the input's property.
-					input.setConfigParam(param, props.getProperty(key));
-				}
+				String msg = "Unable to create Loadable Input %s, because %s";
+				logger.warning(String.format(msg,loadableName,ex.getLocalizedMessage()));
 			}
-		}
+			catch (LrgsInputException ex)
+			{
+				String msg = "Unable to configure Loadable Input %s, because %s";
+				logger.warning(String.format(msg,loadableName,ex.getLocalizedMessage()));
+			}
+		});
 
 		return true;
 	}

--- a/src/main/java/lrgs/lrgsmain/LrgsMain.java
+++ b/src/main/java/lrgs/lrgsmain/LrgsMain.java
@@ -612,6 +612,7 @@ public class LrgsMain
 					addInput(input);
 					nm2if.put(nm, input);
 					input.initLrgsInput();
+					input.setMsgArchive(msgArchive);
 				}
 				catch (Exception ex)
 				{


### PR DESCRIPTION
## Problem Description

I wanted to create simple MQTT interface to pull data of my home loggers. Seeing the LoadableLrgsInputInterface I saw a simple path to do so.

Except that once I started creating it I realized my new input source would have no reference to the message archive and thus no ability to save messages.

Property settings and initialization was also a little confusing.

## Solution

- Added a `setMsgArchive ` function to LoadableLrgsInputInterface
- Modified logic in LrgsMain to gather all appropriate information and only then instatiate and possibly enable the new source

The addition of the function to the interface is technically a breaking change; however, since there was simply no way to get the message archive or LrgsMain instance I don't expect this to affect anyone, and if it does the change is fairly obvious.

## how you tested the change

Currently running in my home lab.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests that run during ant test
   - [ ] Test procedure descriptions
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
