### PR TITLE
Add exit(0) handling to python algorithm calls. Fixes #149.

### DIFF
--- a/src/main/java/decodes/tsdb/algo/PythonAlgorithm.java
+++ b/src/main/java/decodes/tsdb/algo/PythonAlgorithm.java
@@ -316,7 +316,7 @@ public class PythonAlgorithm
 					PyException pe = ((PyException) ex);
 					if (pe.type == Py.SystemExit && PyException.isExceptionInstance(pe.value)
 							&& ((PyObject) pe.value).__findattr__("code").asInt() == 0) {
-						debug3("afterScript exited with system exit and zero exit code");
+						debug3("beforeScript exited with system exit and zero exit code");
 						return;
 					}
 				}
@@ -387,7 +387,8 @@ debug3("Missing action for '" + roleName + "' now set to " + parmRef.missingActi
 				PyException pe = ((PyException) ex);
 				if (pe.type == Py.SystemExit && PyException.isExceptionInstance(pe.value)
 						&& ((PyObject) pe.value).__findattr__("code").asInt() == 0) {
-					debug3("afterScript exited with system exit and zero exit code");
+					debug3("paramInitScript exited with system exit and zero exit code");
+					firstTsGroup = false;
 					return;
 				}
 			}
@@ -529,7 +530,7 @@ debug3("Checking parm '" + parm.getRoleName() + "' with type " + parm.getParmTyp
 					PyException pe = ((PyException) ex);
 					if (pe.type == Py.SystemExit && PyException.isExceptionInstance(pe.value)
 							&& ((PyObject) pe.value).__findattr__("code").asInt() == 0) {
-						debug3("afterScript exited with system exit and zero exit code");
+						debug3("tsScript exited with system exit and zero exit code");
 						return;
 					}
 				}

--- a/src/main/java/decodes/tsdb/algo/PythonAlgorithm.java
+++ b/src/main/java/decodes/tsdb/algo/PythonAlgorithm.java
@@ -108,7 +108,7 @@ import java.util.TreeSet;
 
 import opendcs.dai.TimeSeriesDAI;
 
-import org.python.core.PyFloat;
+import org.python.core.*;
 import org.python.util.PythonInterpreter;
 
 import ilex.util.EnvExpander;
@@ -153,6 +153,8 @@ import decodes.tsdb.ParmRef;
 import ilex.var.TimedVariable;
 import decodes.tsdb.TimeSeriesIdentifier;
 import decodes.util.DecodesSettings;
+
+import static decodes.db.DecodesScript.logger;
 
 //AW:IMPORTS
 // Place an import statements you need here.
@@ -310,6 +312,14 @@ public class PythonAlgorithm
 			}
 			catch(Exception ex)
 			{
+				if (ex instanceof PyException) {
+					PyException pe = ((PyException) ex);
+					if (pe.type == Py.SystemExit && PyException.isExceptionInstance(pe.value)
+							&& ((PyObject) pe.value).__findattr__("code").asInt() == 0) {
+						debug3("afterScript exited with system exit and zero exit code");
+						return;
+					}
+				}
 				String msg = "Error executing beforeScript : " + ex;
 				warning(msg + linesep + beforeScript.getText());
 				throw new DbCompException(msg);
@@ -373,6 +383,14 @@ debug3("Missing action for '" + roleName + "' now set to " + parmRef.missingActi
 		}
 		catch(Exception ex)
 		{
+			if (ex instanceof PyException) {
+				PyException pe = ((PyException) ex);
+				if (pe.type == Py.SystemExit && PyException.isExceptionInstance(pe.value)
+						&& ((PyObject) pe.value).__findattr__("code").asInt() == 0) {
+					debug3("afterScript exited with system exit and zero exit code");
+					return;
+				}
+			}
 			String msg = "Error executing parmInitScript : " + ex;
 			warning(msg + linesep + parmInitScript);
 			throw new DbCompException(msg);
@@ -507,6 +525,14 @@ debug3("Checking parm '" + parm.getRoleName() + "' with type " + parm.getParmTyp
 			}
 			catch(Exception ex)
 			{
+				if (ex instanceof PyException) {
+					PyException pe = ((PyException) ex);
+					if (pe.type == Py.SystemExit && PyException.isExceptionInstance(pe.value)
+							&& ((PyObject) pe.value).__findattr__("code").asInt() == 0) {
+						debug3("afterScript exited with system exit and zero exit code");
+						return;
+					}
+				}
 				String msg = "Error executing tsScript : " + ex;
 				warning(msg + linesep + tsScript.getText());
 //				throw new DbCompException(msg);
@@ -537,6 +563,14 @@ debug3("Checking parm '" + parm.getRoleName() + "' with type " + parm.getParmTyp
 			}
 			catch(Exception ex)
 			{
+				if (ex instanceof PyException) {
+					PyException pe = ((PyException) ex);
+					if (pe.type == Py.SystemExit && PyException.isExceptionInstance(pe.value)
+							&& ((PyObject) pe.value).__findattr__("code").asInt() == 0) {
+						debug3("afterScript exited with system exit and zero exit code");
+						return;
+					}
+				}
 				String msg = "Error executing afterScript : " + ex;
 				warning(msg + linesep + afterScript.getText());
 				throw new DbCompException(msg);

--- a/src/test/java/jython/SystemExitTest.java
+++ b/src/test/java/jython/SystemExitTest.java
@@ -1,0 +1,43 @@
+package jython;
+
+import decodes.tsdb.DbCompException;
+import org.junit.jupiter.api.Test;
+import org.python.core.Py;
+import org.python.core.PyException;
+import org.python.core.PyObject;
+import org.python.util.PythonInterpreter;
+
+import static decodes.db.DecodesScript.logger;
+
+public class SystemExitTest {
+    private static final PyException sysexit0 = new PyException();
+
+    @Test
+    public void test_systemexit() throws Exception
+    {
+
+        try(PythonInterpreter python = new PythonInterpreter();)
+        {
+            python.exec("exit(0)");
+        }
+        catch(Exception ex)
+        {
+            if (ex instanceof PyException) {
+                PyException pe = ((PyException) ex);
+                // after https://github.com/jython/jython/blob/master/src/org/python/core/Py.java#L282
+                if (pe.type == Py.SystemExit && PyException.isExceptionInstance(pe.value)
+                    && ((PyObject)pe.value).__findattr__("code").asInt() == 0) {
+                    logger.info("test script exited with system exit and zero exit code, type: " + pe.type + " value: " + pe.value);
+                    return;
+                }
+            }
+            else
+            {
+                String msg = "Error executing test script: " + ex;
+                logger.warning(msg);
+                throw ex;
+            }
+        }
+
+    }
+}

--- a/src/test/java/jython/SystemExitTest.java
+++ b/src/test/java/jython/SystemExitTest.java
@@ -31,13 +31,9 @@ public class SystemExitTest {
                     return;
                 }
             }
-            else
-            {
-                String msg = "Error executing test script: " + ex;
-                logger.warning(msg);
-                throw ex;
-            }
+            String msg = "Error executing test script: " + ex;
+            logger.warning(msg);
+            throw ex;
         }
-
     }
 }


### PR DESCRIPTION
## Problem Description
Fixes #149

## Solution

Figured out how to determine if a caught exception is the result of a python exit(0) call via
https://github.com/jython/jython/blob/master/src/org/python/core/Py.java#L282

## how you tested the change

New unit test.

## Where the following done:

- [X] Tests. Check all that apply:
   - [X] Unit tests that run during ant test
   - [ ] Test procedure descriptions
- [N/A] Was relevant documentation updated?
- [N/A ] Were relevant config element (e.g. XML data) updated as appropriate
