### PR TITLE
Quick for XML decodes script processing. (that yes, I totally broke.)

### DIFF
--- a/src/main/java/decodes/db/FormatStatement.java
+++ b/src/main/java/decodes/db/FormatStatement.java
@@ -136,4 +136,3 @@ public class FormatStatement extends DatabaseObject
 		return decodesScript;
 	}
 }
-

--- a/src/main/java/decodes/routing/RoutingSpecThread.java
+++ b/src/main/java/decodes/routing/RoutingSpecThread.java
@@ -818,9 +818,14 @@ public class RoutingSpecThread
 			if (p != null)
 				platname = p.makeFileName();
 			String msg = "Exception processing data from platform '" + platname + "': " + ex.toString();
+			PrintStream ps = Logger.instance().getLogOutput();
+			if (ps == null)
+			{
+				ps = System.out; // at least get it somewhere
+			}
 			assertPlatformError(msg, platstat);
-			System.err.println(msg);
-			ex.printStackTrace(System.err);
+			Logger.instance().warning(msg);
+			ex.printStackTrace(ps);
 			return null;
 		}		
 	}


### PR DESCRIPTION
## Problem Description

Did not sufficiently implement new decodes script reader into the XML Pars

## Solution

The implementation leaves a bit to be desired, but it works. NOAA is working on updates to their decoding so getting something in quick since the XML processing is just broken.

Next steps are properly encapsulating the DecodesScript anyways (the script was allowed to be unprepared by the time it was used to decode) and this gave me a better indication of what to do.

## how you tested the change

Was provided test data from NOAA, imported and ran routespec, got null pointer, implemented code, got appropriate data.
Also verified data loaded into the GUI and saved correctly to disk.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests that run during ant test
   - [x] Test procedure descriptions
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

I may investigate using a new XML Parser. Not to bash on what's there, it works and is how it was done in the day, but some of the modern XML parsers might (and I'll stress might here, it's still xml) make things a little easier.)
