### PR TITLE
Fix more broken computation retry queries.

### DIFF
--- a/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -1012,7 +1012,7 @@ public abstract class TimeSeriesDb
 					+ "and ((" + curTime + " - DATE_TIME_LOADED) > " // curTimeName
 					+ inter ); //String.format(maxCompRetryTimeFrmt, maxRetries) + ")"); //
 			PreparedStatement updateFailedRetry = tcon.prepareStatement(
-				"update CP_COMP_TASKLIST set FAIL_TIME = ? where RECORD_NUM = ? and "
+				"update CP_COMP_TASKLIST set FAIL_TIME = " + curTime + " where RECORD_NUM = ? and "
 			+	"( (" + curTime + " - DATE_TIME_LOADED) <= " + inter);
 			PreparedStatement updateFailTime = tcon.prepareStatement(
 				"UPDATE CP_COMP_TASKLIST "


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes HDB Support ticket #1245. Computation retries look to have been broken for some time.

We see failures with this backtrace:
WARNING 03/21/23 02:39:52 hdb java.sql.SQLException: Missing IN or OUT parameter at index:: 3
	at oracle.jdbc.driver.OraclePreparedStatement.processCompletedBindRow(OraclePreparedStatement.java:1937)
	at oracle.jdbc.driver.OraclePreparedStatement.addBatch(OraclePreparedStatement.java:9361)
	at oracle.jdbc.driver.OraclePreparedStatementWrapper.addBatch(OraclePreparedStatementWrapper.java:1069)
	at decodes.tsdb.TimeSeriesDb.releaseNewData(TimeSeriesDb.java:1060)
	at decodes.tsdb.ComputationApp.runApp(ComputationApp.java:484)
	at decodes.tsdb.TsdbAppTemplate.execute(TsdbAppTemplate.java:250)
	at decodes.tsdb.ComputationApp.main(ComputationApp.java:673)

## Solution

Fix the query to not have 3 parameters.

## how you tested the change

Build and tested.

## Were the following done:

- [X] Tests. Check all that apply:
   - [X] Unit tests that run during ant test
   - [N/A] Test procedure descriptions
- [N/A] Was relevant documentation updated?
- [X] Were relevant config element (e.g. XML data) updated as appropriate
