### PR TITLE
Put dependency report in reports folder, expand to all configs.

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -111,7 +111,8 @@
     </target>
 
     <target name="report" depends="resolve,resolve.build" description="--> generates a report of dependencies">
-        <ivy:report todir="${build.dir}"/>
+        <mkdir dir="${build.dir}/reports/dependencies"/>
+        <ivy:report todir="${build.dir}/reports/dependencies" conf="runtime,test,test_platform,izpack,groovy,build,spotbugs,pmd"/>
     </target>
 
 


### PR DESCRIPTION
## Problem Description

Wanted to look at the license of each dependency and realize the common.report task didn't render everything I needed.

## Solution

added parameter, created output directory in the new reports folder where other reports, like spotbugs, go.

## how you tested the change

Just ran it and looked at output. For those that have licenses, we're good. Will need to review the dependencies dependencies at some point though.

## Where the following done:

- [n/a] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [n/a] Was relevant documentation updated?
- [n/a] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
