### PR TITLE
Cleanup/integer double creation

### DIFF
--- a/src/main/java/decodes/consumer/FileAppendConsumer.java
+++ b/src/main/java/decodes/consumer/FileAppendConsumer.java
@@ -154,10 +154,14 @@ public class FileAppendConsumer extends DataConsumer
 //				".$DATE(" + Constants.suffixDateFormat_fmt + ")";
 				".$DATE(yyMMdd.hhmmss)";
 		maxFileSize = PropertiesUtil.getIgnoreCase(props, "maxfilesize");
-		if ( maxFileSize == null )
+		if (maxFileSize == null)
+		{
 			maxSize = -1;
+		}
 		else
-			maxSize = new Integer(maxFileSize).longValue();
+		{
+			maxSize = Long.valueOf(maxFileSize);
+		}
 	}
 
 	/**
@@ -288,7 +292,7 @@ public class FileAppendConsumer extends DataConsumer
 					int k = 0;
 					while  ( new File(path).exists() && k++ < 99 ) {
 						String[] fcomps = path.split("\\.");
-						int s = new Integer(fcomps[fcomps.length-1].substring(4));
+						int s = Integer.valueOf(fcomps[fcomps.length-1].substring(4));
 						if ( ++s > 99 )
 							s = 0;
 						String sec = decimalFormat.format(s);
@@ -361,4 +365,3 @@ public class FileAppendConsumer extends DataConsumer
 	}
 
 }
-

--- a/src/main/java/decodes/cwms/CwmsSiteDAO.java
+++ b/src/main/java/decodes/cwms/CwmsSiteDAO.java
@@ -242,8 +242,8 @@ public class CwmsSiteDAO extends SiteDAO
 			lat = Location.parseLatitude(newSite.latitude);
 		if (newSite.longitude != null)
 			lon = Location.parseLongitude(newSite.longitude);
-		Double dlat = new Double(lat);
-		Double dlon = new Double(lon);
+		Double dlat = lat;
+		Double dlon = lon;
 		Double delev = (elev == Constants.undefinedDouble ? null : new Double(elev));
 		try
 		{

--- a/src/main/java/decodes/cwms/CwmsSiteDAO.java
+++ b/src/main/java/decodes/cwms/CwmsSiteDAO.java
@@ -244,7 +244,7 @@ public class CwmsSiteDAO extends SiteDAO
 			lon = Location.parseLongitude(newSite.longitude);
 		Double dlat = lat;
 		Double dlon = lon;
-		Double delev = (elev == Constants.undefinedDouble ? null : new Double(elev));
+		Double delev = (elev == Constants.undefinedDouble ? null : elev);
 		try
 		{
 			if (DecodesSettings.instance().writeCwmsLocations)

--- a/src/main/java/decodes/decoder/DataOperations.java
+++ b/src/main/java/decodes/decoder/DataOperations.java
@@ -59,7 +59,7 @@ public class DataOperations
 		startLineNum = rawMsg.getStartLineNum();
 		curLine = startLineNum;
 		begLineBytePos = new Vector<Integer>();
-		begLineBytePos.add(new Integer(0));
+		begLineBytePos.add(0);
 		settings = DecodesSettings.instance();
 if (data.length >=2)
 Logger.instance().debug3("DataOperations instantiated with length=" + data.length
@@ -688,10 +688,13 @@ Logger.instance().debug3("getField pos=" + bytePos + ", data.length=" + data.len
 		}
 
 		// Now at first char past NL? increment line.
-		if (bytePos > 0 && data[bytePos-1] == NL) {
+		if (bytePos > 0 && data[bytePos-1] == NL)
+		{
 			curLine++;
 			if ( curLine - startLineNum  >= begLineBytePos.size() )
-				begLineBytePos.add(new Integer(bytePos));
+			{
+				begLineBytePos.add(bytePos);
+			}
 		}
 	}
 
@@ -788,4 +791,3 @@ Logger.instance().debug3("getField pos=" + bytePos + ", data.length=" + data.len
 			formatPositions.remove(0);
 	}
 }
-

--- a/src/main/java/decodes/excel/ExcelConsumer.java
+++ b/src/main/java/decodes/excel/ExcelConsumer.java
@@ -587,7 +587,7 @@ public class ExcelConsumer extends DataConsumer
 					s = col.getBlankSample();
 				
 				try {
-					double val = new Double(s).doubleValue();
+					double val = Double.valueOf(s);
 					createNumberCell(wb, sheet, sampleRowNum, sampleColumnNum,
 							HorizontalAlignment.RIGHT, val);
 				}

--- a/src/main/java/decodes/hdb/algo/CallProcAlg.java
+++ b/src/main/java/decodes/hdb/algo/CallProcAlg.java
@@ -102,23 +102,33 @@ public class CallProcAlg extends decodes.tsdb.algo.AW_AlgorithmBase
 	   SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy HH:mm");
            String new_proccall = proccall.replaceAll("<<INPUT","<<input");
            String tsbt_time = "to_date('" + sdf.format(_timeSliceBaseTime) + "','dd-mon-yyyy HH24:mi')";
-	   new_proccall = new_proccall.replaceAll("<<tsbt>>",tsbt_time);
-	   if (!isMissing(input1))
-	     new_proccall = new_proccall.replaceAll("<<input1>>",(new Double(input1)).toString());
-	   if (!isMissing(input2))
-	     new_proccall = new_proccall.replaceAll("<<input2>>",(new Double(input2)).toString());
-	   if (!isMissing(input3))
-	     new_proccall = new_proccall.replaceAll("<<input3>>",(new Double(input3)).toString());
-	   if (!isMissing(input4))
-	     new_proccall = new_proccall.replaceAll("<<input4>>",(new Double(input4)).toString());
-	   if (!isMissing(input5))
-	     new_proccall = new_proccall.replaceAll("<<input5>>",(new Double(input5)).toString());
-debug3("doAWTimeSlice input1=" + input1 +", input2=" + input2);
+		new_proccall = new_proccall.replaceAll("<<tsbt>>",tsbt_time);
+		if (!isMissing(input1))
+		{
+			new_proccall = new_proccall.replaceAll("<<input1>>",(Double.valueOf(input1)).toString());
+		}
+		if (!isMissing(input2))
+		{
+			new_proccall = new_proccall.replaceAll("<<input2>>",(Double.valueOf(input2)).toString());
+		}
+		if (!isMissing(input3))
+		{
+			new_proccall = new_proccall.replaceAll("<<input3>>",(Double.valueOf(input3)).toString());
+		}
+		if (!isMissing(input4))
+		{
+			new_proccall = new_proccall.replaceAll("<<input4>>",(Double.valueOf(input4)).toString());
+		}
+		if (!isMissing(input5))
+		{
+			new_proccall = new_proccall.replaceAll("<<input5>>",(Double.valueOf(input5)).toString());
+		}
+		debug3("doAWTimeSlice input1=" + input1 +", input2=" + input2);
 
-	   do_setoutput = true;
-	   if (do_setoutput)
-//           Then continue with the calling of the Procedure
-           {
+		do_setoutput = true;
+		if (do_setoutput)
+		//           Then continue with the calling of the Procedure
+        {
              // get the connection and a few other classes so we can do some sql
              conn = tsdb.getConnection();
              DBAccess db = new DBAccess(conn);

--- a/src/main/java/decodes/hdb/algo/DynamicAggregatesAlg.java
+++ b/src/main/java/decodes/hdb/algo/DynamicAggregatesAlg.java
@@ -396,7 +396,7 @@ public class DynamicAggregatesAlg
 					_aggregatePeriodBegin, _aggregatePeriodEnd, "dd-MM-yyyy HH:mm",
 					tsdb.getWriteModelRunId(), table_selector);
 			}
-			Double value_out = new Double(dbobj.get("result").toString());
+			Double value_out = Double.valueOf(dbobj.get("result").toString());
 			debug3("FLAGS: " + flags);
 			if (flags != null)
 				setHdbDerivationFlag(output, flags);

--- a/src/main/java/decodes/hdb/algo/EOPInterpAlg.java
+++ b/src/main/java/decodes/hdb/algo/EOPInterpAlg.java
@@ -224,7 +224,7 @@ public class EOPInterpAlg
 //   I cast it to an int
 //   mod March 2013 by M. Bogner for CP upgrade 5.3.  get SDI must have been changed to an object so
 //   I cast it to an int after I get a long with the getValue method
-		Integer sdi = new Integer( (int) getSDI("input").getValue());
+		Integer sdi = (int) getSDI("input").getValue();
 		conn = tsdb.getConnection();
 		String dt_fmt = "dd-MMM-yyyy HH:mm";
 		RBASEUtils rbu = new RBASEUtils(dbobj,conn);

--- a/src/main/java/decodes/hdb/algo/EOPInterpAlg.java
+++ b/src/main/java/decodes/hdb/algo/EOPInterpAlg.java
@@ -274,7 +274,7 @@ public class EOPInterpAlg
 			debug2 ("EOPINTERP- " + alg_ver + "  " + dbobj.toString());
 			//
 			// now get the date, value of first record in next interval to see if it passes muster
-			new_window_value = new Double(dbobj.get("nwdv").toString());
+			new_window_value = Double.valueOf(dbobj.get("nwdv").toString());
 			new_window_sdt   = new Date(dbobj.get("nwsdt").toString());
 			milly_diff = new_window_sdt.getTime() - _aggregatePeriodEnd.getTime(); 
 			milly_window = 0;

--- a/src/main/java/decodes/hdb/algo/EquationSolverAlg.java
+++ b/src/main/java/decodes/hdb/algo/EquationSolverAlg.java
@@ -128,7 +128,7 @@ public class EquationSolverAlg extends decodes.tsdb.algo.AW_AlgorithmBase
 		
 		// MJM 2017-04-30 replace with "null" if missing.
 		// Note: if we get to here and value is missing, it means that missing action = ignore.
-		String repl = !isMissing(input1) ? (new Double(input1)).toString() : "null";
+		String repl = !isMissing(input1) ? (Double.valueOf(input1)).toString() : "null";
 		new_equation = new_equation.replaceAll("<<input1>>", repl);
 		if (!isMissing(input1))
 		{
@@ -145,7 +145,7 @@ public class EquationSolverAlg extends decodes.tsdb.algo.AW_AlgorithmBase
 						"" + hdbTsid.getModelRunId());
 			}
 		}
-		repl = !isMissing(input2) ? (new Double(input2)).toString() : "null";
+		repl = !isMissing(input2) ? (Double.valueOf(input2)).toString() : "null";
 		new_equation = new_equation.replaceAll("<<input2>>", repl);
 		if (!isMissing(input2))
 		{
@@ -163,7 +163,7 @@ public class EquationSolverAlg extends decodes.tsdb.algo.AW_AlgorithmBase
 			}
 		}
 		
-		repl = !isMissing(input3) ? (new Double(input3)).toString() : "null";
+		repl = !isMissing(input3) ? (Double.valueOf(input3)).toString() : "null";
 		new_equation = new_equation.replaceAll("<<input3>>", repl);
 		if (!isMissing(input3))
 		{
@@ -181,7 +181,7 @@ public class EquationSolverAlg extends decodes.tsdb.algo.AW_AlgorithmBase
 			}
 		}
 		
-		repl = !isMissing(input4) ? (new Double(input4)).toString() : "null";
+		repl = !isMissing(input4) ? (Double.valueOf(input4)).toString() : "null";
 		new_equation = new_equation.replaceAll("<<input4>>", repl);
 		if (!isMissing(input4))
 		{
@@ -200,7 +200,7 @@ public class EquationSolverAlg extends decodes.tsdb.algo.AW_AlgorithmBase
 		}
 
 		
-		repl = !isMissing(input5) ? (new Double(input5)).toString() : "null";
+		repl = !isMissing(input5) ? (Double.valueOf(input5)).toString() : "null";
 		new_equation = new_equation.replaceAll("<<input5>>", repl);
 		if (!isMissing(input5))
 		{
@@ -280,7 +280,7 @@ public class EquationSolverAlg extends decodes.tsdb.algo.AW_AlgorithmBase
 			}
 			else
 			{
-				Double result_value = new Double(dbobj.get("result_value").toString());
+				Double result_value = Double.valueOf(dbobj.get("result_value").toString());
 				//
 				/*
 				 * added to allow users to automatically set the Validation

--- a/src/main/java/decodes/hdb/algo/FlowToVolumeAlg.java
+++ b/src/main/java/decodes/hdb/algo/FlowToVolumeAlg.java
@@ -298,7 +298,7 @@ public class FlowToVolumeAlg extends decodes.tsdb.algo.AW_AlgorithmBase
 		// this SDI initialization was modified by M. Bogner Mar 2013 for the
 		// dbkey surrogate key i
 		// class for the 5.3 CP upgrade project
-		Integer sdi = new Integer((int) getSDI("input").getValue());
+		Integer sdi = (int) getSDI("input").getValue();
 		String dt_fmt = "dd-MMM-yyyy HH:mm";
 
 		RBASEUtils rbu = new RBASEUtils(dbobj, conn);
@@ -400,7 +400,7 @@ public class FlowToVolumeAlg extends decodes.tsdb.algo.AW_AlgorithmBase
 			debug3("FlowToVolumeAlg: Derivation FLAGS: " + flags);
 			if (flags != null)
 				setHdbDerivationFlag(output, flags);
-			Double volume = new Double(dbobj.get("volume").toString());
+			Double volume = Double.valueOf(dbobj.get("volume").toString());
 			//
 			/* added to allow users to automatically set the Validation column */
 			if (validation_flag.length() > 0)

--- a/src/main/java/decodes/hdb/algo/PowerToEnergyAlg.java
+++ b/src/main/java/decodes/hdb/algo/PowerToEnergyAlg.java
@@ -269,7 +269,7 @@ public class PowerToEnergyAlg
                 dbobj.put("ALG_VERSION",alg_ver);
 // Cast to in  resulted from mod for CP 3.0 Upgrade project by M. Bogner Aug 2012
 // call to getValue method resulted from mod for CP 5.3 Upgrade project by M. Bogner March 2013
-                Integer sdi = new Integer((int) getSDI("input").getValue());
+                Integer sdi = (int) getSDI("input").getValue();
                 String dt_fmt = "dd-MMM-yyyy HH:mm";
  
 		RBASEUtils rbu = new RBASEUtils(dbobj,conn);
@@ -345,12 +345,19 @@ public class PowerToEnergyAlg
                    }
 
 		   debug3("PowerToEnergyAlg-"+alg_ver+": Derivation FLAGS: " + flags);
-		   if (flags != null) setHdbDerivationFlag(output,flags);
-                   Double energy = new Double(dbobj.get("energy").toString());
+		   if (flags != null)
+		   {	
+				setHdbDerivationFlag(output,flags);
+		   }
+
+			Double energy = Double.valueOf(dbobj.get("energy").toString());
 		   //
                    /* added to allow users to automatically set the Validation column  */
-                   if (validation_flag.length() > 0) setHdbValidationFlag(output,validation_flag.charAt(1));
-		   setOutput(output,energy);
+			if (validation_flag.length() > 0) 
+			{
+				setHdbValidationFlag(output,validation_flag.charAt(1));
+			}
+		   	setOutput(output,energy);
 		}
 //
 		//  delete any existing value if this calculation failed

--- a/src/main/java/decodes/hdb/algo/TimeWeightedAverageAlg.java
+++ b/src/main/java/decodes/hdb/algo/TimeWeightedAverageAlg.java
@@ -74,7 +74,7 @@ public class TimeWeightedAverageAlg
 	String flags;
 	Connection conn = null;
 	Date[] date_out = new Date[60];
-	Double[] value_out = new Double[60];
+	Double[] value_out = Double.valueOf[60];
 	int total_count;
 	int index;
 	double tally;
@@ -388,7 +388,7 @@ public class TimeWeightedAverageAlg
                    if (((String)dbobj.get("PWDV")).length() != 0)
                    {
                    // now get the date, value of first record in previous interval to see if it passes muster
-                   new_window_value = new Double(dbobj.get("pwdv").toString());
+                   new_window_value = Double.valueOf(dbobj.get("pwdv").toString());
                    new_window_sdt   = new Date(dbobj.get("pwsdt").toString());
                    // now do the interpolation of the eop of previous period to the BOP for this period
                    milly_diff_total = date_out[1].getTime() - new_window_sdt.getTime();
@@ -450,7 +450,7 @@ public class TimeWeightedAverageAlg
                    if (((String)dbobj.get("NWDV")).length() != 0)
                    {
                    // now get the date, value of first record in next interval to see if it passes muster
-                   new_window_value = new Double(dbobj.get("nwdv").toString());
+                   new_window_value = Double.valueOf(dbobj.get("nwdv").toString());
                    new_window_sdt   = new Date(dbobj.get("nwsdt").toString());
                    // now do the interpolation of the eop of this period to the BOP for next period
 			debug3(new_window_sdt + "  " + index);

--- a/src/main/java/decodes/hdb/algo/TimeWeightedAverageAlg.java
+++ b/src/main/java/decodes/hdb/algo/TimeWeightedAverageAlg.java
@@ -74,7 +74,7 @@ public class TimeWeightedAverageAlg
 	String flags;
 	Connection conn = null;
 	Date[] date_out = new Date[60];
-	Double[] value_out = Double.valueOf[60];
+	Double[] value_out = new Double[60];
 	int total_count;
 	int index;
 	double tally;
@@ -294,7 +294,7 @@ public class TimeWeightedAverageAlg
 		String status = null;
 //   getSDI method casted to int since it was changed sometime to a long, M. Bogner Aug 2012
 //   getSDI getValue method since it was changed to a Dbkey object for CP 5.3 project, M. Bogner March 2013
-                Integer sdi = new Integer( (int) getSDI("input").getValue());
+                Integer sdi = (int) getSDI("input").getValue();
 		RBASEUtils rbu = new RBASEUtils(dbobj,conn);
 		GregorianCalendar cal2 = new GregorianCalendar();
 		int calIntervalRoll = 0;

--- a/src/main/java/decodes/hdb/algo/VolumeToFlowAlg.java
+++ b/src/main/java/decodes/hdb/algo/VolumeToFlowAlg.java
@@ -266,7 +266,7 @@ public class VolumeToFlowAlg
 // mod 1.0.06 added int cast by M. Bogner Aug 2012 for the 3.0 CP upgrade project
 // mod 1.0.07 added new getValue method call by M. Bogner March 2013 for the 5.3 CP upgrade project
 // since surrogate keys (like SDI's) where changed to a DbKey class instead of a long
-		                Integer sdi = new Integer( (int) getSDI("input").getValue());
+		                Integer sdi = (int) getSDI("input").getValue();
 		                String dt_fmt = "dd-MMM-yyyy HH:mm";
 		 
 		RBASEUtils rbu = new RBASEUtils(dbobj,conn);

--- a/src/main/java/decodes/hdb/algo/VolumeToFlowAlg.java
+++ b/src/main/java/decodes/hdb/algo/VolumeToFlowAlg.java
@@ -331,7 +331,7 @@ public class VolumeToFlowAlg
 		                   }
 		   debug3("VolumeToFlowAlg: Derivation FLAGS: " + flags);
 		   if (flags != null) setHdbDerivationFlag(output,flags);
-		                   Double flow = new Double(dbobj.get("flow").toString());
+		                   Double flow = Double.valueOf(dbobj.get("flow").toString());
 		   //
 		                   /* added to allow users to automatically set the Validation column  */
 		                   if (validation_flag.length() > 0) setHdbValidationFlag(output,validation_flag.charAt(1));

--- a/src/main/java/decodes/hdb/dbutils/RBASEUtils.java
+++ b/src/main/java/decodes/hdb/dbutils/RBASEUtils.java
@@ -250,7 +250,7 @@ public class RBASEUtils
  
        conn = db.getConnection(do2);
 
-       Integer t_int = new Integer(minutes);
+       Integer t_int = minutes;
        query = "select to_char(trunc(to_date('31-DEC-1899')) + "
              + t_int.toString()
              + "/(60*24),'YYYYMONDD HH24:MI') dss_date from dual";
@@ -274,8 +274,8 @@ public class RBASEUtils
 
        conn = db.getConnection(do2);
 
-       Integer t_int = new Integer(modelId);
-       Integer ret_sdi = new Integer(-9999);
+       Integer t_int = modelId;
+       Integer ret_sdi = -9999;
 
        query = "select  site_datatype_id site_datatype_id from ref_dmi_data_map where "
              + "model_id = " + t_int.toString()
@@ -448,7 +448,10 @@ public class RBASEUtils
 
        if (debug) log.debug( this,"  " + query + "  :" + " PASSED EXTERNAL SDI GET");
 
-      if ((String)do2.get("site_datatype_id") != null && ((String)do2.get("site_datatype_id")).length() != 0) ret_sdi = new Integer ((String )do2.get("site_datatype_id")); 
+      if ((String)do2.get("site_datatype_id") != null && ((String)do2.get("site_datatype_id")).length() != 0)
+      {
+          ret_sdi = Integer.valueOf((String )do2.get("site_datatype_id")); 
+      }
 
        return ret_sdi;
 
@@ -457,5 +460,3 @@ public class RBASEUtils
 
 
 }  // end of RBASEUtils class
-
-

--- a/src/main/java/decodes/hdb/dbutils/RBASEUtils.java
+++ b/src/main/java/decodes/hdb/dbutils/RBASEUtils.java
@@ -287,8 +287,11 @@ public class RBASEUtils
 
        if (debug) log.debug( this,"  " + query + "  :" + " PASSED DMI_SDI GET");
 
-      if ((String)do2.get("site_datatype_id") != null && ((String)do2.get("site_datatype_id")).length() != 0) ret_sdi = new Integer ((String )do2.get("site_datatype_id")); 
-
+      if ((String)do2.get("site_datatype_id") != null 
+      && ((String)do2.get("site_datatype_id")).length() != 0)
+      {
+        ret_sdi = Integer.valueOf((String )do2.get("site_datatype_id")); 
+      }
        return ret_sdi;
  
     } // end of get_DMI_SDI method
@@ -428,7 +431,7 @@ public class RBASEUtils
 
        String query = null;
        String result = null;
-       Integer ret_sdi = new Integer(-9999);
+       Integer ret_sdi = -9999;
 
        // get the site_datatype_id
        query = "select edm.hdb_site_datatype_id site_datatype_id from hdb_ext_data_source eds , ref_ext_site_data_map edm "

--- a/src/main/java/decodes/platwiz/ScriptEditPanel.java
+++ b/src/main/java/decodes/platwiz/ScriptEditPanel.java
@@ -194,8 +194,7 @@ public class ScriptEditPanel extends JPanel
 					int tmIndex = p.transportMedia.indexOf(tm); 
 					if (tm != null)
 					{	
-						tm.channelNum = 
-							new Integer(chanNumFromRawMsg).intValue();
+						tm.channelNum = Integer.valueOf(chanNumFromRawMsg);
 						//Update the transportMedia
 						if (tmIndex != -1)
 							p.transportMedia.set(tmIndex, tm);						

--- a/src/main/java/decodes/routmon2/RoutingTableModel.java
+++ b/src/main/java/decodes/routmon2/RoutingTableModel.java
@@ -328,7 +328,7 @@ class RSColumnizer
 	{
 		switch(col)
 		{
-		case 0: return new Boolean(rsb.isEnabled());
+		case 0: return Boolean.valueOf(rsb.isEnabled());
 		case 1: return rsb.getScheduleEntry().getName().toLowerCase().endsWith("manual")
 					? (rsb.getRsName() + " (manual)") : rsb.getRsName();
 		case 2: return rsb.getAppName();

--- a/src/main/java/decodes/sql/DbKey.java
+++ b/src/main/java/decodes/sql/DbKey.java
@@ -89,19 +89,20 @@ public class DbKey
 			return NullKey;
 
 		// See if this key value is already created.
-		Long kv = new Long(keyValue);
-		DbKey ret = createdKeys.get(kv);
+		
+		DbKey ret = createdKeys.get(keyValue);
 		if (ret != null)
 		{
 			return ret;
 		}
 		// Not in key hash. Have to create new key.
 		if (createdKeys.size() >= MaxHashSize)
+		{
 			trimHash();
-		
-		ret = new DbKey(kv);
+		}		
+		ret = new DbKey(keyValue);
 		ret.createOrder = createCounter++;
-		createdKeys.put(kv, ret);
+		createdKeys.put(keyValue, ret);
 		return ret;
 	}
 	

--- a/src/main/java/decodes/tsdb/RecordRangeHandle.java
+++ b/src/main/java/decodes/tsdb/RecordRangeHandle.java
@@ -43,7 +43,10 @@ public class RecordRangeHandle
 	 * Adds a record number.
 	 * @param recnum the record number
 	 */
-	public void addRecNum(int recnum) { recnums.add(new Integer(recnum)); }
+	public void addRecNum(int recordNumber)
+	{
+		recnums.add(recordNumber);
+	}
 
 	/**
 	 * Returns a string containing comma-separated integer record numbers.

--- a/src/main/java/decodes/tsdb/algo/ExpressionParserAlgorithm.java
+++ b/src/main/java/decodes/tsdb/algo/ExpressionParserAlgorithm.java
@@ -290,9 +290,9 @@ public class ExpressionParserAlgorithm
 			symTab.remove(flagName);
 			if (!isMissing(inputVal))
 			{
-				symTab.addVariable(inputName, new Double(inputVal));
+				symTab.addVariable(inputName, Double.valueOf(inputVal));
 				int f = getInputFlagBits(inputName);
-				symTab.addVariable(flagName, new Double(f));
+				symTab.addVariable(flagName, Double.valueOf(f));
 
 				debug1("" + debugSdf.format(_timeSliceBaseTime) + " " + inputName + "=" + inputVal
 					+ ", " + flagName + "=0x" + Integer.toHexString(f));

--- a/src/main/java/decodes/tsdb/algo/jep/ConditionFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/ConditionFunction.java
@@ -55,7 +55,7 @@ public class ConditionFunction
 Logger.instance().info("condition is false, returning zero.");
 			// Return zero and don't evaluate the second expression, which is probably
 			// an assignment.
-			return new Double(0.0);
+			return Double.valueOf(0.0);
 		}
 		else // evaluate & return value of second arg
 			return evaluator.eval(node.jjtGetChild(1));

--- a/src/main/java/decodes/tsdb/algo/jep/DatchkFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/DatchkFunction.java
@@ -107,6 +107,6 @@ public class DatchkFunction
 					+ " is not a number '" + tv.getStringValue() + "'");
 			}
 		}
-		inStack.push(new Double(retFlags));
+		inStack.push(Double.valueOf(retFlags));
 	}
 }

--- a/src/main/java/decodes/tsdb/algo/jep/ElseFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/ElseFunction.java
@@ -41,18 +41,17 @@ public class ElseFunction
 	public Object evaluate(Node node, EvaluatorI evaluator) throws ParseException
 	{
 		if (!checkNumberOfParameters(node.jjtGetNumChildren()))
+		{
 			throw new ParseException("else function requires 1 argument!");
+		}
 		
 		if (ctx.getLastConditionFailed())
 		{
-//Logger.instance().info("executing the else arg");
 			return evaluator.eval(node.jjtGetChild(0));
 		}
 		else
 		{
-//Logger.instance().info("Else failed");
-			return new Double(0.0);
-	//throw new ParseException("Else failed");
+			return Double.valueOf(0.0);	
 		}
 	}
 }

--- a/src/main/java/decodes/tsdb/algo/jep/ExitFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/ExitFunction.java
@@ -32,6 +32,6 @@ public class ExitFunction
 		checkStack(inStack);
 		ctx.setExitCalled(true);
 		
-		inStack.push(new Double(0.0));
+		inStack.push(Double.valueOf(0.0));
 	}
 }

--- a/src/main/java/decodes/tsdb/algo/jep/GotoFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/GotoFunction.java
@@ -28,6 +28,6 @@ public class GotoFunction
 		checkStack(inStack);
 		String label = inStack.pop().toString();
 		ctx.setGotoLabel(label);
-		inStack.push(new Double(0.0));
+		inStack.push(Double.valueOf(0.0));
 	}
 }

--- a/src/main/java/decodes/tsdb/algo/jep/IsQuestionableFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/IsQuestionableFunction.java
@@ -32,10 +32,12 @@ public class IsQuestionableFunction
 		
 		Object o = inStack.pop().toString();
 		if (!(o instanceof Number))
+		{
 			throw new ParseException(funcName + " must be passed parmname.flags.");
-		int flags = (int)((Number)o).intValue();
+		}
+		int flags = ((Number)o).intValue();
 		inStack.push(
-			new Double(
+			Double.valueOf(
 				(flags & CwmsFlags.VALIDITY_MASK) == CwmsFlags.VALIDITY_QUESTIONABLE ? 1.0 : 0.0));
 	}
 }

--- a/src/main/java/decodes/tsdb/algo/jep/IsRejectedFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/IsRejectedFunction.java
@@ -32,11 +32,13 @@ public class IsRejectedFunction
 		
 		Object o = inStack.pop();
 		if (!(o instanceof Number))
+		{
 			throw new ParseException(funcName + " must be passed 'parmname.flags'. Value passed was: "
 				+ o.toString() + " with type " + o.getClass().getName());
-		int flags = (int)((Number)o).intValue();
+		}
+		int flags = ((Number)o).intValue();
 		inStack.push(
-			new Double(
+			Double.valueOf(
 				(flags & CwmsFlags.VALIDITY_MASK) == CwmsFlags.VALIDITY_REJECTED ? 1.0 : 0.0));
 	}
 }

--- a/src/main/java/decodes/tsdb/algo/jep/LogFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/LogFunction.java
@@ -45,6 +45,6 @@ public class LogFunction
 		default:
 			ctx.getAlgo().warning(logMsg);
 		}
-		inStack.push(new Double(0.0));
+		inStack.push(Double.valueOf(0.0));
 	}
 }

--- a/src/main/java/decodes/tsdb/algo/jep/OnErrorFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/OnErrorFunction.java
@@ -33,6 +33,6 @@ public class OnErrorFunction
 		checkStack(inStack);
 		String label = inStack.pop().toString();
 		ctx.setOnErrorLabel(label);
-		inStack.push(new Double(0.0));
+		inStack.push(Double.valueOf(0.0));
 	}
 }

--- a/src/main/java/decodes/tsdb/algo/jep/RatingFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/RatingFunction.java
@@ -90,7 +90,7 @@ public class RatingFunction
 			for(double v : valueSet)
 				sum += v;
 			Logger.instance().warning("TEST-MODE: No database, rating returning sum of all inputs=" + sum);
-			inStack.push(new Double(sum));
+			inStack.push(Double.valueOf(sum));
 			return;
 		}
 
@@ -102,8 +102,10 @@ public class RatingFunction
 			what = "performing rating";
 			double d = ratingSet.rateOne(valueSet, tsbt.getTime());
 			if (d == Const.UNDEFINED_DOUBLE)
+			{
 				throw new RatingException("input value(s) outside rating bounds.");
-			inStack.push(new Double(d));
+			}
+			inStack.push(Double.valueOf(d));
 		}
 		catch (RatingException ex)
 		{

--- a/src/main/java/decodes/tsdb/algo/jep/ScreeningFunction.java
+++ b/src/main/java/decodes/tsdb/algo/jep/ScreeningFunction.java
@@ -114,6 +114,6 @@ public class ScreeningFunction
 					+ " is not a number '" + tv.getStringValue() + "'");
 			}
 		}
-		inStack.push(new Double(retFlags));
+		inStack.push(Double.valueOf(retFlags));
 	}
 }

--- a/src/main/java/decodes/tsdb/procmonitor/AppInfoStatus.java
+++ b/src/main/java/decodes/tsdb/procmonitor/AppInfoStatus.java
@@ -53,7 +53,7 @@ public class AppInfoStatus
 	
 	private TsdbCompLock compLock = null;
 	
-	private Boolean retrieveEvents = new Boolean(false);
+	private Boolean retrieveEvents = false;
 	
 	private EventClient eventPollClient = null;
 	private ProcessMonitorFrame frame = null;

--- a/src/main/java/decodes/tsdb/test/JEPTest.java
+++ b/src/main/java/decodes/tsdb/test/JEPTest.java
@@ -21,196 +21,194 @@ import org.nfunk.jep.function.PostfixMathCommand;
 import decodes.tsdb.algo.jep.JepContext;
 
 public class JEPTest
-	implements Observer
+    implements Observer
 {
-//	JEP jep = new JEP();
-	
-	public void run()
-	{
-		JepContext jepContext = new JepContext(null, null);
-		JEP jep = jepContext.getParser();
-		
-//		jep.addStandardFunctions();
-//		jep.addStandardConstants();
-//		jep.setAllowAssignment(true);
-//		jep.setAllowUndeclared(true);
-//		jep.addFunction("lookupMeta", new LookupMeta());
-//		jep.addFunction("cond", new Condition());
-//		jep.addFunction("info", new Info());
-		jep.getSymbolTable().addObserver(this);
-		
-		jepContext.setOnErrorLabel(null);
-		int idx = 0;
-		while(true)
-		{
-			System.out.print("Enter expression: ");
-			String line = System.console().readLine();
-			jepContext.reset();
-			jepContext.setTimeSliceBaseTime(new Date());
-			jep.parseExpression(line);
-			Object value = jep.getValueAsObject();
+//    JEP jep = new JEP();
 
-			if (jep.hasError() || value == null)
-				System.out.println("Error: " + jep.getErrorInfo());
-			else
-			{
-				if (value != null)
-					System.out.println("Result type=" + value.getClass().getName());
-				System.out.println("Result=" + value);
-				if (jepContext.isExitCalled())
-				{
-					System.out.println("Exit called.");
-					break;
-				}
-				else if (jepContext.getLastConditionFailed())
-					System.out.println("Last condition failed");
-			}
-			
-			idx++;
-		}
+    public void run()
+    {
+        JepContext jepContext = new JepContext(null, null);
+        JEP jep = jepContext.getParser();
 
-	}
+//        jep.addStandardFunctions();
+//        jep.addStandardConstants();
+//        jep.setAllowAssignment(true);
+//        jep.setAllowUndeclared(true);
+//        jep.addFunction("lookupMeta", new LookupMeta());
+//        jep.addFunction("cond", new Condition());
+//        jep.addFunction("info", new Info());
+        jep.getSymbolTable().addObserver(this);
 
-	public static void main(String[] args)
-	{
-		new JEPTest().run();
+        jepContext.setOnErrorLabel(null);
+        int idx = 0;
+        while(true)
+        {
+            System.out.print("Enter expression: ");
+            String line = System.console().readLine();
+            jepContext.reset();
+            jepContext.setTimeSliceBaseTime(new Date());
+            jep.parseExpression(line);
+            Object value = jep.getValueAsObject();
 
-	}
+            if (jep.hasError() || value == null)
+                System.out.println("Error: " + jep.getErrorInfo());
+            else
+            {
+                if (value != null)
+                    System.out.println("Result type=" + value.getClass().getName());
+                System.out.println("Result=" + value);
+                if (jepContext.isExitCalled())
+                {
+                    System.out.println("Exit called.");
+                    break;
+                }
+                else if (jepContext.getLastConditionFailed())
+                    System.out.println("Last condition failed");
+            }
 
-	@Override
-	public void update(Observable o, Object arg)
-	{
+            idx++;
+        }
+
+    }
+
+    public static void main(String[] args)
+    {
+        new JEPTest().run();
+
+    }
+
+    @Override
+    public void update(Observable o, Object arg)
+    {
         if (o instanceof Variable)
             System.out.println("Var changed: o=" + o + ", arg=" + arg);
         else if(o instanceof SymbolTable.StObservable)
         {
-        	SymbolTable.StObservable obs = (SymbolTable.StObservable)o;
-        	System.out.println("New var: "+arg);
-        	System.out.println("Type of arg is " + arg.getClass().getName());
-        	Variable v = (Variable)arg;
-        	v.setValue(new Double(0.0));
-//        	jep.getSymbolTable().setVarValue(v.getName(), new Double(0.0));
+            SymbolTable.StObservable obs = (SymbolTable.StObservable)o;
+            System.out.println("New var: "+arg);
+            System.out.println("Type of arg is " + arg.getClass().getName());
+            Variable v = (Variable)arg;
+            v.setValue(Double.valueOf(0.0));
+//            jep.getSymbolTable().setVarValue(v.getName(), new Double(0.0));
 
-            // This line is vital to ensure that 
-            // any new variable created will be observed. 
+            // This line is vital to ensure that
+            // any new variable created will be observed.
            ((Variable) arg).addObserver(this);
         }
-	}
+    }
 }
 
 class LookupMeta extends PostfixMathCommand
 {
-	/**
-	 * Metadata params are Location and Param Name
-	 */
-	public LookupMeta()
-	{
-		numberOfParameters = 2;
-	}
-	
-	public void run(Stack inStack)
-		throws ParseException
-	{
-		System.out.println("lookupMeta, stack.size=" + inStack.size());
-		checkStack(inStack);
-		String paramName = inStack.pop().toString();
-		String locName = inStack.pop().toString();
-		
-		System.out.println("lookupMetaData(loc=" + locName 
-			+ ", parm=" + paramName + ", returning 123.45");
-		inStack.push(new Double(123.45));	
-	}
+    /**
+     * Metadata params are Location and Param Name
+     */
+    public LookupMeta()
+    {
+        numberOfParameters = 2;
+    }
+
+    public void run(Stack inStack)
+        throws ParseException
+    {
+        System.out.println("lookupMeta, stack.size=" + inStack.size());
+        checkStack(inStack);
+        String paramName = inStack.pop().toString();
+        String locName = inStack.pop().toString();
+
+        System.out.println("lookupMetaData(loc=" + locName
+            + ", parm=" + paramName + ", returning 123.45");
+        inStack.push(Double.valueOf(123.45));
+    }
 }
 
 class ConditionFailed extends ParseException
 {
-	public ConditionFailed(String msg)
-	{
-		super(msg);
-	}
+    public ConditionFailed(String msg)
+    {
+        super(msg);
+    }
 }
 
 class Condition
-	extends PostfixMathCommand
-	implements CallbackEvaluationI
+    extends PostfixMathCommand
+    implements CallbackEvaluationI
 {
-	public Condition()
-	{
-		super();
-		this.numberOfParameters = 2;
-	}
-	
-//	public Node process(Node node, Object data, ParserVisitor pv)
-//		throws ParseException
-//	{
+    public Condition()
+    {
+        super();
+        this.numberOfParameters = 2;
+    }
+
+//    public Node process(Node node, Object data, ParserVisitor pv)
+//        throws ParseException
+//    {
 //System.out.println("Condition.process called");
-//		return null;
-//	}
-	public boolean checkNumberOfParameters(int n)
-	{
-		return n == 2;
-	}
-	
-	@Override
-	public Object evaluate(Node node, EvaluatorI evaluator) throws ParseException
-	{
+//        return null;
+//    }
+    public boolean checkNumberOfParameters(int n)
+    {
+        return n == 2;
+    }
+
+    @Override
+    public Object evaluate(Node node, EvaluatorI evaluator) throws ParseException
+    {
 System.out.println("Condition.evaluate called");
-		if (!checkNumberOfParameters(node.jjtGetNumChildren()))
-			throw new ParseException("cond function requires 2 arguments!");
-		
-		// Evaluate the condition
-		Object condResult = evaluator.eval(node.jjtGetChild(0));
-		boolean tf = isTrue(condResult);
-		System.out.println("Condition.evaluate result is " + tf);
-		if (!tf)
-		{
+        if (!checkNumberOfParameters(node.jjtGetNumChildren()))
+            throw new ParseException("cond function requires 2 arguments!");
+
+        // Evaluate the condition
+        Object condResult = evaluator.eval(node.jjtGetChild(0));
+        boolean tf = isTrue(condResult);
+        System.out.println("Condition.evaluate result is " + tf);
+        if (!tf)
+        {
 System.out.println("false -- throwing ParseException");
-			throw new ParseException("Condition is false.");
-		}
-//			throw new ConditionFailed("Condition is false.");
-		else
-		{
+            throw new ParseException("Condition is false.");
+        }
+//            throw new ConditionFailed("Condition is false.");
+        else
+        {
 System.out.println("Evaluating second arg");
-			return evaluator.eval(node.jjtGetChild(1));
-		}
-	}
+            return evaluator.eval(node.jjtGetChild(1));
+        }
+    }
 
-	private boolean isTrue(Object result)
-		throws ParseException
-	{
-		if (result instanceof Boolean)
-			return (Boolean)result;
-		else if (result instanceof Number)
-		{
-			Double d = ((Number)result).doubleValue();
+    private boolean isTrue(Object result)
+        throws ParseException
+    {
+        if (result instanceof Boolean)
+            return (Boolean)result;
+        else if (result instanceof Number)
+        {
+            Double d = ((Number)result).doubleValue();
 System.out.println("result of condition is numeric: " + d);
-			return d < -0.0000001 || d > 0.0000001;
-		}
-		else if (result instanceof String)
-			return TextUtil.str2boolean((String)result);
+            return d < -0.0000001 || d > 0.0000001;
+        }
+        else if (result instanceof String)
+            return TextUtil.str2boolean((String)result);
 
-		else
-			throw new ParseException("Condition must result in boolean or number!");
-	}
+        else
+            throw new ParseException("Condition must result in boolean or number!");
+    }
 }
 
 class Info extends PostfixMathCommand
 {
-	public Info()
-	{
-		numberOfParameters = 1;
-	}
-	
-	public void run(Stack inStack)
-		throws ParseException
-	{
-		System.out.println("Info, stack.size=" + inStack.size());
-		checkStack(inStack);
-		String msg1 = inStack.pop().toString();
-	
-		System.out.println("info(msg1='" + msg1 + "')"); 
-		inStack.push(new Double(0.0));	
-	}
+    public Info()
+    {
+        numberOfParameters = 1;
+    }
+
+    public void run(Stack inStack)
+        throws ParseException
+    {
+        System.out.println("Info, stack.size=" + inStack.size());
+        checkStack(inStack);
+        String msg1 = inStack.pop().toString();
+
+        System.out.println("info(msg1='" + msg1 + "')");
+        inStack.push(Double.valueOf(0.0));
+    }
 }
-
-

--- a/src/main/java/ilex/cmdline/BooleanToken.java
+++ b/src/main/java/ilex/cmdline/BooleanToken.java
@@ -45,7 +45,7 @@ public class BooleanToken extends Token
 		          	    boolean def_value)
 	{
 		super(name, message, environment_variable, tokenOptions);
-		setDefaultValue(new Boolean(def_value));
+		setDefaultValue(Boolean.valueOf(def_value));
 	}
 
   	/** @return the empty String.  */
@@ -70,7 +70,7 @@ public class BooleanToken extends Token
 	}
 
 	public Object toObject(String lexeme) {
-		return new Boolean(true);
+		return Boolean.valueOf(true);
 	}
 
 	/** This returns false, since a boolean switch takes no arguments.  */

--- a/src/main/java/ilex/cmdline/IntegerToken.java
+++ b/src/main/java/ilex/cmdline/IntegerToken.java
@@ -44,7 +44,7 @@ public class IntegerToken extends Token
                         int def_value)
 	{
 		super(name, message, environment_variable, tokenOptions);
-		setDefaultValue(new Integer(def_value));
+		setDefaultValue(Integer.valueOf(def_value));
 	}
 
   	/** @return "<Int>"  */

--- a/src/main/java/ilex/gui/EditorMenuSet.java
+++ b/src/main/java/ilex/gui/EditorMenuSet.java
@@ -37,320 +37,340 @@ import javax.swing.ImageIcon;
 */
 public class EditorMenuSet
 {
-	private static ResourceBundle labels = MenuFrame.getLabels();
-	/**
-	* The constants defined here are combined in the constructor
-	* to enable specific actions. They are also used in getAction
-	* to retrieve a specific action object.
-	*/
-	public static final int NEW = 0x0001;
-	public static final int OPEN = 0x0002;
-	public static final int SAVE = 0x0004;
-	public static final int SAVEAS = 0x0008;
-	public static final int UNDO = 0x0010;
-	public static final int CUT = 0x0020;
-	public static final int COPY = 0x0040;
-	public static final int PASTE = 0x0080;
-	public static final int DELETE = 0x0100;
-	public static final int ALL = 0xffff;
-	
-	private static final int[] FILE_ACTIONS = {NEW,OPEN,SAVE,SAVEAS};
-	private static final int[] EDIT_ACTIONS = {UNDO,CUT,COPY,PASTE,DELETE};
-	
-	private Hashtable fileActions, editActions;
-	private Editor editor;
-	
-	/**
-	* Constructs an EditorMenuSet with all actions enabled.
-	* @param editor the editor
-	*/
-	public EditorMenuSet( Editor editor )
-	{
-		this(editor, ALL);
-	}
-	
-	/**
-	* Constructs an EditorMenuSet with specific actions.
-	* The mask should be acombination of the constants defined
-	* in this class.
-	* @param editor the editor
-	* @param mask the mask
-	*/
-	public EditorMenuSet( Editor editor, int mask )
-	{
-		this.editor = editor;
-		fileActions = new Hashtable();
-		editActions = new Hashtable();
-		if ((mask & NEW) != 0)
-			fileActions.put(new Integer(NEW), new NewAction(editor));
-		if ((mask & OPEN) != 0)
-			fileActions.put(new Integer(OPEN), new OpenAction(editor));
-		if ((mask & SAVE) != 0)
-			fileActions.put(new Integer(SAVE), new SaveAction(editor));
-		if ((mask & SAVEAS) != 0)
-			fileActions.put(new Integer(SAVEAS), new SaveAsAction(editor));
-		if ((mask & UNDO) != 0)
-			editActions.put(new Integer(UNDO), new UndoAction(editor));
-		if ((mask & CUT) != 0)
-			editActions.put(new Integer(CUT), new CutAction(editor));
-		if ((mask & COPY) != 0)
-			editActions.put(new Integer(COPY), new CopyAction(editor));
-		if ((mask & PASTE) != 0)
-			editActions.put(new Integer(PASTE), new PasteAction(editor));
-		if ((mask & DELETE) != 0)
-			editActions.put(new Integer(DELETE), new DeleteAction(editor));
-	}
-	
-	/**
-	* Returns the acttion associated with the specified operation code.
-	* Returns null if that code was not specified in the constructor.
-	* @param code one of constants defined in this class
-	* @return an action
-	*/
-	public AbstractAction getAction( int code )
-	{
-		Integer key = new Integer(code);
-		Object ret = fileActions.get(key);
-		if (ret == null)
-			ret = editActions.get(key);
-		return (AbstractAction)ret;
-	}
+    private static ResourceBundle labels = MenuFrame.getLabels();
+    /**
+    * The constants defined here are combined in the constructor
+    * to enable specific actions. They are also used in getAction
+    * to retrieve a specific action object.
+    */
+    public static final int NEW = 0x0001;
+    public static final int OPEN = 0x0002;
+    public static final int SAVE = 0x0004;
+    public static final int SAVEAS = 0x0008;
+    public static final int UNDO = 0x0010;
+    public static final int CUT = 0x0020;
+    public static final int COPY = 0x0040;
+    public static final int PASTE = 0x0080;
+    public static final int DELETE = 0x0100;
+    public static final int ALL = 0xffff;
 
-	/**
-	* @return the array of AbstractAction objects used in the File menu.
-	*/
-	public AbstractAction[] getFileActions( ) 
-	{
-		return getActions(fileActions, FILE_ACTIONS); 
-	}
+    private static final int[] FILE_ACTIONS = {NEW,OPEN,SAVE,SAVEAS};
+    private static final int[] EDIT_ACTIONS = {UNDO,CUT,COPY,PASTE,DELETE};
 
-	/**
-	* @return the array of AbstractAction objects used in the Edit menu.
-	*/
-	public AbstractAction[] getEditActions( ) 
-	{
-		return getActions(editActions, EDIT_ACTIONS);
-	}
-		
-	/**
-	* Returns actions given a set of codes.
-	* @param tbl the hash table
-	* @param codes the codes
-	* @return the actions
-	*/
-	private AbstractAction[] getActions( Hashtable tbl, int[] codes )
-	{
-		int sz = tbl.size();
-		AbstractAction[] ret = new AbstractAction[sz];
-		for(int i=0; i<sz; i++)
-			ret[i] = (AbstractAction)tbl.get(new Integer(codes[i]));
-		return ret;
-	}
+    private Hashtable<Integer,AbstractAction> fileActions, editActions;
+    private Editor editor;
+
+    /**
+    * Constructs an EditorMenuSet with all actions enabled.
+    * @param editor the editor
+    */
+    public EditorMenuSet( Editor editor )
+    {
+        this(editor, ALL);
+    }
+
+    /**
+    * Constructs an EditorMenuSet with specific actions.
+    * The mask should be acombination of the constants defined
+    * in this class.
+    * @param editor the editor
+    * @param mask the mask
+    */
+    public EditorMenuSet( Editor editor, int mask )
+    {
+        this.editor = editor;
+        fileActions = new Hashtable<>();
+        editActions = new Hashtable<>();
+        if ((mask & NEW) != 0)
+        {
+            fileActions.put(NEW, new NewAction(editor));
+        }
+        if ((mask & OPEN) != 0)
+        {
+            fileActions.put(OPEN, new OpenAction(editor));
+        }
+        if ((mask & SAVE) != 0)
+        {
+            fileActions.put(SAVE, new SaveAction(editor));
+        }
+        if ((mask & SAVEAS) != 0)
+        {
+            fileActions.put(SAVEAS, new SaveAsAction(editor));
+        }
+        if ((mask & UNDO) != 0)
+        {
+            editActions.put(UNDO, new UndoAction(editor));
+        }
+        if ((mask & CUT) != 0)
+        {
+            editActions.put(CUT, new CutAction(editor));
+        }
+        if ((mask & COPY) != 0)
+        {
+            editActions.put(COPY, new CopyAction(editor));
+        }
+        if ((mask & PASTE) != 0)
+        {
+            editActions.put(PASTE, new PasteAction(editor));
+        }
+        if ((mask & DELETE) != 0)
+        {
+            editActions.put(DELETE, new DeleteAction(editor));
+        }
+    }
+
+    /**
+    * Returns the acttion associated with the specified operation code.
+    * Returns null if that code was not specified in the constructor.
+    * @param code one of constants defined in this class
+    * @return an action
+    */
+    public AbstractAction getAction( int code )
+    {
+        AbstractAction ret = fileActions.get(code);
+        if (ret == null)
+        {
+            ret = editActions.get(code);
+        }
+        return ret;
+    }
+
+    /**
+    * @return the array of AbstractAction objects used in the File menu.
+    */
+    public AbstractAction[] getFileActions( )
+    {
+        return getActions(fileActions, FILE_ACTIONS);
+    }
+
+    /**
+    * @return the array of AbstractAction objects used in the Edit menu.
+    */
+    public AbstractAction[] getEditActions( )
+    {
+        return getActions(editActions, EDIT_ACTIONS);
+    }
+
+    /**
+    * Returns actions given a set of codes.
+    * @param tbl the hash table
+    * @param codes the codes
+    * @return the actions
+    */
+    private AbstractAction[] getActions( Hashtable<Integer,AbstractAction> tbl, int[] codes )
+    {
+        int sz = tbl.size();
+        AbstractAction[] ret = new AbstractAction[sz];
+        for(int i=0; i<sz; i++)
+        {
+            ret[i] = tbl.get(codes[i]);
+        }
+        return ret;
+    }
 }
 
 abstract class EditorMenuSetAction extends AbstractAction
 {
-	protected Editor editor;
-	
-	/**
-	* @param editor
-	* @param text
-	* @param iconfile
-	*/
-	EditorMenuSetAction( Editor editor, String text, String iconfile )
-	{
-		super(text, new ImageIcon(iconfile));
-		this.editor = editor;
-	}
-	
-	/**
-	* @param editor
-	* @param text
-	*/
-	EditorMenuSetAction( Editor editor, String text )
-	{
-		super(text);
-		this.editor = editor;
-	}
+    protected Editor editor;
+
+    /**
+    * @param editor
+    * @param text
+    * @param iconfile
+    */
+    EditorMenuSetAction( Editor editor, String text, String iconfile )
+    {
+        super(text, new ImageIcon(iconfile));
+        this.editor = editor;
+    }
+
+    /**
+    * @param editor
+    * @param text
+    */
+    EditorMenuSetAction( Editor editor, String text )
+    {
+        super(text);
+        this.editor = editor;
+    }
 }
 
 class NewAction extends EditorMenuSetAction
 {
-	private static ResourceBundle labels = MenuFrame.getLabels();
-	/**
-	* @param editor
-	*/
-	NewAction( Editor editor )
-	{
-		super(editor, labels.getString("EditorMenuSet.exit"), "new.gif");
-	}
-	
-	/**
-	* @param ae
-	*/
-	public void actionPerformed( ActionEvent ae )
-	{
-		editor.newPress();
-	}
+    private static ResourceBundle labels = MenuFrame.getLabels();
+    /**
+    * @param editor
+    */
+    NewAction( Editor editor )
+    {
+        super(editor, labels.getString("EditorMenuSet.exit"), "new.gif");
+    }
+
+    /**
+    * @param ae
+    */
+    public void actionPerformed( ActionEvent ae )
+    {
+        editor.newPress();
+    }
 }
 
 class OpenAction extends EditorMenuSetAction
 {
-	private static ResourceBundle labels = MenuFrame.getLabels();
-	/**
-	* @param editor
-	*/
-	OpenAction( Editor editor )
-	{
-		super(editor, labels.getString("EditorMenuSet.open"), "open.gif");
-	}
-	
-	/**
-	* @param ae
-	*/
-	public void actionPerformed( ActionEvent ae )
-	{
-		editor.openPress();
-	}
+    private static ResourceBundle labels = MenuFrame.getLabels();
+    /**
+    * @param editor
+    */
+    OpenAction( Editor editor )
+    {
+        super(editor, labels.getString("EditorMenuSet.open"), "open.gif");
+    }
+
+    /**
+    * @param ae
+    */
+    public void actionPerformed( ActionEvent ae )
+    {
+        editor.openPress();
+    }
 }
 
 class SaveAction extends EditorMenuSetAction
 {
-	private static ResourceBundle labels = MenuFrame.getLabels();
-	/**
-	* @param editor
-	*/
-	SaveAction( Editor editor )
-	{
-		super(editor, labels.getString("EditorMenuSet.save"), "save.gif");
-	}
-	
-	/**
-	* @param ae
-	*/
-	public void actionPerformed( ActionEvent ae )
-	{
-		editor.savePress();
-	}
+    private static ResourceBundle labels = MenuFrame.getLabels();
+    /**
+    * @param editor
+    */
+    SaveAction( Editor editor )
+    {
+        super(editor, labels.getString("EditorMenuSet.save"), "save.gif");
+    }
+
+    /**
+    * @param ae
+    */
+    public void actionPerformed( ActionEvent ae )
+    {
+        editor.savePress();
+    }
 }
 
 class SaveAsAction extends EditorMenuSetAction
 {
-	private static ResourceBundle labels = MenuFrame.getLabels();
-	/**
-	* @param editor
-	*/
-	SaveAsAction( Editor editor )
-	{
-		super(editor, labels.getString("EditorMenuSet.saveAs"));
-	}
-	
-	/**
-	* @param ae
-	*/
-	public void actionPerformed( ActionEvent ae )
-	{
-		editor.saveAsPress();
-	}
+    private static ResourceBundle labels = MenuFrame.getLabels();
+    /**
+    * @param editor
+    */
+    SaveAsAction( Editor editor )
+    {
+        super(editor, labels.getString("EditorMenuSet.saveAs"));
+    }
+
+    /**
+    * @param ae
+    */
+    public void actionPerformed( ActionEvent ae )
+    {
+        editor.saveAsPress();
+    }
 }
 
 class UndoAction extends EditorMenuSetAction
 {
-	private static ResourceBundle labels = MenuFrame.getLabels();
-	/**
-	* @param editor
-	*/
-	UndoAction( Editor editor )
-	{
-		super(editor, labels.getString("EditorMenuSet.undo"));
-	}
-	
-	/**
-	* @param ae
-	*/
-	public void actionPerformed( ActionEvent ae )
-	{
-		editor.undoPress();
-	}
+    private static ResourceBundle labels = MenuFrame.getLabels();
+    /**
+    * @param editor
+    */
+    UndoAction( Editor editor )
+    {
+        super(editor, labels.getString("EditorMenuSet.undo"));
+    }
+
+    /**
+    * @param ae
+    */
+    public void actionPerformed( ActionEvent ae )
+    {
+        editor.undoPress();
+    }
 }
 
 class CutAction extends EditorMenuSetAction
 {
-	private static ResourceBundle labels = MenuFrame.getLabels();
-	/**
-	* @param editor
-	*/
-	CutAction( Editor editor )
-	{
-		super(editor, labels.getString("EditorMenuSet.cut"), "cut.gif");
-	}
-	
-	/**
-	* @param ae
-	*/
-	public void actionPerformed( ActionEvent ae )
-	{
-		editor.cutPress();
-	}
+    private static ResourceBundle labels = MenuFrame.getLabels();
+    /**
+    * @param editor
+    */
+    CutAction( Editor editor )
+    {
+        super(editor, labels.getString("EditorMenuSet.cut"), "cut.gif");
+    }
+
+    /**
+    * @param ae
+    */
+    public void actionPerformed( ActionEvent ae )
+    {
+        editor.cutPress();
+    }
 }
 
 class CopyAction extends EditorMenuSetAction
 {
-	private static ResourceBundle labels = MenuFrame.getLabels();
-	/**
-	* @param editor
-	*/
-	CopyAction( Editor editor )
-	{
-		super(editor, labels.getString("EditorMenuSet.copy"), "copy.gif");
-	}
-	
-	/**
-	* @param ae
-	*/
-	public void actionPerformed( ActionEvent ae )
-	{
-		editor.copyPress();
-	}
+    private static ResourceBundle labels = MenuFrame.getLabels();
+    /**
+    * @param editor
+    */
+    CopyAction( Editor editor )
+    {
+        super(editor, labels.getString("EditorMenuSet.copy"), "copy.gif");
+    }
+
+    /**
+    * @param ae
+    */
+    public void actionPerformed( ActionEvent ae )
+    {
+        editor.copyPress();
+    }
 }
 
 class PasteAction extends EditorMenuSetAction
 {
-	private static ResourceBundle labels = MenuFrame.getLabels();
-	/**
-	* @param editor
-	*/
-	PasteAction( Editor editor )
-	{
-		super(editor, labels.getString("EditorMenuSet.paste"), "paste.gif");
-	}
-	
-	/**
-	* @param ae
-	*/
-	public void actionPerformed( ActionEvent ae )
-	{
-		editor.pastePress();
-	}
+    private static ResourceBundle labels = MenuFrame.getLabels();
+    /**
+    * @param editor
+    */
+    PasteAction( Editor editor )
+    {
+        super(editor, labels.getString("EditorMenuSet.paste"), "paste.gif");
+    }
+
+    /**
+    * @param ae
+    */
+    public void actionPerformed( ActionEvent ae )
+    {
+        editor.pastePress();
+    }
 }
 
 class DeleteAction extends EditorMenuSetAction
 {
-	private static ResourceBundle labels = MenuFrame.getLabels();
-	/**
-	* @param editor
-	*/
-	DeleteAction( Editor editor )
-	{
-		super(editor, labels.getString("EditorMenuSet.delete"));
-	}
-	
-	/**
-	* @param ae
-	*/
-	public void actionPerformed( ActionEvent ae )
-	{
-		editor.deletePress();
-	}
-}
+    private static ResourceBundle labels = MenuFrame.getLabels();
+    /**
+    * @param editor
+    */
+    DeleteAction( Editor editor )
+    {
+        super(editor, labels.getString("EditorMenuSet.delete"));
+    }
 
+    /**
+    * @param ae
+    */
+    public void actionPerformed( ActionEvent ae )
+    {
+        editor.deletePress();
+    }
+}

--- a/src/main/java/ilex/util/BeanUtil.java
+++ b/src/main/java/ilex/util/BeanUtil.java
@@ -13,109 +13,96 @@ import java.util.TimeZone;
  */
 public class BeanUtil
 {
-	public static SimpleDateFormat sdf = new SimpleDateFormat(
-		"yyyy/MM/dd-HH:mm:ss");
-	static { sdf.setTimeZone(TimeZone.getTimeZone("UTC")); }
-	
-	/**
-	 * Calls a bean's setXXX method through reflection. Intended for setting
-	 * bean attributes from a properties file where you have property names
-	 * and string values.
-	 * <p>
-	 * Look for a matching 'set' method for the passed name. Examine the method's
-	 * argument type and convert the value if necessary before calling the set 
-	 * method.
-	 * @param bean the bean object
-	 * @param name the attribute name (non-case sensitive)
-	 * @param value the attribute value as a string
-	 * @return true if matching set method called, false if not.
-	 */
-	public static boolean callSetMethod(Object bean, String name, String value)
-	{
-		Class beanCls = bean.getClass();
-		Method methods[] = beanCls.getDeclaredMethods();
-		
-//System.out.println("bean's class is '" + beanCls.getName() + "'");
-//System.out.println("bean has " + methods.length + " declared methods.");
-//System.out.println("name='" + name + "' value='" + value + "'");
+    public static SimpleDateFormat sdf = new SimpleDateFormat(
+        "yyyy/MM/dd-HH:mm:ss");
+    static { sdf.setTimeZone(TimeZone.getTimeZone("UTC")); }
 
-		// value is always string so class is "java.lang.String"
+    /**
+     * Calls a bean's setXXX method through reflection. Intended for setting
+     * bean attributes from a properties file where you have property names
+     * and string values.
+     * <p>
+     * Look for a matching 'set' method for the passed name. Examine the method's
+     * argument type and convert the value if necessary before calling the set
+     * method.
+     * @param bean the bean object
+     * @param name the attribute name (non-case sensitive)
+     * @param value the attribute value as a string
+     * @return true if matching set method called, false if not.
+     */
+    public static boolean callSetMethod(Object bean, String name, String value)
+    {
+        Class beanCls = bean.getClass();
+        Method methods[] = beanCls.getDeclaredMethods();
 
-		for(Method m : methods)
-		{
-			String mname = m.getName();
-			if (!Modifier.isPublic(m.getModifiers()))
-			{
-//System.out.println("Skipping method " + mname + " because not public");
-				continue;
-			}
-			Class argtypes[] = m.getParameterTypes();
-//System.out.println("Checking method '" + mname + "' with " + argtypes.length + " args.");
-			if (argtypes.length != 1)
-			{
-//System.out.println("Skipping method with " + argtypes.length + " args.");
-				continue;
-			}
-//System.out.println("methods arg is of type '" + argtypes[0].getName() + "'");
-			
-			if (mname.equalsIgnoreCase("set" + name))
-			{
-				Object arglist[] = new Object[1];
-				String atype = argtypes[0].getName();
-//System.out.println("Found matching method '" + mname + "'");
-				if (atype.equals("java.lang.String"))
-					arglist[0] = value;
-				else if (atype.equals("int") || atype.equals("java.lang.Integer"))
-				{
-					try { arglist[0] = new Integer(Integer.parseInt(value)); }
-					catch(NumberFormatException ex)
-					{
-//System.out.println("Method requires int but non-integer was passed.");
-						return false;
-					}
-				}
-				else if (atype.equals("boolean") || atype.equals("java.lang.Boolean"))
-					arglist[0] = TextUtil.str2boolean(value);
-				else if (atype.equals("java.util.Date"))
-				{
-					try { arglist[0] = sdf.parse(value); }
-					catch(Exception ex)
-					{
-//System.out.println("Parse exception for date '" + value + "'");
-						return false;
-					}
-				}	
-				try
-				{
-					m.invoke(bean, arglist);
-					return true;
-				}
-				catch (Exception ex)
-				{
-					System.err.println(ex.toString());
-				}
-			}
-		}
-		return false;
-	}
-	
+        // value is always string so class is "java.lang.String"
 
-	public static void main(String args[])
-	{
-		testbean b = new testbean();
-		callSetMethod(b, "intval", "123456");
-		callSetMethod(b, "BOOLVAL", "false");
-		callSetMethod(b, "stringval", "this is a string");
-		callSetMethod(b, "dateval", "2010/04/15-12:00:00");
-	}
+        for(Method m : methods)
+        {
+            String mname = m.getName();
+            if (!Modifier.isPublic(m.getModifiers()))
+            {
+                continue;
+            }
+            Class argtypes[] = m.getParameterTypes();
+            if (argtypes.length != 1)
+            {
+                continue;
+            }
+
+            if (mname.equalsIgnoreCase("set" + name))
+            {
+                Object arglist[] = new Object[1];
+                String atype = argtypes[0].getName();
+                if (atype.equals("java.lang.String"))
+                    arglist[0] = value;
+                else if (atype.equals("int") || atype.equals("java.lang.Integer"))
+                {
+                    try { arglist[0] = Integer.valueOf(value); }
+                    catch(NumberFormatException ex)
+                    {
+                        return false;
+                    }
+                }
+                else if (atype.equals("boolean") || atype.equals("java.lang.Boolean"))
+                    arglist[0] = TextUtil.str2boolean(value);
+                else if (atype.equals("java.util.Date"))
+                {
+                    try { arglist[0] = sdf.parse(value); }
+                    catch(Exception ex)
+                    {
+                        return false;
+                    }
+                }
+                try
+                {
+                    m.invoke(bean, arglist);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    System.err.println(ex.toString());
+                }
+            }
+        }
+        return false;
+    }
+
+
+    public static void main(String args[])
+    {
+        testbean b = new testbean();
+        callSetMethod(b, "intval", "123456");
+        callSetMethod(b, "BOOLVAL", "false");
+        callSetMethod(b, "stringval", "this is a string");
+        callSetMethod(b, "dateval", "2010/04/15-12:00:00");
+    }
 }
 class testbean
 {
-	private void setIntval(float f) {}
-	public void setIntVAL(int i1, int i2) { }
-	public void setIntval(Integer i) { System.out.println("Setting intval to " + i); }
-	public void setBoolVal(Boolean b) { System.out.println("Setting boolval to " + b); }
-	public void setStringVal(String s) { System.out.println("Setting stringval to " + s); }
-	public void setDateVal(Date d) { System.out.println("Setting dateval to " 
-		+ BeanUtil.sdf.format(d)); }
+    public void setIntVAL(int i1, int i2) { }
+    public void setIntval(Integer i) { System.out.println("Setting intval to " + i); }
+    public void setBoolVal(Boolean b) { System.out.println("Setting boolval to " + b); }
+    public void setStringVal(String s) { System.out.println("Setting stringval to " + s); }
+    public void setDateVal(Date d) { System.out.println("Setting dateval to " + BeanUtil.sdf.format(d)); }
 }

--- a/src/main/java/lrgs/drgsrecv/DrgsRecvMsgThread.java
+++ b/src/main/java/lrgs/drgsrecv/DrgsRecvMsgThread.java
@@ -1251,7 +1251,7 @@ Logger.instance().debug3("Looking for property '" + s + "'");
 		if (!cfgFile.canRead())
 			log(Logger.E_DEBUG1, DrgsRecv.EVT_BAD_CONFIG,
 				"Cannot read channel config '" + cfgFileName + "'");
-		Vector chanvec = new Vector();
+		Vector<Integer> chanvec = new Vector<>();
 		BufferedReader br = null;
 		try
 		{
@@ -1272,7 +1272,7 @@ Logger.instance().debug3("Looking for property '" + s + "'");
 					{
 						int chan = Integer.parseInt(cs);
 						if (chan > 0)
-							chanvec.add(new Integer(chan));
+							chanvec.add(chan);
 					}
 					catch(Exception ex) {}
 				}
@@ -1283,12 +1283,16 @@ Logger.instance().debug3("Looking for property '" + s + "'");
 			{
 				chanArray = new int[chanvec.size()];
 				for(int i=0; i<chanArray.length; i++)
+				{
 					chanArray[i] = ((Integer)chanvec.get(i)).intValue();
+				}
 			}
 			Logger.instance().debug1("DRGS " + getName() + " monitoring "
 				+ chanArray.length + " channels: ");
 			for(int i=0; i<chanArray.length; i++)
+			{
 				Logger.instance().debug1("" + chanArray[i]);
+			}
 					
 		}
 		catch(IOException ex)
@@ -1384,4 +1388,3 @@ class BadHeader extends Exception
 {
 	public BadHeader(String s) { super(s); }
 }
-

--- a/src/main/java/lrgs/rtstat/RtSummaryStat.java
+++ b/src/main/java/lrgs/rtstat/RtSummaryStat.java
@@ -26,7 +26,7 @@ public class RtSummaryStat
 	//Construct the application
 	public RtSummaryStat(String args[])
 	{
-		cmdLineArgs.scan_arg.setDefaultValue(new Integer(30));
+		cmdLineArgs.scan_arg.setDefaultValue(Integer.valueOf(30));
 		cmdLineArgs.parseArgs(args);
 		getMyLabelDescriptions();
 		final RtSummaryStatFrame frame = new RtSummaryStatFrame(


### PR DESCRIPTION
## Problem Description

I got sick of deprecation warnings from the compiler.

## Solution

Migrate away from `new Integer` or `new Double` to each ".valueOf". Additionally Java 8 correctly handles box/unbox of the primitive and object times.

No function change. Did add type to a Vector and HashArray.
Some formatting changes for clarity where it seemed appropriate.

## how you tested the change

Covered by integration tests (generally). But if anyone has something specific that you think I might have missed let me know and I'll test specifically.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
