### PR TITLE
Correct sequencing for GUI login.

### DIFF
--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
@@ -809,19 +809,21 @@ public class CwmsTimeSeriesDb
 	{
 		String dbUri = this.dbUri != null ? this.dbUri : DecodesSettings.instance().editDatabaseLocation;
 
-		String username = credentials.getProperty("username");
-		String password = credentials.getProperty("password");
-
-		CwmsGuiLogin cgl = CwmsGuiLogin.instance();
-		if (DecodesInterface.isGUI())
-		{
+		String username = null;
+		String password = null;
+		CwmsGuiLogin cgl = null;
+		if (credentials == null && DecodesInterface.isGUI())
+		{			
+			cgl = CwmsGuiLogin.instance();
 			try
 			{
 				if (!cgl.isLoginSuccess())
 				{
 					cgl.doLogin(null);
 					if (!cgl.isLoginSuccess()) // user hit cancel
+					{
 						throw new BadConnectException("Login aborted by user.");
+					}
 				}
 				username = cgl.getUserName();
 				password = new String(cgl.getPassword());
@@ -831,6 +833,15 @@ public class CwmsTimeSeriesDb
 				throw new BadConnectException(
 					"Cannot display login dialog: " + ex);
 			}
+		}
+		else if(credentials == null)
+		{
+			throw new BadConnectException("Cannot connect to CWMS without credentials.");
+		}
+		else
+		{	// use the provided credentials
+			username = credentials.getProperty("username");
+			password = credentials.getProperty("password");
 		}
 
 		// MJM 2018-12-05 The new HEC/RMA connection facility requires that office ID
@@ -861,7 +872,10 @@ public class CwmsTimeSeriesDb
 				postConnectInit(appName, conn); // Make sure the versions and such are set
 				setupKeyGenerator();
 
-				cgl.setLoginSuccess(true);
+				if(cgl!=null)
+				{
+					cgl.setLoginSuccess(true);
+				}
 
 				try
 				{


### PR DESCRIPTION
## Problem Description

After release we discovered that I did not account for the changes with the AuthService correctly leading to a null pointer exception.

## Solution

A quick fix to account for when to pop up the GUI for CWMS users.

Long term I don't think this check should be in the individual TimeSeriesDb implementations. I will investigate moving this to the auth service mechanism, or at least in the methods that call TimeseriesDb::connect implementations.

## how you tested the change

Manually running dbedit and compedit to verify operation.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
