### PR TITLE
Make sure tests actually fail the build if they fail.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -143,6 +143,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
         <echo message="platform path: ${platform_path}"/>
         <mkdir dir="${build.dir}/test-results"/>
+        <mkdir dir="${build.dir}/test-tmp"/>
         <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="test.failed">
             <classpath refid="test.classpath"/>
             <classpath refid="runtime.classpath"/>
@@ -157,6 +158,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
             <testclasses outputdir="${build.dir}/test-results">
                 <fork>
                     <jvmarg value="-Dbuild.dir=${build.dir}"/>
+                    <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-tmp"/>
                     <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
                 </fork>
                 <fileset dir="${build.test.classes}"/>
@@ -183,6 +185,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
             description="Run the integration test suite with available implementations.">
         <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
         <mkdir dir="${build.dir}/test-integration/results"/>
+        <mkdir dir="${build.dir}/test-integration/tmp"/>
         <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="integration.failed">
             <classpath refid="test.classpath"/>
             <classpath refid="runtime.classpath"/>
@@ -196,6 +199,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
             <testclasses outputdir="${build.dir}/test-integration/results">
                 <fork>
                     <jvmarg value="-Dbuild.dir=${build.dir}"/>
+                    <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-integration/tmp"/>
                     <jvmarg value="-Dresource.dir=${build.test-integration.resources}"/>
                     <jvmarg value="-DDCSTOOL_HOME=${stage.dir}"/>
                     <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>

--- a/build.xml
+++ b/build.xml
@@ -143,7 +143,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
         <echo message="platform path: ${platform_path}"/>
         <mkdir dir="${build.dir}/test-results"/>
-        <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="integration.failed">
+        <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="test.failed">
             <classpath refid="test.classpath"/>
             <classpath refid="runtime.classpath"/>
             <classpath refid="junit.platform.libs.classpath"/>

--- a/src/test/java/org/opendcs/authentication/UserAuthFileTest.java
+++ b/src/test/java/org/opendcs/authentication/UserAuthFileTest.java
@@ -19,6 +19,7 @@ public class UserAuthFileTest
     @Test
     public void test_user_auth_file_default(@TempDir Path configDir) throws Exception
     {
+        System.out.println(configDir.resolve("test.txt").toString());
         final String USERNAME = "Testuser";
         final String PASSWORD = "Testpassword";
         File uaf = configDir.resolve("uaf.txt").toFile();
@@ -42,7 +43,7 @@ public class UserAuthFileTest
     {
         final String badAuthTypeName = "BAD_AUTH_TYPE_NAME:location_doesn't_matter";
         assertThrows( AuthException.class, () -> {
-            final AuthSource source = AuthSourceService.getFromString(badAuthTypeName);            
+            final AuthSource source = AuthSourceService.getFromString(badAuthTypeName);
         });
     }
 }

--- a/src/test/java/org/opendcs/authentication/UserAuthFileTest.java
+++ b/src/test/java/org/opendcs/authentication/UserAuthFileTest.java
@@ -19,7 +19,6 @@ public class UserAuthFileTest
     @Test
     public void test_user_auth_file_default(@TempDir Path configDir) throws Exception
     {
-        System.out.println(configDir.resolve("test.txt").toString());
         final String USERNAME = "Testuser";
         final String PASSWORD = "Testpassword";
         File uaf = configDir.resolve("uaf.txt").toFile();


### PR DESCRIPTION
## Problem Description


<!-- if you are referencing a specific issue a problem description is not required -->
while testing something I discovered that I copy pasted and forgot to change in one location a variable required for the `ant test` command to actually fail the build properly.

## Solution

Set test failure property variable to the correct value.

## how you tested the change

A test that was failing didn't fail the build. Once the property was correct the build failed as expected for that code.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
