### PR TITLE
Computation Editor - computations tab list sorting fix.

### DIFF
--- a/src/main/java/decodes/tsdb/compedit/ComputationsListPanel.java
+++ b/src/main/java/decodes/tsdb/compedit/ComputationsListPanel.java
@@ -155,13 +155,14 @@ public class ComputationsListPanel extends ListPanel
 	protected void doOpen()
 	{
 		int r = compListTable.getSelectedRow();
-		if (r == -1)
+		int rowModel = compListTable.convertRowIndexToModel(r);
+		if (rowModel== -1)
 		{
 			parentFrame.showError(
 				compLabels.getString("ComputationsFilterPanel.OpenError"));
 			return;
 		}
-		ComputationInList dc = (ComputationInList)compListTableModel.getRowObject(r);
+		ComputationInList dc = (ComputationInList)compListTableModel.getRowObject(rowModel);
 		ComputationDAI computationDAO = tsdb.makeComputationDAO();
 		try
 		{

--- a/src/main/java/decodes/tsdb/groupedit/TsGroupListPanel.java
+++ b/src/main/java/decodes/tsdb/groupedit/TsGroupListPanel.java
@@ -175,7 +175,10 @@ public class TsGroupListPanel extends JPanel
 		int r = tsGroupsListTable.getSelectedRow();
 		if (r == -1)
 			return null;
-		return model.getTsGroupAt(r);
+		//Get the correct selected row from the model
+		int rowModel = this.tsGroupsListTable.convertRowIndexToModel(r);
+		TsGroupsSelectTableModel model = (TsGroupsSelectTableModel) tsGroupsListTable.getModel();
+		return model.getTsGroupAt(rowModel);
 	}
 
 	public int[] getSelectedRows()

--- a/src/main/java/decodes/tsdb/groupedit/TsListSelectPanel.java
+++ b/src/main/java/decodes/tsdb/groupedit/TsListSelectPanel.java
@@ -193,7 +193,8 @@ public class TsListSelectPanel extends JPanel
 		int idx[] = tsIdListTable.getSelectedRows();
 		TimeSeriesIdentifier ret[] = new TimeSeriesIdentifier[idx.length];
 		for (int i = 0; i < idx.length; i++)
-			ret[i] = model.getTSIDAt(idx[i]);
+			//Get the correct row from the table model
+			ret[i] = model.getTSIDAt(tsIdListTable.convertRowIndexToModel(idx[i]));
 		return ret;
 	}
 


### PR DESCRIPTION
## Problem Description
Resolves: Computation Editor - Computations Tab - sorting doesn't fully refresh list #252
<!-- if your PR does not address an open issue you can remove this line -->
Fixes # 252 Computations Tab - sorting doesn't fully refresh list

## Solution
Updated the table lists to pull from the table model list.  This will get the correct selected row when the table is filtered or sorted.

## how you tested the change
Test steps stated in issue #252

## Where the following done:

- [y] Tests. Check all that apply:
   - [n] Unit tests created or modified that run during ant test.
   - [n] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [n] Test procedure descriptions for manual testing
- [y] Was relevant documentation updated?
- [n] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
