### PR TITLE
Allow the LoginDialog to be an AuthSource and implement our first GUI…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,11 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           ant integration-test -D"no.docs=true"
+      - name: Gui Tests
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          apt install xvfb
+          xvfb-run ant gui-test -D"no.docs=true"
       - name: Documentation and Create installer jar
         run: |
           ant opendcs
@@ -44,7 +49,7 @@ jobs:
           name: test-results-${{matrix.platform}}
           path: |
             build/reports/**
-            /tmp/config**
+            build/tmp/config**
 #docker-images:
 #  runs-on: ubuntu-latest
 #  steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Gui Tests
         if: matrix.platform == 'ubuntu-latest'
         run: |
-          apt install xvfb
+          sudo apt install xvfb
           xvfb-run ant gui-test -D"no.docs=true"
       - name: Documentation and Create installer jar
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           name: test-results-${{matrix.platform}}
           path: |
             build/reports/**
-            build/tmp/config**
+            build/test-integration/tmp/configs**
 #docker-images:
 #  runs-on: ubuntu-latest
 #  steps:

--- a/build.xml
+++ b/build.xml
@@ -138,6 +138,25 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         </sync>
     </target>
 
+    <target name="compile-test-gui" depends="jar,test,common.resolve,common.resolve.build">
+        <mkdir dir="${build.test-gui.classes}"/>
+        <javac debug="true" destdir="${build.test-gui.classes}"
+            target="1.8" source="1.8" includeantruntime="false"
+            encoding="UTF-8"
+        >
+            <src path="${src.test-gui.dir}"/>
+            <classpath>
+                <pathelement location="${build.classes}"/>
+                <!--<pathelement location="${build.classes}"/>-->
+                <path refid="runtime.classpath"/>
+                <path refid="test.classpath"/>
+            </classpath>
+        </javac>
+       <!-- <sync todir="${build.test-gui.resources}">
+            <fileset dir="${resources.test-gui.dir}"/>
+        </sync>-->
+    </target>
+
     <target name="test" depends="compile-test,jar,common.resolve.build">
         <mkdir dir="${junit.html.output.dir}"/>
         <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
@@ -165,13 +184,14 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 <listener type="legacy-brief" sendSysOut="true" useLegacyReportingName="false"/>
                 <listener type="legacy-xml" sendSysErr="true" sendSysOut="true" useLegacyReportingName="false"/>
             </testclasses>
-
         </junitlauncher>
+
+        <mkdir dir="${junit.html.output.dir}/test"/>
         <junitreport todir="${junit.html.output.dir}">
             <fileset dir="${build.dir}/test-results">
                 <include name="TEST-*.xml"/>
             </fileset>
-            <report format="noframes" todir="${junit.html.output.dir}"/>
+            <report format="noframes" todir="${junit.html.output.dir}/test"/>
         </junitreport>
         <if>
             <isset property="test.failed"/>
@@ -208,21 +228,64 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 <listener type="legacy-brief" sendSysOut="true" useLegacyReportingName="false"/>
                 <listener type="legacy-xml" sendSysErr="true" sendSysOut="true" useLegacyReportingName="false"/>
             </testclasses>
-
         </junitlauncher>
+
+        <mkdir dir="${junit.html.output.dir}/test-integration"/>
         <junitreport todir="${junit.html.output.dir}">
             <fileset dir="${build.dir}/test-integration/results">
                 <include name="TEST-*.xml"/>
             </fileset>
-            <fileset dir="${build.dir}/test-results">
-                <include name="TEST-*.xml"/>
-            </fileset>
-            <report format="frames" todir="${junit.html.output.dir}"/>
+            <report format="noframes" todir="${junit.html.output.dir}/test-intregration"/>
         </junitreport>
         <if>
             <isset property="integration.failed"/>
             <then>
                 <fail message="Integration tests have failures."/>
+            </then>
+        </if>
+    </target>
+
+    <target name="gui-test" depends="compile-test-gui,stage,common.resolve"
+            description="Run available GUI element tests">
+        <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
+        <mkdir dir="${build.dir}/test-gui/results"/>
+        <mkdir dir="${build.dir}/test-gui/tmp"/>
+        <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="gui.failed">
+            <classpath refid="test.classpath"/>
+            <classpath refid="runtime.classpath"/>
+            <classpath refid="junit.platform.libs.classpath"/>
+            <classpath>
+                <pathelement location="${build.classes}"/>
+                <pathelement location="${build.resources}"/>
+                <pathelement location="${build.test-gui.resources}"/>
+                <pathelement location="${build.test-gui.classes}"/>
+            </classpath>
+
+            <testclasses outputdir="${build.dir}/test-gui/results">
+                <fork>
+                    <jvmarg value="-Dbuild.dir=${build.dir}"/>
+                    <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-gui/tmp"/>
+                    <jvmarg value="-Dresource.dir=${build.test-gui.resources}"/>
+                    <jvmarg value="-DDCSTOOL_HOME=${stage.dir}"/>
+                    <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
+                </fork>
+                <fileset dir="${build.test-gui.classes}"/>
+                <listener type="legacy-brief" sendSysOut="true" useLegacyReportingName="false"/>
+                <listener type="legacy-xml" sendSysErr="true" sendSysOut="true" useLegacyReportingName="false"/>
+            </testclasses>
+        </junitlauncher>
+
+        <mkdir dir="${junit.html.output.dir}/test-gui"/>
+        <junitreport todir="${junit.html.output.dir}">
+            <fileset dir="${build.dir}/test-gui/results">
+                <include name="TEST-*.xml"/>
+            </fileset>
+            <report format="frames" todir="${junit.html.output.dir}/test-gui"/>
+        </junitreport>
+        <if>
+            <isset property="gui.failed"/>
+            <then>
+                <fail message="Gui tests have failures."/>
             </then>
         </if>
     </target>
@@ -642,6 +705,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                     classpathentry(kind:"src",    path:"src/main/resources", output="bin/main")
                     classpathentry(kind:"src",    path:"src/test/java", output="bin/test")
                     classpathentry(kind:"src",    path:"src/test-integration/java", output="bin/test-integration")
+                    classpathentry(kind:"src",    path:"src/test-gui/java", output="bin/test-gui")
                     classpathentry(kind:"output", path:"bin")
                     classpathentry(kind:"con",    path:"org.eclipse.jdt.launching.JRE_CONTAINER")
 

--- a/common.xml
+++ b/common.xml
@@ -26,6 +26,8 @@
     <property name="resources.test.dir" value="src/test/resources"/>
     <property name="src.test-integration.dir" value="src/test-integration/java"/>
     <property name="resources.test-integration.dir" value="src/test-integration/resources"/>
+    <property name="src.test-gui.dir" value="src/test-gui/java"/>
+    <property name="resources.test-gui.dir" value="src/test-gui/resources"/>
 
     <property name="build.dir" value="build"/>
     <property name="build.classes" value="${build.dir}/classes"/>
@@ -37,6 +39,8 @@
     <property name="build.test.lib" value="${build.dir}/test-libs"/>
     <property name="build.test-integration.classes" value="${build.dir}/test-integration/classes"/>
     <property name="build.test-integration.resources" value="${build.dir}/test-integration/resources"/>
+    <property name="build.test-gui.classes" value="${build.dir}/test-gui/classes"/>
+    <property name="build.test-gui.resources" value="${build.dir}/test-gui/resources"/>
     <property name="build.test.lib" value="${build.dir}/test-integration/libs"/>
     <property name="dist.jar" value="${build.lib}/opendcs.jar"/>
     <property name="build.release.dir" value="${build.dir}/release"/>

--- a/docs/source/install-guide.rst
+++ b/docs/source/install-guide.rst
@@ -715,6 +715,9 @@ Table 3-2: DbAuthFile values
 |                |                         |env-auth-source:username=OPENDCS_USERNAME,password=OPENDCS_PASSWORD|
 |                |                         |                                                                   |
 +----------------+-------------------------+-------------------------------------------------------------------+
+|gui-auth-source |Prompt user with a       |Dialog title.                                                      |
+|                | dialog.                 |                                                                   |
++----------------+-------------------------+-------------------------------------------------------------------+
 
 
 The “decodes.properties” file is read when an OPENDCS program is

--- a/ivy.xml
+++ b/ivy.xml
@@ -98,6 +98,7 @@
         <dependency org="org.jdbi" name="jdbi3-sqlobject" rev="3.38.2" conf="test->default"/>
         <dependency org="org.jdbi" name="jdbi3-postgres" rev="3.38.2" conf="test->default"/>
         <dependency org="org.flywaydb" name="flyway-core" rev="9.8.1" conf="test->default"/>
+        <dependency org="org.assertj" name="assertj-swing-junit" rev="3.9.2" conf="test->default"/>
 
         <!-- izpack -->
         <dependency org="org.codehaus.izpack" name="izpack-standalone-compiler" rev="4.3.5" conf="izpack->default"/>

--- a/src/main/java/ilex/gui/LoginDialog.java
+++ b/src/main/java/ilex/gui/LoginDialog.java
@@ -43,9 +43,12 @@ import ilex.util.LoadResourceBundle;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.util.Properties;
 import java.util.ResourceBundle;
 
 import javax.swing.*;
+
+import org.opendcs.spi.authentication.AuthSource;
 
 import decodes.gui.GuiDialog;
 
@@ -59,7 +62,7 @@ import decodes.gui.GuiDialog;
 * You can re-use the same LoginDialog object by calling clear before
 * making it visible.
 */
-public class LoginDialog extends GuiDialog
+public class LoginDialog extends GuiDialog implements AuthSource
 {
 	private static ResourceBundle labels = null;
 	private JButton okButton, cancelButton;
@@ -99,6 +102,7 @@ public class LoginDialog extends GuiDialog
 		JPanel south = new JPanel(new FlowLayout(FlowLayout.CENTER, 7, 7));
 
 		okButton = new JButton(labels.getString("EditPropsAction.ok"));
+		okButton.setName("ok");
 		okButton.addActionListener(
 			new ActionListener()
 			{
@@ -110,6 +114,7 @@ public class LoginDialog extends GuiDialog
 		south.add(okButton);
 		
 		cancelButton = new JButton(labels.getString("EditPropsAction.cancel"));
+		cancelButton.setName("cancel");
 		cancelButton.addActionListener(
 			new ActionListener()
 			{
@@ -131,6 +136,7 @@ public class LoginDialog extends GuiDialog
 				new Insets(5, 10, 3, 2), 0, 0));
 
 		usernameField = new JTextField(10);
+		usernameField.setName("username");
 		center.add(usernameField,
 			new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0,
 				GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
@@ -144,6 +150,7 @@ public class LoginDialog extends GuiDialog
 				new Insets(3, 10, 5, 2), 0, 0));
 
 		passwordField = new JPasswordField(10);
+		passwordField.setName("password");
 		center.add(passwordField,
 			new GridBagConstraints(1, 1, 1, 1, 1.0, 0.0,
 				GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
@@ -268,5 +275,24 @@ public class LoginDialog extends GuiDialog
 	{
 		usernameField.setText(user);
 		usernameField.setEnabled(tf);
+	}
+
+	/**
+	 * Primarily intended to be used by areas of code that require authentication. Like GUI app logins
+	 * @return Valid properties with username and password if okay, otherwise null
+	 */
+	@Override
+	public Properties getCredentials()
+	{
+		this.clear();
+		this.setVisible(true);
+		if (this.isOK())
+		{
+			Properties credentials = new Properties();
+			credentials.setProperty("username", getUserName());
+            credentials.setProperty("password", new String(getPassword()));
+            return credentials;
+		}
+		return null;
 	}
 }

--- a/src/main/java/ilex/gui/LoginDialog.java
+++ b/src/main/java/ilex/gui/LoginDialog.java
@@ -285,6 +285,7 @@ public class LoginDialog extends GuiDialog implements AuthSource
 	public Properties getCredentials()
 	{
 		this.clear();
+		this.setLocationRelativeTo(null);
 		this.setVisible(true);
 		if (this.isOK())
 		{

--- a/src/main/java/org/opendcs/authentication/impl/GuiAuthSourceProvider.java
+++ b/src/main/java/org/opendcs/authentication/impl/GuiAuthSourceProvider.java
@@ -1,0 +1,24 @@
+package org.opendcs.authentication.impl;
+
+import org.opendcs.spi.authentication.AuthSource;
+import org.opendcs.spi.authentication.AuthSourceProvider;
+
+import ilex.gui.LoginDialog;
+import ilex.util.AuthException;
+
+public class GuiAuthSourceProvider implements AuthSourceProvider
+{
+
+    @Override
+    public String getType()
+    {
+        return "gui-auth-source";
+    }
+
+    @Override
+    public AuthSource process(String configurationString) throws AuthException
+    {
+        AuthSource gau = new LoginDialog(null,configurationString);
+        return gau;
+    }
+}

--- a/src/main/resources/META-INF/services/org.opendcs.spi.authentication.AuthSourceProvider
+++ b/src/main/resources/META-INF/services/org.opendcs.spi.authentication.AuthSourceProvider
@@ -1,2 +1,3 @@
 org.opendcs.authentication.impl.UserAuthFileProvider
 org.opendcs.authentication.impl.EnvironmentAuthSourceProvider
+org.opendcs.authentication.impl.GuiAuthSourceProvider

--- a/src/test-gui/java/org/opendcs/authentication/GuiAuthSourceTest.java
+++ b/src/test-gui/java/org/opendcs/authentication/GuiAuthSourceTest.java
@@ -1,0 +1,75 @@
+package org.opendcs.authentication;
+
+import ilex.gui.LoginDialog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.SwingWorker;
+
+import org.assertj.swing.edt.GuiActionRunner;
+import org.assertj.swing.fixture.DialogFixture;
+import org.assertj.swing.fixture.FrameFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opendcs.spi.authentication.AuthSource;
+
+import com.github.dockerjava.api.model.Frame;
+
+
+public class GuiAuthSourceTest
+{
+    private DialogFixture dialog;
+    //private FrameFixture frame;
+    private LoginDialog loginDialog;
+    //private JFrame rootFrame;
+    private ExecutorService executor = Executors.newCachedThreadPool();
+
+    @BeforeEach
+    public void setup() throws Exception
+    {
+        loginDialog = (LoginDialog)AuthSourceService.getFromString("gui-auth-source:Login");
+        //rootFrame = GuiActionRunner.execute(() -> new JFrame("Root Window"));
+        //frame = new FrameFixture(rootFrame);
+        dialog = new DialogFixture(loginDialog);
+        //frame.show();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {        
+        dialog.cleanUp();
+    }
+
+    @Test
+    public void login_accepted() throws Exception
+    {        
+        final String username = "user";
+        final String password = "password";
+    
+        Future<Properties> credentialsFuture = executor.submit(() -> loginDialog.getCredentials());
+        assertTrue(loginDialog.isValid(), "Our Dialog isn't valid.");
+
+        Thread.sleep(500); // give the dialog a bit of time to actually start
+
+        dialog.textBox("username").setText(username);
+        dialog.textBox("password").setText(password);
+        dialog.button("ok").click();
+        Properties creds = credentialsFuture.get();
+        assertNotNull(creds, "no credentials returned.");
+        assertEquals(username,creds.getProperty("username"), "Username did not match");
+        assertEquals(password,creds.getProperty("password"), "Password did not match");
+    }
+}


### PR DESCRIPTION
## Problem Description

The current database connection/credential loading system is full of edge cases.
1. HDB has a "tryOsAuth"
2. Cwms is a "isCwms and isGUI"
3. etc

However, except in the now rare instances of running the GUI application on a remote server, in use I've never seen a case where this was required and it should just be specified in the user.properties as one of the sources.

## Solution

I've taken the existing LoginDialog and had it implement the `AuthSource` interface as well as creating an appropriate Provider.

This will allow a given setup to just assert how credentials are provided.

## how you tested the change

An automated test was created. NOTE: test requires a GUI environment of some sort, so the use of xvfb was added to the github action.

I manually verified this didn't break the CWMS Login which uses the same base dialog.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [X] Unit tests created or modified that run during ant test.
   - [X] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [X] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
