### PR TITLE
Added checking for U1 hour/minute offset, and primary and redundant W…

### DIFF
--- a/src/main/java/decodes/decoder/Nos6Min.java
+++ b/src/main/java/decodes/decoder/Nos6Min.java
@@ -3,15 +3,6 @@
 *
 * $Log$
 *
-* 2023/08/28 Baoyu Yin
-* added checking for primary WL sensor with wrong raw data (@@@ and ???) - ING697
-*
-* 2023/08/25 Baoyu Yin
-* added checking for redundant WL sensor with wrong raw data (@@@ and ???) - ING694
-*
-* 2023/08/14 Baoyu Yin
-* added U1 sensor hour and minutes offset checking - ING -690
-*
 * 2023/08/04 Baoyu Yin
 * Fixed wrong timestamps for U1 data for the first 0-5 minutes during day change - ING -681
 *
@@ -252,7 +243,7 @@ public class Nos6Min
                                 if (sensorNum != -1) // sensor number already set from previous flag
                                 {
 			           // Discard ??? (262143) or @@@ (0) from decoding 
-				   if (Integer.valueOf(v.getStringValue()) != 262143 && Integer.valueOf(v.getStringValue()) != 0)
+				   if ( isValid(Integer.valueOf(v.getStringValue())) )
 				   {
                                         msg.addSampleWithTime(sensorNum, v, redundantDataTime, 1);
 			           }


### PR DESCRIPTION
…L invalid

reading issues.

## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->


<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Added checking for U1 hour/minute offset and primary/redundant WL bad readings

## how you tested the change

Confirmed bad U1 offset and WL readings are discarded. 

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
