### PR TITLE
Bugfix/screening connection retrieval

### DIFF
--- a/src/main/java/decodes/cwms/validation/ScreeningExport.java
+++ b/src/main/java/decodes/cwms/validation/ScreeningExport.java
@@ -172,7 +172,7 @@ public class ScreeningExport extends TsdbAppTemplate
             System.exit(1);
         }
 
-        ArrayList<TsidScreeningAssignment> tsidAssignments = screeningDAO.getTsidScreeningAssignments(false);
+        List<TsidScreeningAssignment> tsidAssignments = screeningDAO.getTsidScreeningAssignments(false);
         for(String screeningID : screeningIDs)
         {
             DbKey key = screeningDAO.getKeyForId(screeningID);

--- a/src/main/java/decodes/cwms/validation/ScreeningExport.java
+++ b/src/main/java/decodes/cwms/validation/ScreeningExport.java
@@ -10,6 +10,7 @@ package decodes.cwms.validation;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
 import java.util.StringTokenizer;
 
 import opendcs.dai.TimeSeriesDAI;
@@ -123,9 +124,11 @@ public class ScreeningExport extends TsdbAppTemplate
 
 		if (allArg.getValue())
 		{
-			ArrayList<Screening> allScreenings = screeningDAO.getAllScreenings();
+			List<Screening> allScreenings = screeningDAO.getAllScreenings();
 			for(Screening s : allScreenings)
+			{
 				screeningIDs.add(s.getScreeningName());
+			}
 		}
 		else
 		{

--- a/src/main/java/decodes/cwms/validation/ScreeningExport.java
+++ b/src/main/java/decodes/cwms/validation/ScreeningExport.java
@@ -1,8 +1,8 @@
 /**
  * $Id$
- * 
+ *
  * Copyright 2015 U.S. Army Corps of Engineers, Hydrologic Engineering Center.
- * 
+ *
  * $Log$
  */
 package decodes.cwms.validation;
@@ -42,315 +42,315 @@ import decodes.util.DecodesException;
  */
 public class ScreeningExport extends TsdbAppTemplate
 {
-	public static final String module = "ScreeningExport";
-	
-	private StringToken screeningIdArg = new StringToken("n", "screening ID",
-		"", TokenOptions.optSwitch | TokenOptions.optMultiple, "");
-	private BooleanToken nameListOnStdin = new BooleanToken("q", "(Accept list of IDs from stdin.)",
-		"", TokenOptions.optSwitch, false);
-	private StringToken presentationArg = new StringToken("G", "PresentationGroup to define screening units", "", 
-		TokenOptions.optSwitch, "");
-	private BooleanToken allArg = new BooleanToken("A", "(Export all screenings)",
-		"", TokenOptions.optSwitch, false);
-	private BooleanToken englishUnitsArg = new BooleanToken("E", "(Export in English units)",
-		"", TokenOptions.optSwitch, false);
-	private StringToken tsIdArg = new StringToken("T", "Time Series ID -- output screening for referenced TSID.",
-		"", TokenOptions.optSwitch | TokenOptions.optMultiple, "");
+    public static final String module = "ScreeningExport";
+
+    private StringToken screeningIdArg = new StringToken("n", "screening ID",
+        "", TokenOptions.optSwitch | TokenOptions.optMultiple, "");
+    private BooleanToken nameListOnStdin = new BooleanToken("q", "(Accept list of IDs from stdin.)",
+        "", TokenOptions.optSwitch, false);
+    private StringToken presentationArg = new StringToken("G", "PresentationGroup to define screening units", "",
+        TokenOptions.optSwitch, "");
+    private BooleanToken allArg = new BooleanToken("A", "(Export all screenings)",
+        "", TokenOptions.optSwitch, false);
+    private BooleanToken englishUnitsArg = new BooleanToken("E", "(Export in English units)",
+        "", TokenOptions.optSwitch, false);
+    private StringToken tsIdArg = new StringToken("T", "Time Series ID -- output screening for referenced TSID.",
+        "", TokenOptions.optSwitch | TokenOptions.optMultiple, "");
 
 
-	
-	private ArrayList<String> screeningIDs = new ArrayList<String>();
-	private NumberFormat nf = NumberFormat.getNumberInstance();
-	private NumberFormat intf = NumberFormat.getIntegerInstance();
-	private PresentationGroup presGroup = null;
-	private DataPresentation dataPres = null;
-	private UnitConverter unitConverter = null;
-	
 
-	public ScreeningExport()
-	{
-		super("screening.log");
-		nf.setMaximumFractionDigits(3);
-		nf.setGroupingUsed(false);
-		intf.setGroupingUsed(false);
-	}
+    private ArrayList<String> screeningIDs = new ArrayList<String>();
+    private NumberFormat nf = NumberFormat.getNumberInstance();
+    private NumberFormat intf = NumberFormat.getIntegerInstance();
+    private PresentationGroup presGroup = null;
+    private DataPresentation dataPres = null;
+    private UnitConverter unitConverter = null;
 
-	public static void main(String[] args)
-		throws Exception
-	{
-		ScreeningExport me = new ScreeningExport();
-		me.execute(args);
-	}
 
-	@Override
-	public void addCustomArgs(CmdLineArgs cmdLineArgs)
-	{
-		cmdLineArgs.addToken(screeningIdArg);
-		cmdLineArgs.addToken(nameListOnStdin);
-		cmdLineArgs.addToken(presentationArg);
-		cmdLineArgs.addToken(allArg);
-		cmdLineArgs.addToken(englishUnitsArg);
-		cmdLineArgs.addToken(tsIdArg);
-		DecodesInterface.silent = true;
-	}
+    public ScreeningExport()
+    {
+        super("screening.log");
+        nf.setMaximumFractionDigits(3);
+        nf.setGroupingUsed(false);
+        intf.setGroupingUsed(false);
+    }
 
-	@Override
-	protected void runApp() throws Exception
-	{
-		if (!theDb.isCwms())
-		{
-			System.err.println("This utility exports CWMS screenings. You are not connected to a CWMS database.");
-			System.exit(1);
-		}
-		CwmsTimeSeriesDb cwmsDb = (CwmsTimeSeriesDb)theDb;
-		
-		String pgName = presentationArg.getValue();
-		if (pgName != null && pgName.length() > 0)
-		{
-			presGroup = Database.getDb().presentationGroupList.find(pgName);
-			try
-			{
-				if (presGroup != null)
-					presGroup.prepareForExec();
-			}
-			catch (InvalidDatabaseException ex)
-			{
-				warning("Cannot initialize presentation group '" + pgName + ": " + ex);
-				presGroup = null;
-			}
-		}
-		ScreeningDAI screeningDAO = cwmsDb.makeScreeningDAO();
-		TimeSeriesDAI timeSeriesDAO = cwmsDb.makeTimeSeriesDAO();
+    public static void main(String[] args)
+        throws Exception
+    {
+        ScreeningExport me = new ScreeningExport();
+        me.execute(args);
+    }
 
-		if (allArg.getValue())
-		{
-			List<Screening> allScreenings = screeningDAO.getAllScreenings();
-			for(Screening s : allScreenings)
-			{
-				screeningIDs.add(s.getScreeningName());
-			}
-		}
-		else
-		{
-			for(int idx = 0; idx < screeningIdArg.NumberOfValues(); idx++)
-			{
-				String id = screeningIdArg.getValue(idx);
-				if (id == null || id.trim().length() == 0)
-					continue;
-				screeningIDs.add(id);
-			}
-			for(int idx = 0; idx < tsIdArg.NumberOfValues(); idx++)
-			{
-				String tsidStr = tsIdArg.getValue(idx);
-				try
-				{
-					TimeSeriesIdentifier tsid = timeSeriesDAO.getTimeSeriesIdentifier(tsidStr);
-					TsidScreeningAssignment tsa = screeningDAO.getScreeningForTS(tsid);
-					if (tsa == null)
-						warning("No screening assigned to '" + tsidStr + "'");
-					else screeningIDs.add(tsa.getScreening().getScreeningName());
-				}
-				catch(NoSuchObjectException ex)
-				{
-					warning("No such time series '" + tsidStr + "': " + ex);
-				}
-			}
-			
-			if (nameListOnStdin.getValue())
-			{
-				String line;
-				while((line = System.console().readLine()) != null)
-				{
-					screeningIDs.add(line);
-				}
-			}
-		}
-		
-		if (screeningIDs.size() == 0)
-		{
-			System.err.println("No Screening IDs provided. Nothing to do.");
-			System.exit(1);
-		}
-		
-		ArrayList<TsidScreeningAssignment> tsidAssignments = screeningDAO.getTsidScreeningAssignments(false);
-		for(String screeningID : screeningIDs)
-		{
-			DbKey key = screeningDAO.getKeyForId(screeningID);
-			if (DbKey.isNull(key))
-			{
-				System.err.println("Screening ID '" + screeningID + "' not found.");
-				continue;
-			}
-				
-			Screening screening = screeningDAO.getByKey(key);
-			output(screening);
-			
-			System.out.println();
-			// Output assignments for this screening, if any
-			for(TsidScreeningAssignment tsa : tsidAssignments)
-				if (tsa.getScreening().getKey().equals(key))
-				{
-					System.out.println("ASSIGN " + tsa.getTsid().getUniqueString() + " : "
-						+ screening.getScreeningName());
-				}
-			System.out.println();	
-		}
-		screeningDAO.close();
-		timeSeriesDAO.close();
-	}
-	
-	private void output(Screening screening)
-	{
-		String unitsAbbr = ((CwmsTimeSeriesDb)theDb).getBaseParam().getStoreUnits4Param(screening.getParamId());
+    @Override
+    public void addCustomArgs(CmdLineArgs cmdLineArgs)
+    {
+        cmdLineArgs.addToken(screeningIdArg);
+        cmdLineArgs.addToken(nameListOnStdin);
+        cmdLineArgs.addToken(presentationArg);
+        cmdLineArgs.addToken(allArg);
+        cmdLineArgs.addToken(englishUnitsArg);
+        cmdLineArgs.addToken(tsIdArg);
+        DecodesInterface.silent = true;
+    }
 
-		if (englishUnitsArg.getValue())
-		{
-			// Convert all the limits in this screening to the english units
-			String storUnits = screening.getCheckUnitsAbbr();
-			String engUnits = ((CwmsTimeSeriesDb)theDb).getBaseParam().getEnglishUnits4Param(screening.getParamId());
+    @Override
+    protected void runApp() throws Exception
+    {
+        if (!theDb.isCwms())
+        {
+            System.err.println("This utility exports CWMS screenings. You are not connected to a CWMS database.");
+            System.exit(1);
+        }
+        CwmsTimeSeriesDb cwmsDb = (CwmsTimeSeriesDb)theDb;
+
+        String pgName = presentationArg.getValue();
+        if (pgName != null && pgName.length() > 0)
+        {
+            presGroup = Database.getDb().presentationGroupList.find(pgName);
+            try
+            {
+                if (presGroup != null)
+                    presGroup.prepareForExec();
+            }
+            catch (InvalidDatabaseException ex)
+            {
+                warning("Cannot initialize presentation group '" + pgName + ": " + ex);
+                presGroup = null;
+            }
+        }
+        ScreeningDAI screeningDAO = cwmsDb.makeScreeningDAO();
+        TimeSeriesDAI timeSeriesDAO = cwmsDb.makeTimeSeriesDAO();
+
+        if (allArg.getValue())
+        {
+            List<Screening> allScreenings = screeningDAO.getAllScreenings();
+            for(Screening s : allScreenings)
+            {
+                screeningIDs.add(s.getScreeningName());
+            }
+        }
+        else
+        {
+            for(int idx = 0; idx < screeningIdArg.NumberOfValues(); idx++)
+            {
+                String id = screeningIdArg.getValue(idx);
+                if (id == null || id.trim().length() == 0)
+                    continue;
+                screeningIDs.add(id);
+            }
+            for(int idx = 0; idx < tsIdArg.NumberOfValues(); idx++)
+            {
+                String tsidStr = tsIdArg.getValue(idx);
+                try
+                {
+                    TimeSeriesIdentifier tsid = timeSeriesDAO.getTimeSeriesIdentifier(tsidStr);
+                    TsidScreeningAssignment tsa = screeningDAO.getScreeningForTS(tsid);
+                    if (tsa == null)
+                        warning("No screening assigned to '" + tsidStr + "'");
+                    else screeningIDs.add(tsa.getScreening().getScreeningName());
+                }
+                catch(NoSuchObjectException ex)
+                {
+                    warning("No such time series '" + tsidStr + "': " + ex);
+                }
+            }
+
+            if (nameListOnStdin.getValue())
+            {
+                String line;
+                while((line = System.console().readLine()) != null)
+                {
+                    screeningIDs.add(line);
+                }
+            }
+        }
+
+        if (screeningIDs.size() == 0)
+        {
+            System.err.println("No Screening IDs provided. Nothing to do.");
+            System.exit(1);
+        }
+
+        ArrayList<TsidScreeningAssignment> tsidAssignments = screeningDAO.getTsidScreeningAssignments(false);
+        for(String screeningID : screeningIDs)
+        {
+            DbKey key = screeningDAO.getKeyForId(screeningID);
+            if (DbKey.isNull(key))
+            {
+                System.err.println("Screening ID '" + screeningID + "' not found.");
+                continue;
+            }
+
+            Screening screening = screeningDAO.getByKey(key);
+            output(screening);
+
+            System.out.println();
+            // Output assignments for this screening, if any
+            for(TsidScreeningAssignment tsa : tsidAssignments)
+                if (tsa.getScreening().getKey().equals(key))
+                {
+                    System.out.println("ASSIGN " + tsa.getTsid().getUniqueString() + " : "
+                        + screening.getScreeningName());
+                }
+            System.out.println();
+        }
+        screeningDAO.close();
+        timeSeriesDAO.close();
+    }
+
+    private void output(Screening screening)
+    {
+        String unitsAbbr = ((CwmsTimeSeriesDb)theDb).getBaseParam().getStoreUnits4Param(screening.getParamId());
+
+        if (englishUnitsArg.getValue())
+        {
+            // Convert all the limits in this screening to the english units
+            String storUnits = screening.getCheckUnitsAbbr();
+            String engUnits = ((CwmsTimeSeriesDb)theDb).getBaseParam().getEnglishUnits4Param(screening.getParamId());
 Logger.instance().info("English units requested, looking for converter for param '" + screening.getParamId()
-	+ "' storUnits='" + storUnits + "' engunits='" + engUnits + "'");
-			unitConverter = Database.getDb().unitConverterSet.get(
-				EngineeringUnit.getEngineeringUnit(storUnits), 
-				EngineeringUnit.getEngineeringUnit(engUnits));
-			unitsAbbr = engUnits;
-		}
-		System.out.println("*===========================================");
-		System.out.println("SCREENING " + screening.getScreeningName());
-		if (screening.getScreeningDesc() != null)
-		{
-			String desc = screening.getScreeningDesc();
-			StringTokenizer st = new StringTokenizer(desc, "\r\n");
-			while(st.hasMoreTokens())
-				System.out.println("DESC " + st.nextToken());
-		}
-		
-		System.out.println("PARAM " + screening.getParamId());
-		
-		if (screening.getParamTypeId() != null)
-			System.out.println("PARAMTYPE " + screening.getParamTypeId());
-		if (screening.getDurationId() != null)
-			System.out.println("DURATION " + screening.getDurationId());
-		
-		dataPres = null;
-		if (presGroup != null)
-		{
-			DataType dt = DataType.getDataType(Constants.datatype_CWMS, screening.getParamId());
-			dataPres = presGroup.findDataPresentation(dt);
-			if (dataPres == null)
-			{
-				// try with just the base param
-				int idx = screening.getParamId().indexOf('-');
-				if (idx > 0)
-				{
-					dt = DataType.getDataType(Constants.datatype_CWMS, screening.getParamId().substring(0, idx));
-					dataPres = presGroup.findDataPresentation(dt);
-				}
-			}
-		}
-		if (dataPres != null && dataPres.getUnitsAbbr() != null && !unitsAbbr.equalsIgnoreCase(dataPres.getUnitsAbbr()))
-		{
-			unitConverter = decodes.db.Database.getDb().unitConverterSet.get(
-				EngineeringUnit.getEngineeringUnit(unitsAbbr), EngineeringUnit.getEngineeringUnit(dataPres.getUnitsAbbr()));
-			if (unitConverter == null)
-			{
-				System.err.println("Cannot convert param " + screening.getParamId() + " units from "
-					+ unitsAbbr + " to " + dataPres.getUnitsAbbr() + " -- will output limits in " + unitsAbbr);
-			}
-			else
-				unitsAbbr = dataPres.getUnitsAbbr();
-		}
-		System.out.println("UNITS " + unitsAbbr);
+    + "' storUnits='" + storUnits + "' engunits='" + engUnits + "'");
+            unitConverter = Database.getDb().unitConverterSet.get(
+                EngineeringUnit.getEngineeringUnit(storUnits),
+                EngineeringUnit.getEngineeringUnit(engUnits));
+            unitsAbbr = engUnits;
+        }
+        System.out.println("*===========================================");
+        System.out.println("SCREENING " + screening.getScreeningName());
+        if (screening.getScreeningDesc() != null)
+        {
+            String desc = screening.getScreeningDesc();
+            StringTokenizer st = new StringTokenizer(desc, "\r\n");
+            while(st.hasMoreTokens())
+                System.out.println("DESC " + st.nextToken());
+        }
 
-		System.out.println("RANGE_ACTIVE " + screening.isRangeActive());
-		System.out.println("ROC_ACTIVE " + screening.isRocActive());
-		System.out.println("CONST_ACTIVE " + screening.isConstActive());
-		System.out.println("DURMAG_ACTIVE " + screening.isDurMagActive());
-		
-		for(ScreeningCriteria crit : screening.criteriaSeasons)
-			outputCrit(crit);
-		
-		System.out.println("SCREENING_END");
-	}
+        System.out.println("PARAM " + screening.getParamId());
 
-	private void outputCrit(ScreeningCriteria crit)
-	{
-		System.out.println();
-		
-		System.out.println("CRITERIA_SET");
+        if (screening.getParamTypeId() != null)
+            System.out.println("PARAMTYPE " + screening.getParamTypeId());
+        if (screening.getDurationId() != null)
+            System.out.println("DURATION " + screening.getDurationId());
 
-		Calendar cal = crit.getSeasonStart();
-		if (cal != null)
-			System.out.println("SEASON " + (cal.get(Calendar.MONTH)+1) + "/" + cal.get(Calendar.DAY_OF_MONTH));
-		
-		String est = crit.getEstimateExpression();
-		if (est != null && est.trim().length() > 0)
-			System.out.println("ESTIMATE " + est);
-		
-		AbsCheck abs = crit.getAbsCheckFor('R');
-		if (abs != null)
-			System.out.println("CRITERIA ABS R " + nf.format(cnvt(abs.getLow())) 
-				+ " " + nf.format(cnvt(abs.getHigh())));
-		
-		abs = crit.getAbsCheckFor('Q');
-		if (abs != null)
-			System.out.println("CRITERIA ABS Q " + nf.format(cnvt(abs.getLow())) 
-				+ " " + nf.format(cnvt(abs.getHigh())));
-		
-		RocPerHourCheck roc = crit.getRocCheckFor('R');
-		if (roc != null)
-			System.out.println("CRITERIA RATE R " + nf.format(cnvt(roc.getFall())) 
-				+ " " + nf.format(cnvt(roc.getRise())));
-		
-		roc = crit.getRocCheckFor('Q');
-		if (roc != null)
-			System.out.println("CRITERIA RATE Q " + nf.format(cnvt(roc.getFall())) 
-				+ " " + nf.format(cnvt(roc.getRise())));
-		
-		ConstCheck con = crit.getConstCheckFor('R');
-		if (con != null)
-			System.out.println("CRITERIA CONST R " + cwmsDur2Datchk(con.getDuration()) + " "
-				+ nf.format(cnvt(con.getMinToCheck())) + " " + nf.format(cnvt(con.getTolerance())) 
-				+ " " + intf.format(con.getAllowedMissing()));
-		
-		con = crit.getConstCheckFor('Q');
-		if (con != null)
-			System.out.println("CRITERIA CONST Q " + cwmsDur2Datchk(con.getDuration()) + " "
-				+ nf.format(cnvt(con.getMinToCheck())) + " " + nf.format(cnvt(con.getTolerance())) 
-				+ " " + intf.format(con.getAllowedMissing()));
-		
-		for(DurCheckPeriod dcp : crit.durCheckPeriods)
-			System.out.println("CRITERIA DUR " + dcp.getFlag() + " " + nf.format(cnvt(dcp.getLow()))
-				+ " " + nf.format(cnvt(dcp.getHigh())) + " " + cwmsDur2Datchk(dcp.getDuration()));
-		
-		System.out.println("CRITERIA_SET_END");
-	}
-	
-	public double cnvt(double stor)
-	{
-		if (unitConverter != null)
-			try
-			{
-				return unitConverter.convert(stor);
-			}
-			catch (DecodesException ex)
-			{
-				System.err.println("Cannot convert limit " + stor + ": " + ex);
-			}
-		return stor;
-	}
-	
-	private String cwmsDur2Datchk(String dur)
-	{
-		StringBuilder sb = new StringBuilder();
-		for(int idx = 0; idx < dur.length(); idx++)
-			if (Character.isDigit(dur.charAt(idx)))
-				sb.append(dur.charAt(idx));
-			else
-			{
-				sb.append(dur.charAt(idx));
-				break;
-			}
-		return sb.toString();
-	}
+        dataPres = null;
+        if (presGroup != null)
+        {
+            DataType dt = DataType.getDataType(Constants.datatype_CWMS, screening.getParamId());
+            dataPres = presGroup.findDataPresentation(dt);
+            if (dataPres == null)
+            {
+                // try with just the base param
+                int idx = screening.getParamId().indexOf('-');
+                if (idx > 0)
+                {
+                    dt = DataType.getDataType(Constants.datatype_CWMS, screening.getParamId().substring(0, idx));
+                    dataPres = presGroup.findDataPresentation(dt);
+                }
+            }
+        }
+        if (dataPres != null && dataPres.getUnitsAbbr() != null && !unitsAbbr.equalsIgnoreCase(dataPres.getUnitsAbbr()))
+        {
+            unitConverter = decodes.db.Database.getDb().unitConverterSet.get(
+                EngineeringUnit.getEngineeringUnit(unitsAbbr), EngineeringUnit.getEngineeringUnit(dataPres.getUnitsAbbr()));
+            if (unitConverter == null)
+            {
+                System.err.println("Cannot convert param " + screening.getParamId() + " units from "
+                    + unitsAbbr + " to " + dataPres.getUnitsAbbr() + " -- will output limits in " + unitsAbbr);
+            }
+            else
+                unitsAbbr = dataPres.getUnitsAbbr();
+        }
+        System.out.println("UNITS " + unitsAbbr);
+
+        System.out.println("RANGE_ACTIVE " + screening.isRangeActive());
+        System.out.println("ROC_ACTIVE " + screening.isRocActive());
+        System.out.println("CONST_ACTIVE " + screening.isConstActive());
+        System.out.println("DURMAG_ACTIVE " + screening.isDurMagActive());
+
+        for(ScreeningCriteria crit : screening.criteriaSeasons)
+            outputCrit(crit);
+
+        System.out.println("SCREENING_END");
+    }
+
+    private void outputCrit(ScreeningCriteria crit)
+    {
+        System.out.println();
+
+        System.out.println("CRITERIA_SET");
+
+        Calendar cal = crit.getSeasonStart();
+        if (cal != null)
+            System.out.println("SEASON " + (cal.get(Calendar.MONTH)+1) + "/" + cal.get(Calendar.DAY_OF_MONTH));
+
+        String est = crit.getEstimateExpression();
+        if (est != null && est.trim().length() > 0)
+            System.out.println("ESTIMATE " + est);
+
+        AbsCheck abs = crit.getAbsCheckFor('R');
+        if (abs != null)
+            System.out.println("CRITERIA ABS R " + nf.format(cnvt(abs.getLow()))
+                + " " + nf.format(cnvt(abs.getHigh())));
+
+        abs = crit.getAbsCheckFor('Q');
+        if (abs != null)
+            System.out.println("CRITERIA ABS Q " + nf.format(cnvt(abs.getLow()))
+                + " " + nf.format(cnvt(abs.getHigh())));
+
+        RocPerHourCheck roc = crit.getRocCheckFor('R');
+        if (roc != null)
+            System.out.println("CRITERIA RATE R " + nf.format(cnvt(roc.getFall()))
+                + " " + nf.format(cnvt(roc.getRise())));
+
+        roc = crit.getRocCheckFor('Q');
+        if (roc != null)
+            System.out.println("CRITERIA RATE Q " + nf.format(cnvt(roc.getFall()))
+                + " " + nf.format(cnvt(roc.getRise())));
+
+        ConstCheck con = crit.getConstCheckFor('R');
+        if (con != null)
+            System.out.println("CRITERIA CONST R " + cwmsDur2Datchk(con.getDuration()) + " "
+                + nf.format(cnvt(con.getMinToCheck())) + " " + nf.format(cnvt(con.getTolerance()))
+                + " " + intf.format(con.getAllowedMissing()));
+
+        con = crit.getConstCheckFor('Q');
+        if (con != null)
+            System.out.println("CRITERIA CONST Q " + cwmsDur2Datchk(con.getDuration()) + " "
+                + nf.format(cnvt(con.getMinToCheck())) + " " + nf.format(cnvt(con.getTolerance()))
+                + " " + intf.format(con.getAllowedMissing()));
+
+        for(DurCheckPeriod dcp : crit.durCheckPeriods)
+            System.out.println("CRITERIA DUR " + dcp.getFlag() + " " + nf.format(cnvt(dcp.getLow()))
+                + " " + nf.format(cnvt(dcp.getHigh())) + " " + cwmsDur2Datchk(dcp.getDuration()));
+
+        System.out.println("CRITERIA_SET_END");
+    }
+
+    public double cnvt(double stor)
+    {
+        if (unitConverter != null)
+            try
+            {
+                return unitConverter.convert(stor);
+            }
+            catch (DecodesException ex)
+            {
+                System.err.println("Cannot convert limit " + stor + ": " + ex);
+            }
+        return stor;
+    }
+
+    private String cwmsDur2Datchk(String dur)
+    {
+        StringBuilder sb = new StringBuilder();
+        for(int idx = 0; idx < dur.length(); idx++)
+            if (Character.isDigit(dur.charAt(idx)))
+                sb.append(dur.charAt(idx));
+            else
+            {
+                sb.append(dur.charAt(idx));
+                break;
+            }
+        return sb.toString();
+    }
 }

--- a/src/main/java/decodes/cwms/validation/dao/ScreeningDAI.java
+++ b/src/main/java/decodes/cwms/validation/dao/ScreeningDAI.java
@@ -7,7 +7,6 @@
  */
 package decodes.cwms.validation.dao;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import decodes.cwms.validation.Screening;
@@ -74,7 +73,7 @@ public interface ScreeningDAI
 	 * @return an array of all screening assignments
 	 * @throws DbIoException on any SQL error
 	 */
-	public ArrayList<TsidScreeningAssignment> getTsidScreeningAssignments(boolean activeOnly)
+	public List<TsidScreeningAssignment> getTsidScreeningAssignments(boolean activeOnly)
 		throws DbIoException;
 	
 	/**

--- a/src/main/java/decodes/cwms/validation/dao/ScreeningDAI.java
+++ b/src/main/java/decodes/cwms/validation/dao/ScreeningDAI.java
@@ -8,6 +8,7 @@
 package decodes.cwms.validation.dao;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import decodes.cwms.validation.Screening;
 import decodes.sql.DbKey;
@@ -64,7 +65,7 @@ public interface ScreeningDAI
 	 * Used by GUI to populate the list tab.
 	 * @return list of all screening objects in the database.
 	 */
-	public ArrayList<Screening> getAllScreenings()
+	public List<Screening> getAllScreenings()
 		throws DbIoException;
 	
 	/**

--- a/src/main/java/decodes/cwms/validation/dao/ScreeningDAI.java
+++ b/src/main/java/decodes/cwms/validation/dao/ScreeningDAI.java
@@ -15,7 +15,7 @@ import decodes.tsdb.DbIoException;
 import decodes.tsdb.NoSuchObjectException;
 import decodes.tsdb.TimeSeriesIdentifier;
 
-public interface ScreeningDAI
+public interface ScreeningDAI extends AutoCloseable
 {
 	/**
 	 * Write a screening object to the CWMS database.

--- a/src/main/java/decodes/cwms/validation/dao/ScreeningDAO.java
+++ b/src/main/java/decodes/cwms/validation/dao/ScreeningDAO.java
@@ -345,9 +345,9 @@ public class ScreeningDAO
             doQuery(q, rs -> rsAddCriteria(rs, ret),screeningCode);
 
             q = "select distinct " + durMagColumns + " from " + durMagTable
-                + " where screening_code = ?"// + screeningCode
+                + " where screening_code = ?"
                 + " and unit_system = 'SI'"
-                + " and unit_id = ?"; // + sqlString(ret.getCheckUnitsAbbr());
+                + " and unit_id = ?";
             doQuery(q, rs -> {
                 int day = rs.getInt(2);
                 int month = rs.getInt(3);
@@ -390,7 +390,7 @@ public class ScreeningDAO
             }
 
             q = "select distinct " + screenCritColumns + " from " + screenCritTable
-                + " where upper(db_office_id) = ?"// + sqlString(((CwmsTimeSeriesDb)db).getDbOfficeId())
+                + " where upper(db_office_id) = ?"
                 + " and (unit_system = 'SI' or unit_system is null)";
             doQuery(q, rs -> {
                 DbKey screeningCode = DbKey.createDbKey(rs, 1);
@@ -430,7 +430,7 @@ public class ScreeningDAO
             });
 
             q = "select distinct " + durMagColumns + " from " + durMagTable
-                + " where upper(db_office_id) = ? " + sqlString(((CwmsTimeSeriesDb)db).getDbOfficeId())
+                + " where upper(db_office_id) = ?"
                 + " and (unit_system = 'SI' or unit_system is null)";
             doQuery(q, rs -> {
                 DbKey screeningCode = DbKey.createDbKey(rs, 1);

--- a/src/main/java/decodes/cwms/validation/dao/ScreeningDAO.java
+++ b/src/main/java/decodes/cwms/validation/dao/ScreeningDAO.java
@@ -791,7 +791,7 @@ Logger.instance().debug1("ScreeningDAO.makeCal day=" + day + ", mon=" + month
     }
 
     @Override
-    public ArrayList<TsidScreeningAssignment> getTsidScreeningAssignments(boolean activeOnly)
+    public List<TsidScreeningAssignment> getTsidScreeningAssignments(boolean activeOnly)
         throws DbIoException
     {
         String q = "select distinct screening_code, ts_code, active_flag "

--- a/src/main/java/decodes/cwms/validation/dao/ScreeningDAO.java
+++ b/src/main/java/decodes/cwms/validation/dao/ScreeningDAO.java
@@ -1,8 +1,8 @@
 /**
  * $Id$
- * 
+ *
  * Copyright 2015 U.S. Army Corps of Engineers, Hydrologic Engineering Center.
- * 
+ *
  * $Log$
  * Revision 1.10  2019/01/16 15:31:19  mmaloney
  * test
@@ -69,870 +69,870 @@ import usace.cwms.db.dao.util.services.CwmsDbServiceLookup;
  * used by the JPub-Generated CwmsScreeningDbIo module.
  */
 public class ScreeningDAO
-	extends DaoBase
-	implements ScreeningDAI
+    extends DaoBase
+    implements ScreeningDAI
 {
-	public static final String module = "ScreeningDAO";
-	
-	// Screenings are allowed to stay in the cache for an hour
-	protected static DbObjectCache<Screening> cache = new DbObjectCache<Screening>(60 * 60 * 1000L, false);
-	
-	// Associates a time series with a screening
-//	private static HashMap<TimeSeriesIdentifier, Screening> ts2screening = new HashMap<TimeSeriesIdentifier, Screening>();
+    public static final String module = "ScreeningDAO";
 
-	/** Columns to read from cwms_v_screening_id to tell if a screening exists. */
-	public static final String screenIdTable = "CWMS_V_SCREENING_ID";
-	public static final String screenIdColumns = "SCREENING_CODE, SCREENING_ID, SCREENING_ID_DESC, "
-		+ "PARAMETER_ID, PARAMETER_TYPE_ID, DURATION_ID";
-	
-	/** Columns in cwms_v_screening_criteria to read screening criteria info */
-	public static final String screenCritTable = "CWMS_V_SCREENING_CRITERIA";
-	public static final String screenCritColumns = "SCREENING_CODE, "
-		+ "SEASON_START_DAY, SEASON_START_MONTH, "
-		+ "ESTIMATE_EXPRESSION, "
-		+ "RANGE_REJECT_LO, RANGE_REJECT_HI, RANGE_QUESTION_LO, RANGE_QUESTION_HI, "
-		+ "RATE_CHANGE_REJECT_FALL, RATE_CHANGE_REJECT_RISE, "
-		+ "RATE_CHANGE_QUEST_FALL, RATE_CHANGE_QUEST_RISE, "
-		+ "CONST_REJECT_DURATION, CONST_REJECT_MIN, CONST_REJECT_TOLERANCE, CONST_REJECT_N_MISS, "
-		+ "CONST_QUEST_DURATION, CONST_QUEST_MIN, CONST_QUEST_TOLERANCE, CONST_QUEST_N_MISS";
-//		+ "RANGE_ACTIVE_FLAG, RATE_CHANGE_ACTIVE_FLAG, CONST_ACTIVE_FLAG, DUR_MAG_ACTIVE_FLAG";
-	
-	public static final String screenControlTable = "CWMS_V_SCREENING_CONTROL";
-	public static final String screenControlColumns = "SCREENING_CODE, "
-		+ "RANGE_ACTIVE_FLAG, RATE_CHANGE_ACTIVE_FLAG, CONST_ACTIVE_FLAG, DUR_MAG_ACTIVE_FLAG";
+    // Screenings are allowed to stay in the cache for an hour
+    protected static DbObjectCache<Screening> cache = new DbObjectCache<Screening>(60 * 60 * 1000L, false);
 
-	public static final String durMagTable = "CWMS_V_SCREENING_DUR_MAG";
-	public static final String durMagColumns = "SCREENING_CODE, SEASON_START_DAY, SEASON_START_MONTH, "
-		+ "DUR_MAG_DURATION_ID, REJECT_LO, REJECT_HI, QUESTION_LO, QUESTION_HI";
-	
-	private CwmsDbVt csdbio = null;
+    // Associates a time series with a screening
+//    private static HashMap<TimeSeriesIdentifier, Screening> ts2screening = new HashMap<TimeSeriesIdentifier, Screening>();
 
-	public ScreeningDAO(DatabaseConnectionOwner tsdb)
-		throws DbIoException
-	{
-		super(tsdb, module);
-		try { csdbio = CwmsDbServiceLookup.buildCwmsDb(CwmsDbVt.class, getConnection()); }
-		catch(Exception ex)
-		{
-			String msg = module + " cannot create CwmsScreeningDbIo: " + ex;
-			Logger.instance().failure(msg);
-			System.err.println(msg);
-			ex.printStackTrace(System.err);
-			throw new DbIoException(msg);
-		}
-	}
-	
-	@Override
-	public void writeScreening(Screening screening)
-		throws DbIoException
-	{
-		Logger.instance().debug1(module + ".writeScreening(" + screening.getScreeningName() + ") key=" + screening.getScreeningCode());
-		
-		// if screening does not have a DbKey, try to get key through the unique id.
-		if (DbKey.isNull(screening.getScreeningCode()))
-			screening.setScreeningCode(getKeyForId(screening.getScreeningName()));
-		
-		try(Connection conn = getConnection();)
-		{
-			String officeId = ((CwmsTimeSeriesDb)db).getDbOfficeId();
-			String P_SCREENING_ID = screening.getScreeningName();
-			String P_DB_OFFICE_ID = officeId;
-			String P_SCREENING_ID_DESC = screening.getScreeningDesc();
+    /** Columns to read from cwms_v_screening_id to tell if a screening exists. */
+    public static final String screenIdTable = "CWMS_V_SCREENING_ID";
+    public static final String screenIdColumns = "SCREENING_CODE, SCREENING_ID, SCREENING_ID_DESC, "
+        + "PARAMETER_ID, PARAMETER_TYPE_ID, DURATION_ID";
 
-			// If it still does not have a key, create the screening id and assign a surrogate key.
-			if (DbKey.isNull(screening.getScreeningCode()))
-			{
-				if (screening.getScreeningName() == null || screening.getScreeningName().length() > 16)
-					throw new DbIoException(module + " invalid screeningId '" + screening.getScreeningName()
-						+ "' must be a string of 16 chars or less");
-				
-				String P_PARAMETER_ID = screening.getParamId();
-				String P_PARAMETER_TYPE_ID = screening.getParamTypeId();
-				String P_DURATION_ID = screening.getDurationId();
-				
-				Logger.instance().info("Creating screening '" + screening.getScreeningName() + "' param="
-					+ screening.getParamId() + ", paramType=" + screening.getParamTypeId() + ", dur="
-					+ screening.getDurationId() + ", officeId=" + officeId);
+    /** Columns in cwms_v_screening_criteria to read screening criteria info */
+    public static final String screenCritTable = "CWMS_V_SCREENING_CRITERIA";
+    public static final String screenCritColumns = "SCREENING_CODE, "
+        + "SEASON_START_DAY, SEASON_START_MONTH, "
+        + "ESTIMATE_EXPRESSION, "
+        + "RANGE_REJECT_LO, RANGE_REJECT_HI, RANGE_QUESTION_LO, RANGE_QUESTION_HI, "
+        + "RATE_CHANGE_REJECT_FALL, RATE_CHANGE_REJECT_RISE, "
+        + "RATE_CHANGE_QUEST_FALL, RATE_CHANGE_QUEST_RISE, "
+        + "CONST_REJECT_DURATION, CONST_REJECT_MIN, CONST_REJECT_TOLERANCE, CONST_REJECT_N_MISS, "
+        + "CONST_QUEST_DURATION, CONST_QUEST_MIN, CONST_QUEST_TOLERANCE, CONST_QUEST_N_MISS";
+//        + "RANGE_ACTIVE_FLAG, RATE_CHANGE_ACTIVE_FLAG, CONST_ACTIVE_FLAG, DUR_MAG_ACTIVE_FLAG";
+
+    public static final String screenControlTable = "CWMS_V_SCREENING_CONTROL";
+    public static final String screenControlColumns = "SCREENING_CODE, "
+        + "RANGE_ACTIVE_FLAG, RATE_CHANGE_ACTIVE_FLAG, CONST_ACTIVE_FLAG, DUR_MAG_ACTIVE_FLAG";
+
+    public static final String durMagTable = "CWMS_V_SCREENING_DUR_MAG";
+    public static final String durMagColumns = "SCREENING_CODE, SEASON_START_DAY, SEASON_START_MONTH, "
+        + "DUR_MAG_DURATION_ID, REJECT_LO, REJECT_HI, QUESTION_LO, QUESTION_HI";
+
+    private CwmsDbVt csdbio = null;
+
+    public ScreeningDAO(DatabaseConnectionOwner tsdb)
+        throws DbIoException
+    {
+        super(tsdb, module);
+        try { csdbio = CwmsDbServiceLookup.buildCwmsDb(CwmsDbVt.class, getConnection()); }
+        catch(Exception ex)
+        {
+            String msg = module + " cannot create CwmsScreeningDbIo: " + ex;
+            Logger.instance().failure(msg);
+            System.err.println(msg);
+            ex.printStackTrace(System.err);
+            throw new DbIoException(msg);
+        }
+    }
+
+    @Override
+    public void writeScreening(Screening screening)
+        throws DbIoException
+    {
+        Logger.instance().debug1(module + ".writeScreening(" + screening.getScreeningName() + ") key=" + screening.getScreeningCode());
+
+        // if screening does not have a DbKey, try to get key through the unique id.
+        if (DbKey.isNull(screening.getScreeningCode()))
+            screening.setScreeningCode(getKeyForId(screening.getScreeningName()));
+
+        try(Connection conn = getConnection();)
+        {
+            String officeId = ((CwmsTimeSeriesDb)db).getDbOfficeId();
+            String P_SCREENING_ID = screening.getScreeningName();
+            String P_DB_OFFICE_ID = officeId;
+            String P_SCREENING_ID_DESC = screening.getScreeningDesc();
+
+            // If it still does not have a key, create the screening id and assign a surrogate key.
+            if (DbKey.isNull(screening.getScreeningCode()))
+            {
+                if (screening.getScreeningName() == null || screening.getScreeningName().length() > 16)
+                    throw new DbIoException(module + " invalid screeningId '" + screening.getScreeningName()
+                        + "' must be a string of 16 chars or less");
+
+                String P_PARAMETER_ID = screening.getParamId();
+                String P_PARAMETER_TYPE_ID = screening.getParamTypeId();
+                String P_DURATION_ID = screening.getDurationId();
+
+                Logger.instance().info("Creating screening '" + screening.getScreeningName() + "' param="
+                    + screening.getParamId() + ", paramType=" + screening.getParamTypeId() + ", dur="
+                    + screening.getDurationId() + ", officeId=" + officeId);
 //System.out.println("Calling create Screening with P_PARAMETER_ID=" + P_PARAMETER_ID);
-				csdbio.createScreeningId(conn,
-					P_SCREENING_ID, P_SCREENING_ID_DESC, P_PARAMETER_ID,
-					P_PARAMETER_TYPE_ID, P_DURATION_ID, P_DB_OFFICE_ID);
-				
-				screening.setScreeningCode(getKeyForId(screening.getScreeningName()));
-				Logger.instance().info("after creation, screening code = " + screening.getScreeningCode());
-				
-				if (DbKey.isNull(screening.getScreeningCode()))
-					throw new DbIoException("Key for screening '" + screening.getScreeningName() 
-						+ "' does not exist and cannot be created.");
-			}
-			else // Screening exists. The only thing that can be changed is the description.
-			{
-				Logger.instance().info("Screening already exists with key=" + screening.getScreeningCode()
-					+ ", updating description.");
-				csdbio.updateScreeningIdDesc(conn,
-					P_SCREENING_ID, P_SCREENING_ID_DESC, P_DB_OFFICE_ID);
-			}
-			
-			// Translate the CCP's array list of ScreeningCriteria into an Oracle ScreenCritArray
-			ArrayList<ScreeningCriteria> cpCriteriaArray = screening.getCriteriaSeasons();
-			if (cpCriteriaArray.size() == 0)
-			{
-				warning("Screening " + screening.getScreeningName() + " has no criteria sets.");
-				return; // No criteria to write
-			}
-			
-			ScreenCritType oracleScreenCrit[] = new ScreenCritType[cpCriteriaArray.size()];
-			for(int critIdx = 0; critIdx < cpCriteriaArray.size(); critIdx++)
-			{
-				ScreeningCriteria cpCrit = cpCriteriaArray.get(critIdx);
-				
-				ArrayList<DurCheckPeriod> cpDurCheckPeriods = cpCrit.getDurCheckPeriods();
-				HashMap<String, ScreenDurMagType> season_oracleDurMag = new HashMap<String, ScreenDurMagType>();
+                csdbio.createScreeningId(conn,
+                    P_SCREENING_ID, P_SCREENING_ID_DESC, P_PARAMETER_ID,
+                    P_PARAMETER_TYPE_ID, P_DURATION_ID, P_DB_OFFICE_ID);
 
-				for(int durIdx = 0; durIdx < cpDurCheckPeriods.size(); durIdx++)
-				{
-					DurCheckPeriod cpDCP = cpDurCheckPeriods.get(durIdx);
-					
-					ScreenDurMagType oracleDurMagType = season_oracleDurMag.get(cpDCP.getDuration());
-					if (oracleDurMagType == null)
-					{
-						oracleDurMagType = new ScreenDurMagType();
-						oracleDurMagType.setDurationId(cpDCP.getDuration());
-						season_oracleDurMag.put(cpDCP.getDuration(), oracleDurMagType);
-					}
-					if (cpDCP.getFlag() == 'Q')
-					{
-						oracleDurMagType.setQuestionLo(BigDecimal.valueOf(cpDCP.getLow()));
-						oracleDurMagType.setQuestionHi(BigDecimal.valueOf(cpDCP.getHigh()));
-					}
-					else if (cpDCP.getFlag() == 'R')
-					{
-						oracleDurMagType.setRejectLo(BigDecimal.valueOf(cpDCP.getLow()));
-						oracleDurMagType.setRejectHi(BigDecimal.valueOf(cpDCP.getHigh()));
-					}
-				}
-				
-				ScreenDurMagType oracleDurMagTypeArray[] = new ScreenDurMagType[season_oracleDurMag.size()];
-				season_oracleDurMag.values().toArray(oracleDurMagTypeArray);
-				
-				AbsCheck qAbsCheck = cpCrit.getAbsCheckFor('Q');
-				AbsCheck rAbsCheck = cpCrit.getAbsCheckFor('R');
-				RocPerHourCheck qRocCheck = cpCrit.getRocCheckFor('Q');
-				RocPerHourCheck rRocCheck = cpCrit.getRocCheckFor('R');
-				ConstCheck qConstCheck = cpCrit.getConstCheckFor('Q');
-				ConstCheck rConstCheck = cpCrit.getConstCheckFor('R');
-	
-				int startDay = cpCrit.getSeasonStart() == null ? 0 : cpCrit.getSeasonStart().get(Calendar.DAY_OF_MONTH);
-				int startMonth = cpCrit.getSeasonStart() == null ? 0 : (cpCrit.getSeasonStart().get(Calendar.MONTH)+1);
-				info("Preparing crit with season " + startMonth + "/" + startDay);
+                screening.setScreeningCode(getKeyForId(screening.getScreeningName()));
+                Logger.instance().info("after creation, screening code = " + screening.getScreeningCode());
 
-				oracleScreenCrit[critIdx] = new ScreenCritType(
-					BigDecimal.valueOf(startDay),
-					BigDecimal.valueOf(startMonth),
-					rAbsCheck == null ? null : rAbsCheck.getLow() == Double.NEGATIVE_INFINITY ? null : BigDecimal.valueOf(rAbsCheck.getLow()),
-					rAbsCheck == null ? null : rAbsCheck.getHigh() == Double.POSITIVE_INFINITY ? null : BigDecimal.valueOf(rAbsCheck.getHigh()),
-					qAbsCheck == null ? null : qAbsCheck.getLow() == Double.NEGATIVE_INFINITY ? null : BigDecimal.valueOf(qAbsCheck.getLow()),
-					qAbsCheck == null ? null : qAbsCheck.getHigh() == Double.POSITIVE_INFINITY ? null : BigDecimal.valueOf(qAbsCheck.getHigh()),
-					rRocCheck == null ? null : rRocCheck.getRise() == Double.POSITIVE_INFINITY ? null : BigDecimal.valueOf(rRocCheck.getRise()),
-					rRocCheck == null ? null : rRocCheck.getFall() == Double.NEGATIVE_INFINITY ? null : BigDecimal.valueOf(rRocCheck.getFall()),
-					qRocCheck == null ? null : qRocCheck.getRise() == Double.POSITIVE_INFINITY ? null : BigDecimal.valueOf(qRocCheck.getRise()),
-					qRocCheck == null ? null : qRocCheck.getFall() == Double.NEGATIVE_INFINITY ? null : BigDecimal.valueOf(qRocCheck.getFall()),
-						
-					rConstCheck == null ? null : rConstCheck.getDuration(),
-					rConstCheck == null ? null : BigDecimal.valueOf(rConstCheck.getMinToCheck()),
-					rConstCheck == null ? null : BigDecimal.valueOf(rConstCheck.getTolerance()),
-					rConstCheck == null ? null : BigDecimal.valueOf(rConstCheck.getAllowedMissing()),
-	
-					qConstCheck == null ? null : qConstCheck.getDuration(),
-					qConstCheck == null ? null : BigDecimal.valueOf(qConstCheck.getMinToCheck()),
-					qConstCheck == null ? null : BigDecimal.valueOf(qConstCheck.getTolerance()),
-					qConstCheck == null ? null : BigDecimal.valueOf(qConstCheck.getAllowedMissing()),
-						
-					cpCrit.getEstimateExpression(),
-					Arrays.asList(oracleDurMagTypeArray)
-				);
-			}
-			
-			List<ScreenCritType> oracleScreenCritArray = Arrays.asList(oracleScreenCrit);
-			
-			ScreeningControlT screenControlType = new ScreeningControlT(
-				screening.isRangeActive() ? "T" : "F",
-				screening.isRocActive() ? "T" : "F",
-				screening.isConstActive() ? "T" : "F",
-				screening.isDurMagActive() ? "T" : "F");
-			
-			info("Calling storeScreeningCriteria with " + oracleScreenCrit.length + " seasons.");
-			csdbio.storeScreeningCriteria(conn,
-				P_SCREENING_ID,
-				oracleScreenCritArray,
-				"1Hour",
-				screenControlType,
-				"DELETE INSERT",
-				true,
-				P_DB_OFFICE_ID,
-				screening.getCheckUnitsAbbr());
-		}
-		catch(SQLException ex)
-		{
-			String msg = module + ".writeScreening(" + screening.getScreeningName() + ") Error: " + ex;
-			Logger.instance().failure(msg);
-			System.err.println(msg);
-			ex.printStackTrace(System.err);
-			throw new DbIoException(msg,ex);
-		}
-		
-	}
-	
-	@Override
-	public void deleteScreening(Screening screening)
-		throws DbIoException
-	{
-		try (Connection conn = getConnection();)
-		{
-			csdbio.deleteScreeningId(conn,
-				screening.getScreeningName(),
-				screening.getParamId(),
-				screening.getParamTypeId(),
-				screening.getDurationId(),
-				true,
-				((CwmsTimeSeriesDb)db).getDbOfficeId());
-		}
-		catch (SQLException ex)
-		{
-			String msg = module + ".deleteScreening() error deleting screening '" + screening.getScreeningName()
-				+ "': " + ex;
-			warning(msg);
-			throw new DbIoException(msg);
-		}
-	}
+                if (DbKey.isNull(screening.getScreeningCode()))
+                    throw new DbIoException("Key for screening '" + screening.getScreeningName()
+                        + "' does not exist and cannot be created.");
+            }
+            else // Screening exists. The only thing that can be changed is the description.
+            {
+                Logger.instance().info("Screening already exists with key=" + screening.getScreeningCode()
+                    + ", updating description.");
+                csdbio.updateScreeningIdDesc(conn,
+                    P_SCREENING_ID, P_SCREENING_ID_DESC, P_DB_OFFICE_ID);
+            }
 
-	@Override
-	public Screening getByKey(DbKey screeningCode)
-		throws DbIoException, NoSuchObjectException
-	{
-		if (DbKey.isNull(screeningCode))
-			return null;
+            // Translate the CCP's array list of ScreeningCriteria into an Oracle ScreenCritArray
+            ArrayList<ScreeningCriteria> cpCriteriaArray = screening.getCriteriaSeasons();
+            if (cpCriteriaArray.size() == 0)
+            {
+                warning("Screening " + screening.getScreeningName() + " has no criteria sets.");
+                return; // No criteria to write
+            }
 
-		Screening tmp = cache.getByKey(screeningCode);
-		if (tmp != null)
-			return tmp;
+            ScreenCritType oracleScreenCrit[] = new ScreenCritType[cpCriteriaArray.size()];
+            for(int critIdx = 0; critIdx < cpCriteriaArray.size(); critIdx++)
+            {
+                ScreeningCriteria cpCrit = cpCriteriaArray.get(critIdx);
 
-		String q = "select distinct " + screenIdColumns + " from " + screenIdTable
-			+ " where screening_code = ?"
-			+ " ORDER BY SCREENING_ID";
+                ArrayList<DurCheckPeriod> cpDurCheckPeriods = cpCrit.getDurCheckPeriods();
+                HashMap<String, ScreenDurMagType> season_oracleDurMag = new HashMap<String, ScreenDurMagType>();
 
-		try
-		{
-			final Screening ret = getSingleResult(q,rs-> {
-					return rs2Screening(rs);
-				}, screeningCode);
+                for(int durIdx = 0; durIdx < cpDurCheckPeriods.size(); durIdx++)
+                {
+                    DurCheckPeriod cpDCP = cpDurCheckPeriods.get(durIdx);
 
-			if (ret == null)
-			{
-				throw new NoSuchObjectException("No screening with code=" + screeningCode);
-			}
+                    ScreenDurMagType oracleDurMagType = season_oracleDurMag.get(cpDCP.getDuration());
+                    if (oracleDurMagType == null)
+                    {
+                        oracleDurMagType = new ScreenDurMagType();
+                        oracleDurMagType.setDurationId(cpDCP.getDuration());
+                        season_oracleDurMag.put(cpDCP.getDuration(), oracleDurMagType);
+                    }
+                    if (cpDCP.getFlag() == 'Q')
+                    {
+                        oracleDurMagType.setQuestionLo(BigDecimal.valueOf(cpDCP.getLow()));
+                        oracleDurMagType.setQuestionHi(BigDecimal.valueOf(cpDCP.getHigh()));
+                    }
+                    else if (cpDCP.getFlag() == 'R')
+                    {
+                        oracleDurMagType.setRejectLo(BigDecimal.valueOf(cpDCP.getLow()));
+                        oracleDurMagType.setRejectHi(BigDecimal.valueOf(cpDCP.getHigh()));
+                    }
+                }
 
-			q = "select distinct " + screenControlColumns + " from " + screenControlTable
-				+ " where screening_code = ?";
-			doQuery(q, rs -> rsAddControl(rs, ret),screeningCode);
+                ScreenDurMagType oracleDurMagTypeArray[] = new ScreenDurMagType[season_oracleDurMag.size()];
+                season_oracleDurMag.values().toArray(oracleDurMagTypeArray);
 
-			q = "select distinct " + screenCritColumns + " from " + screenCritTable
-				+ " where screening_code = ?"
-				+ " and unit_system = 'SI'";
-			doQuery(q, rs -> rsAddCriteria(rs, ret),screeningCode);
+                AbsCheck qAbsCheck = cpCrit.getAbsCheckFor('Q');
+                AbsCheck rAbsCheck = cpCrit.getAbsCheckFor('R');
+                RocPerHourCheck qRocCheck = cpCrit.getRocCheckFor('Q');
+                RocPerHourCheck rRocCheck = cpCrit.getRocCheckFor('R');
+                ConstCheck qConstCheck = cpCrit.getConstCheckFor('Q');
+                ConstCheck rConstCheck = cpCrit.getConstCheckFor('R');
 
-			q = "select distinct " + durMagColumns + " from " + durMagTable
-				+ " where screening_code = ?"// + screeningCode
-				+ " and unit_system = 'SI'"
-				+ " and unit_id = ?"; // + sqlString(ret.getCheckUnitsAbbr());
-			doQuery(q, rs -> {
-				int day = rs.getInt(2);
-				int month = rs.getInt(3);
-				ScreeningCriteria crit = getCritFor(ret, day, month);
-				if (crit == null)
-				{
-					Calendar cal = makeCal(day,month);
-					crit = new ScreeningCriteria(cal);
-					ret.add(crit);
-				}
-				rsAddDurMag(rs, crit);
-			}, screeningCode,ret.getCheckUnitsAbbr());
+                int startDay = cpCrit.getSeasonStart() == null ? 0 : cpCrit.getSeasonStart().get(Calendar.DAY_OF_MONTH);
+                int startMonth = cpCrit.getSeasonStart() == null ? 0 : (cpCrit.getSeasonStart().get(Calendar.MONTH)+1);
+                info("Preparing crit with season " + startMonth + "/" + startDay);
 
-			checkUnits(ret);
-			cache.put(ret);
-			return ret;
-		}
-		catch (SQLException ex)
-		{
-			String msg = module + ".getByKey(): Error parsing results for query '" + q + "': " + ex;
-			throw new DbIoException(msg,ex);
-		}
-	}
-	
-	/*
-	 * TODO: This can probably be converted to a join and be cleaner.
-	 */
-	@Override
-	public List<Screening> getAllScreenings() throws DbIoException
-	{
-		String q = "select distinct " + screenIdColumns + " from cwms_v_screening_id "
-			+ " ORDER BY SCREENING_ID";
+                oracleScreenCrit[critIdx] = new ScreenCritType(
+                    BigDecimal.valueOf(startDay),
+                    BigDecimal.valueOf(startMonth),
+                    rAbsCheck == null ? null : rAbsCheck.getLow() == Double.NEGATIVE_INFINITY ? null : BigDecimal.valueOf(rAbsCheck.getLow()),
+                    rAbsCheck == null ? null : rAbsCheck.getHigh() == Double.POSITIVE_INFINITY ? null : BigDecimal.valueOf(rAbsCheck.getHigh()),
+                    qAbsCheck == null ? null : qAbsCheck.getLow() == Double.NEGATIVE_INFINITY ? null : BigDecimal.valueOf(qAbsCheck.getLow()),
+                    qAbsCheck == null ? null : qAbsCheck.getHigh() == Double.POSITIVE_INFINITY ? null : BigDecimal.valueOf(qAbsCheck.getHigh()),
+                    rRocCheck == null ? null : rRocCheck.getRise() == Double.POSITIVE_INFINITY ? null : BigDecimal.valueOf(rRocCheck.getRise()),
+                    rRocCheck == null ? null : rRocCheck.getFall() == Double.NEGATIVE_INFINITY ? null : BigDecimal.valueOf(rRocCheck.getFall()),
+                    qRocCheck == null ? null : qRocCheck.getRise() == Double.POSITIVE_INFINITY ? null : BigDecimal.valueOf(qRocCheck.getRise()),
+                    qRocCheck == null ? null : qRocCheck.getFall() == Double.NEGATIVE_INFINITY ? null : BigDecimal.valueOf(qRocCheck.getFall()),
 
-		try
-		{
-			final List<Screening> ret = getResults(q, rs -> rs2Screening(rs));
-			for(Screening s: ret)
-			{
-				cache.put(s);
-			}
+                    rConstCheck == null ? null : rConstCheck.getDuration(),
+                    rConstCheck == null ? null : BigDecimal.valueOf(rConstCheck.getMinToCheck()),
+                    rConstCheck == null ? null : BigDecimal.valueOf(rConstCheck.getTolerance()),
+                    rConstCheck == null ? null : BigDecimal.valueOf(rConstCheck.getAllowedMissing()),
 
-			q = "select distinct " + screenCritColumns + " from " + screenCritTable
-				+ " where upper(db_office_id) = ?"// + sqlString(((CwmsTimeSeriesDb)db).getDbOfficeId())
-				+ " and (unit_system = 'SI' or unit_system is null)";
-			doQuery(q, rs -> {
-				DbKey screeningCode = DbKey.createDbKey(rs, 1);
-				Screening screening = null;
-				for(Screening s : ret)
-					if (s.getScreeningCode().equals(screeningCode))
-					{
-						screening = s;
-						break;
-					}
-				if (screening == null)
-				{
-					warning("Screening criteria with code=" + screeningCode + " but there is no "
-						+ "matching screening id");
-					return; // shouldn't happen
-				}
-				rsAddCriteria(rs, screening);
-			}, ((CwmsTimeSeriesDb)db).getDbOfficeId());
+                    qConstCheck == null ? null : qConstCheck.getDuration(),
+                    qConstCheck == null ? null : BigDecimal.valueOf(qConstCheck.getMinToCheck()),
+                    qConstCheck == null ? null : BigDecimal.valueOf(qConstCheck.getTolerance()),
+                    qConstCheck == null ? null : BigDecimal.valueOf(qConstCheck.getAllowedMissing()),
 
-			q = "select distinct " + screenControlColumns + " from " + screenControlTable;
-			doQuery(q, rs -> {
-				DbKey screeningCode = DbKey.createDbKey(rs, 1);
-				Screening screening = null;
-				for(Screening s : ret)
-					if (s.getScreeningCode().equals(screeningCode))
-					{
-						screening = s;
-						break;
-					}
-				if (screening == null)
-				{
-					warning("Screening criteria with code=" + screeningCode + " but there is no "
-						+ "matching screening id");
-					return; // shouldn't happen
-				}
-				rsAddControl(rs, screening);
-			});
+                    cpCrit.getEstimateExpression(),
+                    Arrays.asList(oracleDurMagTypeArray)
+                );
+            }
 
-			q = "select distinct " + durMagColumns + " from " + durMagTable
-				+ " where upper(db_office_id) = ? " + sqlString(((CwmsTimeSeriesDb)db).getDbOfficeId())
-				+ " and (unit_system = 'SI' or unit_system is null)";
-			doQuery(q, rs -> {
-				DbKey screeningCode = DbKey.createDbKey(rs, 1);
-				Screening screening = null;
-				for(Screening s : ret)
-					if (s.getScreeningCode().equals(screeningCode))
-					{
-						screening = s;
-						break;
-					}
-				if (screening == null)
-					return; // shouldn't happen
+            List<ScreenCritType> oracleScreenCritArray = Arrays.asList(oracleScreenCrit);
 
-				int day = rs.getInt(2);
-				int month = rs.getInt(3);
-				ScreeningCriteria crit = getCritFor(screening, day, month);
-				if (crit == null)
-				{
-					Calendar cal = makeCal(day,month);
-					crit = new ScreeningCriteria(cal);
-					screening.add(crit);
-				}
-				rsAddDurMag(rs, crit);
-			},((CwmsTimeSeriesDb)db).getDbOfficeId());
-			
-			for(Screening scr : ret)
-			{
-				checkUnits(scr);
-			}
-			
-			return ret;
-		}
-		catch (SQLException ex)
-		{
-			String msg = module + ".getAllScreenings(): Error parsing results for query '" + q + "': " + ex;
-			throw new DbIoException(msg,ex);
-		}
-	}
-	
-	/** 
-	 * Called after freshly reading a screening in SI units from the database.
-	 * @param scr
-	 */
-	private void checkUnits(Screening scr)
-	{
-		if (DecodesSettings.instance().screeningUnitSystem.equalsIgnoreCase("SI"))
-			return;
+            ScreeningControlT screenControlType = new ScreeningControlT(
+                screening.isRangeActive() ? "T" : "F",
+                screening.isRocActive() ? "T" : "F",
+                screening.isConstActive() ? "T" : "F",
+                screening.isDurMagActive() ? "T" : "F");
 
-		String engUnits = 
-			((CwmsTimeSeriesDb)this.db).getBaseParam().getEnglishUnits4Param(
-				scr.getParamId());
-		if (engUnits != null && !engUnits.equalsIgnoreCase(scr.getCheckUnitsAbbr()))
-			try
-			{
-				scr.convertUnits(engUnits);
-			}
-			catch (NoConversionException ex)
-			{
-				warning("Screening '" + scr.getScreeningName() + "': " + ex);
-			}
-	}
+            info("Calling storeScreeningCriteria with " + oracleScreenCrit.length + " seasons.");
+            csdbio.storeScreeningCriteria(conn,
+                P_SCREENING_ID,
+                oracleScreenCritArray,
+                "1Hour",
+                screenControlType,
+                "DELETE INSERT",
+                true,
+                P_DB_OFFICE_ID,
+                screening.getCheckUnitsAbbr());
+        }
+        catch(SQLException ex)
+        {
+            String msg = module + ".writeScreening(" + screening.getScreeningName() + ") Error: " + ex;
+            Logger.instance().failure(msg);
+            System.err.println(msg);
+            ex.printStackTrace(System.err);
+            throw new DbIoException(msg,ex);
+        }
 
-	
-	@Override
-	public void clearCache()
-	{
-		cache.clear();
-	}
-	
-	@Override
-	public TsidScreeningAssignment getScreeningForTS(TimeSeriesIdentifier tsid)
-		throws DbIoException
-	{
-		String q = "select distinct screening_code, active_flag "
-			+ "from CWMS_V_SCREENED_TS_IDS "
-			+ "where DB_OFFICE_ID = " + sqlString(((CwmsTimeSeriesDb)db).getDbOfficeId())
-			+ " and TS_CODE = " + tsid.getKey();
-		ResultSet rs = doQuery(q);
-		
-		try
-		{
-			if (rs.next())
-			{
-				DbKey screeningCode = DbKey.createDbKey(rs, 1);
-				boolean active = TextUtil.str2boolean(rs.getString(2));
-				
-				Screening screening = null;
-				try { screening = getByKey(screeningCode); }
-				catch(NoSuchObjectException ex)
-				{
-					warning("Screening Code " + screeningCode + " refers to non-existent screening.");
-					return null;
-				}
+    }
 
-				return new TsidScreeningAssignment(tsid, screening, active);
-			}
-			else
-				return null;
-		}
-		catch (SQLException ex)
-		{
-			String msg = module + ".getScreeningForTS() Error reading screening assignment: " + ex;
-			throw new DbIoException(msg);
-		}
-	}
-	
+    @Override
+    public void deleteScreening(Screening screening)
+        throws DbIoException
+    {
+        try (Connection conn = getConnection();)
+        {
+            csdbio.deleteScreeningId(conn,
+                screening.getScreeningName(),
+                screening.getParamId(),
+                screening.getParamTypeId(),
+                screening.getDurationId(),
+                true,
+                ((CwmsTimeSeriesDb)db).getDbOfficeId());
+        }
+        catch (SQLException ex)
+        {
+            String msg = module + ".deleteScreening() error deleting screening '" + screening.getScreeningName()
+                + "': " + ex;
+            warning(msg);
+            throw new DbIoException(msg);
+        }
+    }
 
-	
-	/**
-	 * Passed a result set with screenIdColumns, parse & return a Screening object with no criteria.
-	 * @param rs the result set
-	 * @return the screening
-	 * @throws SQLException on error extracting resultset info
-	 */
-	private Screening rs2Screening(ResultSet rs)
-		throws SQLException
-	{
-		
-		DbKey screeningCode = DbKey.createDbKey(rs, 1);
-		String id = rs.getString(2);
-		String desc = rs.getString(3);
-		String paramId = rs.getString(4);
+    @Override
+    public Screening getByKey(DbKey screeningCode)
+        throws DbIoException, NoSuchObjectException
+    {
+        if (DbKey.isNull(screeningCode))
+            return null;
 
-		// Note the screening is created with the storage units ID for the base param ID
-		Screening ret = new Screening(screeningCode, id, desc, 
-			((CwmsTimeSeriesDb)db).getBaseParam().getStoreUnits4Param(paramId));
-		
-		ret.setParamId(paramId);
-		ret.setParamTypeId(rs.getString(5));
-		ret.setDurationId(rs.getString(6));
+        Screening tmp = cache.getByKey(screeningCode);
+        if (tmp != null)
+            return tmp;
 
-		// Now since we always query for SI units, set the check units to this param's
-		// SI units
-		ret.setCheckUnitsAbbr(((CwmsTimeSeriesDb)db).getBaseParam().getStoreUnits4Param(paramId));
-		
-		return ret;
-	}
-	
-	
-	/**
-	 * Passed a resultSet with ScreenCritColumns, parse a ScreeningCriteria object
-	 * and add it to the passed Screening object.
-	 * @param rs the result set
-	 * @param screening the screening to which to add
-	 * @throws SQLException on result set access error
-	 */
-	private void rsAddCriteria(ResultSet rs, Screening screening)
-		throws SQLException
-	{
-//		public static final String screenCritColumns = "SCREENING_CODE, "
-//	2		+ "SEASON_START_DAY, SEASON_START_MONTH, "
-//	4		+ "ESTIMATE_EXPRESSION, "
-//	5		+ "RANGE_REJECT_LO, RANGE_REJECT_HI, RANGE_QUESTION_LO, RANGE_QUESTION_HI, "
-//	9		+ "RATE_CHANGE_REJECT_RISE, RATE_CHANGE_REJECT_FALL, "
-//	11		+ "RATE_CHANGE_QUEST_RISE, RATE_CHANGE_QUEST_FALL, "
-//	13		+ "CONST_REJECT_DURATION, CONST_REJECT_MIN, CONST_REJECT_TOLERANCE, CONST_REJECT_N_MISS, "
-//	17		+ "CONST_QUEST_DURATION, CONST_QUEST_MIN, CONST_QUEST_TOLERANCE, CONST_QUEST_N_MISS, ";
+        String q = "select distinct " + screenIdColumns + " from " + screenIdTable
+            + " where screening_code = ?"
+            + " ORDER BY SCREENING_ID";
 
-		int seasonStartDay = rs.getInt(2);
-		int seasonStartMonth = rs.getInt(3);
-		Calendar seasonStart = seasonStartDay == 0 || seasonStartMonth == 0 ? null :
-			makeCal(seasonStartDay, seasonStartMonth);
-			
-		ScreeningCriteria crit = new ScreeningCriteria(seasonStart);
-		crit.setEstimateExpression(rs.getString(4));
-		
-		double lo = rs.getDouble(5);
-		if (rs.wasNull())
-			lo = Double.NEGATIVE_INFINITY;
-		double hi = rs.getDouble(6);
-		if (rs.wasNull())
-			hi = Double.POSITIVE_INFINITY;
-		if (lo != Double.NEGATIVE_INFINITY || hi != Double.POSITIVE_INFINITY)
-		{
-			crit.addAbsCheck(new AbsCheck('R', lo, hi));
-		}
-		
-		lo = rs.getDouble(7);
-		if (rs.wasNull())
-			lo = Double.NEGATIVE_INFINITY;
-		hi = rs.getDouble(8);
-		if (rs.wasNull())
-			hi = Double.POSITIVE_INFINITY;
-		if (lo != Double.NEGATIVE_INFINITY || hi != Double.POSITIVE_INFINITY)
-		{
-			crit.addAbsCheck(new AbsCheck('Q', lo, hi));
-		}
-		
-		double fall = rs.getDouble(9);
-		if (!rs.wasNull())
-		{
-			double rise = rs.getDouble(10);
-			if (!rs.wasNull())
-			{
-				crit.addRocPerHourCheck(new RocPerHourCheck('R', fall, rise));
-			}
-		}
+        try
+        {
+            final Screening ret = getSingleResult(q,rs-> {
+                    return rs2Screening(rs);
+                }, screeningCode);
 
-		fall = rs.getDouble(11);
-		if (!rs.wasNull())
-		{
-			double rise = rs.getDouble(12);
-			if (!rs.wasNull())
-			{
-				crit.addRocPerHourCheck(new RocPerHourCheck('Q', fall, rise));
-			}
-		}
-		
-		String dur = rs.getString(13);
-		if (dur != null && !dur.toLowerCase().startsWith("u"))
-		{
-			// ctor args: check, duration, min2Check, tolerance, allowedMissing
-			crit.addConstCheck(new ConstCheck('R', dur, rs.getDouble(14), rs.getDouble(15), rs.getInt(16)));
-		}
+            if (ret == null)
+            {
+                throw new NoSuchObjectException("No screening with code=" + screeningCode);
+            }
 
-		dur = rs.getString(17);
-		if (dur != null && !dur.toLowerCase().startsWith("u"))
-		{
-			// ctor args: check, duration, min2Check, tolerance, allowedMissing
-			crit.addConstCheck(new ConstCheck('Q', dur, rs.getDouble(18), rs.getDouble(19), rs.getInt(20)));
-		}
+            q = "select distinct " + screenControlColumns + " from " + screenControlTable
+                + " where screening_code = ?";
+            doQuery(q, rs -> rsAddControl(rs, ret),screeningCode);
+
+            q = "select distinct " + screenCritColumns + " from " + screenCritTable
+                + " where screening_code = ?"
+                + " and unit_system = 'SI'";
+            doQuery(q, rs -> rsAddCriteria(rs, ret),screeningCode);
+
+            q = "select distinct " + durMagColumns + " from " + durMagTable
+                + " where screening_code = ?"// + screeningCode
+                + " and unit_system = 'SI'"
+                + " and unit_id = ?"; // + sqlString(ret.getCheckUnitsAbbr());
+            doQuery(q, rs -> {
+                int day = rs.getInt(2);
+                int month = rs.getInt(3);
+                ScreeningCriteria crit = getCritFor(ret, day, month);
+                if (crit == null)
+                {
+                    Calendar cal = makeCal(day,month);
+                    crit = new ScreeningCriteria(cal);
+                    ret.add(crit);
+                }
+                rsAddDurMag(rs, crit);
+            }, screeningCode,ret.getCheckUnitsAbbr());
+
+            checkUnits(ret);
+            cache.put(ret);
+            return ret;
+        }
+        catch (SQLException ex)
+        {
+            String msg = module + ".getByKey(): Error parsing results for query '" + q + "': " + ex;
+            throw new DbIoException(msg,ex);
+        }
+    }
+
+    /*
+     * TODO: This can probably be converted to a join and be cleaner.
+     */
+    @Override
+    public List<Screening> getAllScreenings() throws DbIoException
+    {
+        String q = "select distinct " + screenIdColumns + " from cwms_v_screening_id "
+            + " ORDER BY SCREENING_ID";
+
+        try
+        {
+            final List<Screening> ret = getResults(q, rs -> rs2Screening(rs));
+            for(Screening s: ret)
+            {
+                cache.put(s);
+            }
+
+            q = "select distinct " + screenCritColumns + " from " + screenCritTable
+                + " where upper(db_office_id) = ?"// + sqlString(((CwmsTimeSeriesDb)db).getDbOfficeId())
+                + " and (unit_system = 'SI' or unit_system is null)";
+            doQuery(q, rs -> {
+                DbKey screeningCode = DbKey.createDbKey(rs, 1);
+                Screening screening = null;
+                for(Screening s : ret)
+                    if (s.getScreeningCode().equals(screeningCode))
+                    {
+                        screening = s;
+                        break;
+                    }
+                if (screening == null)
+                {
+                    warning("Screening criteria with code=" + screeningCode + " but there is no "
+                        + "matching screening id");
+                    return; // shouldn't happen
+                }
+                rsAddCriteria(rs, screening);
+            }, ((CwmsTimeSeriesDb)db).getDbOfficeId());
+
+            q = "select distinct " + screenControlColumns + " from " + screenControlTable;
+            doQuery(q, rs -> {
+                DbKey screeningCode = DbKey.createDbKey(rs, 1);
+                Screening screening = null;
+                for(Screening s : ret)
+                    if (s.getScreeningCode().equals(screeningCode))
+                    {
+                        screening = s;
+                        break;
+                    }
+                if (screening == null)
+                {
+                    warning("Screening criteria with code=" + screeningCode + " but there is no "
+                        + "matching screening id");
+                    return; // shouldn't happen
+                }
+                rsAddControl(rs, screening);
+            });
+
+            q = "select distinct " + durMagColumns + " from " + durMagTable
+                + " where upper(db_office_id) = ? " + sqlString(((CwmsTimeSeriesDb)db).getDbOfficeId())
+                + " and (unit_system = 'SI' or unit_system is null)";
+            doQuery(q, rs -> {
+                DbKey screeningCode = DbKey.createDbKey(rs, 1);
+                Screening screening = null;
+                for(Screening s : ret)
+                    if (s.getScreeningCode().equals(screeningCode))
+                    {
+                        screening = s;
+                        break;
+                    }
+                if (screening == null)
+                    return; // shouldn't happen
+
+                int day = rs.getInt(2);
+                int month = rs.getInt(3);
+                ScreeningCriteria crit = getCritFor(screening, day, month);
+                if (crit == null)
+                {
+                    Calendar cal = makeCal(day,month);
+                    crit = new ScreeningCriteria(cal);
+                    screening.add(crit);
+                }
+                rsAddDurMag(rs, crit);
+            },((CwmsTimeSeriesDb)db).getDbOfficeId());
+
+            for(Screening scr : ret)
+            {
+                checkUnits(scr);
+            }
+
+            return ret;
+        }
+        catch (SQLException ex)
+        {
+            String msg = module + ".getAllScreenings(): Error parsing results for query '" + q + "': " + ex;
+            throw new DbIoException(msg,ex);
+        }
+    }
+
+    /**
+     * Called after freshly reading a screening in SI units from the database.
+     * @param scr
+     */
+    private void checkUnits(Screening scr)
+    {
+        if (DecodesSettings.instance().screeningUnitSystem.equalsIgnoreCase("SI"))
+            return;
+
+        String engUnits =
+            ((CwmsTimeSeriesDb)this.db).getBaseParam().getEnglishUnits4Param(
+                scr.getParamId());
+        if (engUnits != null && !engUnits.equalsIgnoreCase(scr.getCheckUnitsAbbr()))
+            try
+            {
+                scr.convertUnits(engUnits);
+            }
+            catch (NoConversionException ex)
+            {
+                warning("Screening '" + scr.getScreeningName() + "': " + ex);
+            }
+    }
+
+
+    @Override
+    public void clearCache()
+    {
+        cache.clear();
+    }
+
+    @Override
+    public TsidScreeningAssignment getScreeningForTS(TimeSeriesIdentifier tsid)
+        throws DbIoException
+    {
+        String q = "select distinct screening_code, active_flag "
+            + "from CWMS_V_SCREENED_TS_IDS "
+            + "where DB_OFFICE_ID = " + sqlString(((CwmsTimeSeriesDb)db).getDbOfficeId())
+            + " and TS_CODE = " + tsid.getKey();
+        ResultSet rs = doQuery(q);
+
+        try
+        {
+            if (rs.next())
+            {
+                DbKey screeningCode = DbKey.createDbKey(rs, 1);
+                boolean active = TextUtil.str2boolean(rs.getString(2));
+
+                Screening screening = null;
+                try { screening = getByKey(screeningCode); }
+                catch(NoSuchObjectException ex)
+                {
+                    warning("Screening Code " + screeningCode + " refers to non-existent screening.");
+                    return null;
+                }
+
+                return new TsidScreeningAssignment(tsid, screening, active);
+            }
+            else
+                return null;
+        }
+        catch (SQLException ex)
+        {
+            String msg = module + ".getScreeningForTS() Error reading screening assignment: " + ex;
+            throw new DbIoException(msg);
+        }
+    }
+
+
+
+    /**
+     * Passed a result set with screenIdColumns, parse & return a Screening object with no criteria.
+     * @param rs the result set
+     * @return the screening
+     * @throws SQLException on error extracting resultset info
+     */
+    private Screening rs2Screening(ResultSet rs)
+        throws SQLException
+    {
+
+        DbKey screeningCode = DbKey.createDbKey(rs, 1);
+        String id = rs.getString(2);
+        String desc = rs.getString(3);
+        String paramId = rs.getString(4);
+
+        // Note the screening is created with the storage units ID for the base param ID
+        Screening ret = new Screening(screeningCode, id, desc,
+            ((CwmsTimeSeriesDb)db).getBaseParam().getStoreUnits4Param(paramId));
+
+        ret.setParamId(paramId);
+        ret.setParamTypeId(rs.getString(5));
+        ret.setDurationId(rs.getString(6));
+
+        // Now since we always query for SI units, set the check units to this param's
+        // SI units
+        ret.setCheckUnitsAbbr(((CwmsTimeSeriesDb)db).getBaseParam().getStoreUnits4Param(paramId));
+
+        return ret;
+    }
+
+
+    /**
+     * Passed a resultSet with ScreenCritColumns, parse a ScreeningCriteria object
+     * and add it to the passed Screening object.
+     * @param rs the result set
+     * @param screening the screening to which to add
+     * @throws SQLException on result set access error
+     */
+    private void rsAddCriteria(ResultSet rs, Screening screening)
+        throws SQLException
+    {
+//        public static final String screenCritColumns = "SCREENING_CODE, "
+//    2        + "SEASON_START_DAY, SEASON_START_MONTH, "
+//    4        + "ESTIMATE_EXPRESSION, "
+//    5        + "RANGE_REJECT_LO, RANGE_REJECT_HI, RANGE_QUESTION_LO, RANGE_QUESTION_HI, "
+//    9        + "RATE_CHANGE_REJECT_RISE, RATE_CHANGE_REJECT_FALL, "
+//    11        + "RATE_CHANGE_QUEST_RISE, RATE_CHANGE_QUEST_FALL, "
+//    13        + "CONST_REJECT_DURATION, CONST_REJECT_MIN, CONST_REJECT_TOLERANCE, CONST_REJECT_N_MISS, "
+//    17        + "CONST_QUEST_DURATION, CONST_QUEST_MIN, CONST_QUEST_TOLERANCE, CONST_QUEST_N_MISS, ";
+
+        int seasonStartDay = rs.getInt(2);
+        int seasonStartMonth = rs.getInt(3);
+        Calendar seasonStart = seasonStartDay == 0 || seasonStartMonth == 0 ? null :
+            makeCal(seasonStartDay, seasonStartMonth);
+
+        ScreeningCriteria crit = new ScreeningCriteria(seasonStart);
+        crit.setEstimateExpression(rs.getString(4));
+
+        double lo = rs.getDouble(5);
+        if (rs.wasNull())
+            lo = Double.NEGATIVE_INFINITY;
+        double hi = rs.getDouble(6);
+        if (rs.wasNull())
+            hi = Double.POSITIVE_INFINITY;
+        if (lo != Double.NEGATIVE_INFINITY || hi != Double.POSITIVE_INFINITY)
+        {
+            crit.addAbsCheck(new AbsCheck('R', lo, hi));
+        }
+
+        lo = rs.getDouble(7);
+        if (rs.wasNull())
+            lo = Double.NEGATIVE_INFINITY;
+        hi = rs.getDouble(8);
+        if (rs.wasNull())
+            hi = Double.POSITIVE_INFINITY;
+        if (lo != Double.NEGATIVE_INFINITY || hi != Double.POSITIVE_INFINITY)
+        {
+            crit.addAbsCheck(new AbsCheck('Q', lo, hi));
+        }
+
+        double fall = rs.getDouble(9);
+        if (!rs.wasNull())
+        {
+            double rise = rs.getDouble(10);
+            if (!rs.wasNull())
+            {
+                crit.addRocPerHourCheck(new RocPerHourCheck('R', fall, rise));
+            }
+        }
+
+        fall = rs.getDouble(11);
+        if (!rs.wasNull())
+        {
+            double rise = rs.getDouble(12);
+            if (!rs.wasNull())
+            {
+                crit.addRocPerHourCheck(new RocPerHourCheck('Q', fall, rise));
+            }
+        }
+
+        String dur = rs.getString(13);
+        if (dur != null && !dur.toLowerCase().startsWith("u"))
+        {
+            // ctor args: check, duration, min2Check, tolerance, allowedMissing
+            crit.addConstCheck(new ConstCheck('R', dur, rs.getDouble(14), rs.getDouble(15), rs.getInt(16)));
+        }
+
+        dur = rs.getString(17);
+        if (dur != null && !dur.toLowerCase().startsWith("u"))
+        {
+            // ctor args: check, duration, min2Check, tolerance, allowedMissing
+            crit.addConstCheck(new ConstCheck('Q', dur, rs.getDouble(18), rs.getDouble(19), rs.getInt(20)));
+        }
 
 // In CCP view, these are moved to separate view.
-//		// These flags really should be in the ID view but they are not.
-//		// They come from at_screening_criteria and are only available in the criteria view.
-//		screening.setRangeActive(TextUtil.str2boolean(rs.getString(21)));
-//		screening.setRocActive(TextUtil.str2boolean(rs.getString(22)));
-//		screening.setConstActive(TextUtil.str2boolean(rs.getString(23)));
-//		screening.setDurMagActive(TextUtil.str2boolean(rs.getString(24)));
-		
-		screening.add(crit);
-	}
-	
-	
-	private void rsAddControl(ResultSet rs, Screening screening)
-		throws SQLException
-	{
-//		public static final String screenControlColumns = "SCREENING_CODE, "
-//			+ "RANGE_ACTIVE_FLAG, RATE_CHANGE_ACTIVE_FLAG, CONST_ACTIVE_FLAG, DUR_MAG_ACTIVE_FLAG";
-		screening.setRangeActive(TextUtil.str2boolean(rs.getString(2)));
-		screening.setRocActive(TextUtil.str2boolean(rs.getString(3)));
-		screening.setConstActive(TextUtil.str2boolean(rs.getString(4)));
-		screening.setDurMagActive(TextUtil.str2boolean(rs.getString(5)));
-	}
+//        // These flags really should be in the ID view but they are not.
+//        // They come from at_screening_criteria and are only available in the criteria view.
+//        screening.setRangeActive(TextUtil.str2boolean(rs.getString(21)));
+//        screening.setRocActive(TextUtil.str2boolean(rs.getString(22)));
+//        screening.setConstActive(TextUtil.str2boolean(rs.getString(23)));
+//        screening.setDurMagActive(TextUtil.str2boolean(rs.getString(24)));
+
+        screening.add(crit);
+    }
 
 
-	
-	/**
-	 * Passed a result set for durMagColumns and a criteria object, parse the coefficients and
-	 * add the appropriate DurCheckPeriod objects
-	 * @param rs the result set
-	 * @param crit the ScreeningCriteria
-	 * @throws SQLException on parsing result set
-	 */
-	private void rsAddDurMag(ResultSet rs, ScreeningCriteria crit)
-		throws SQLException
-	{
-//		public static final String durMagColumns = "SCREENING_CODE, SEASON_START_DAY, SEASON_START_MONTH, "
-//			+ "DUR_MAG_DURATION_ID, REJECT_LO, REJECT_HI, QUESTION_LO, QUESTION_HI";
+    private void rsAddControl(ResultSet rs, Screening screening)
+        throws SQLException
+    {
+//        public static final String screenControlColumns = "SCREENING_CODE, "
+//            + "RANGE_ACTIVE_FLAG, RATE_CHANGE_ACTIVE_FLAG, CONST_ACTIVE_FLAG, DUR_MAG_ACTIVE_FLAG";
+        screening.setRangeActive(TextUtil.str2boolean(rs.getString(2)));
+        screening.setRocActive(TextUtil.str2boolean(rs.getString(3)));
+        screening.setConstActive(TextUtil.str2boolean(rs.getString(4)));
+        screening.setDurMagActive(TextUtil.str2boolean(rs.getString(5)));
+    }
 
-		String dur = rs.getString(4);
-		double lo = rs.getDouble(5);
-		if (rs.wasNull())
-			lo = Double.NEGATIVE_INFINITY;
-		double hi = rs.getDouble(6);
-		if (rs.wasNull())
-			hi = Double.POSITIVE_INFINITY;
-		if (lo != Double.NEGATIVE_INFINITY || hi != Double.POSITIVE_INFINITY)
-			crit.addDurCheckPeriod(new DurCheckPeriod('R', dur, lo, hi));
- 
-		lo = rs.getDouble(7);
-		if (rs.wasNull())
-			lo = Double.NEGATIVE_INFINITY;
-		hi = rs.getDouble(8);
-		if (rs.wasNull())
-			hi = Double.POSITIVE_INFINITY;
-		if (lo != Double.NEGATIVE_INFINITY || hi != Double.POSITIVE_INFINITY)
-			crit.addDurCheckPeriod(new DurCheckPeriod('Q', dur, lo, hi));
-	}
-	
-	/**
-	 * Pass screening and day & month as they exist in the table.
-	 * @param screening the screening
-	 * @param day the day in the table (0 means null)
-	 * @param month the month in the table (0 means null)
-	 * @return the matching criteria object, or null if not found
-	 */
-	private ScreeningCriteria getCritFor(Screening screening, int day, int month)
-	{
-		for (ScreeningCriteria crit : screening.getCriteriaSeasons())
-			if (crit.getSeasonStart() == null)
-			{
-				if (day == 0 || month == 0)
-					return crit;
-			}
-			else if (crit.getSeasonStart().get(Calendar.MONTH)+1 == month
-				  && crit.getSeasonStart().get(Calendar.DAY_OF_MONTH) == day)
-				return crit;
-		return null;
-	}
-			
-	/**
-	 * Given a string screening ID, return the surrogate key, or null if none exists
-	 * @param screeningId the unique string screening ID
-	 * @return surrogate key or DbKey.NullKey if no match in database
-	 * @throws DbIoException on database SQL error
-	 */
-	@Override
-	public DbKey getKeyForId(String screeningId)
-		throws DbIoException
-	{
-		try
-		{
-			String P_SCREENING_ID = screeningId;
-			long P_DB_OFFICE_CODE = ((CwmsTimeSeriesDb)db).getDbOfficeCode().getValue();
-			BigDecimal O_RET = csdbio.getScreeningCode(getConnection(), P_SCREENING_ID, (double)P_DB_OFFICE_CODE);
-			return O_RET == null ? DbKey.NullKey : DbKey.createDbKey(O_RET.longValue());
-		}
-		catch (SQLException ex)
-		{
-			if (ex.toString().contains("DOES_NOT_EXIST"))
-				return DbKey.NullKey;
-			
-			String msg = module + " getKeyForId(" + screeningId + ") error: " + ex;
-			Logger.instance().failure(msg);
-			System.err.println(msg);
-			ex.printStackTrace(System.err);
-			throw new DbIoException(msg);
-		}
-	}
-	
-	/**
-	 * Passed day & month as they are in the table, return a calendar set to
-	 * midnight on the specified day/month. Return null if day or month are out of range.
-	 * Day and month should be 0 (meaning they are null in the table) for criteria that
-	 * should apply all year.
-	 * @param day the day, or 0 if all-year
-	 * @param month the month, or 0 if all-year
-	 * @return the calender or null
-	 */
-	private Calendar makeCal(int day, int month)
-	{
-		Calendar cal = null;
-		if (day >=1 && day <= 31
-		 && month >= 1 && month <= 12)
-		{
-			cal = Calendar.getInstance();
-			cal.set(Calendar.MONTH, month-1);
-			cal.set(Calendar.DAY_OF_MONTH, day);
-			cal.set(Calendar.HOUR_OF_DAY, 0);
-			cal.set(Calendar.MINUTE, 0);
-			cal.set(Calendar.SECOND, 0);
-			cal.set(Calendar.MILLISECOND, 0);
-		}
-Logger.instance().debug1("ScreeningDAO.makeCal day=" + day + ", mon=" + month 
+
+
+    /**
+     * Passed a result set for durMagColumns and a criteria object, parse the coefficients and
+     * add the appropriate DurCheckPeriod objects
+     * @param rs the result set
+     * @param crit the ScreeningCriteria
+     * @throws SQLException on parsing result set
+     */
+    private void rsAddDurMag(ResultSet rs, ScreeningCriteria crit)
+        throws SQLException
+    {
+//        public static final String durMagColumns = "SCREENING_CODE, SEASON_START_DAY, SEASON_START_MONTH, "
+//            + "DUR_MAG_DURATION_ID, REJECT_LO, REJECT_HI, QUESTION_LO, QUESTION_HI";
+
+        String dur = rs.getString(4);
+        double lo = rs.getDouble(5);
+        if (rs.wasNull())
+            lo = Double.NEGATIVE_INFINITY;
+        double hi = rs.getDouble(6);
+        if (rs.wasNull())
+            hi = Double.POSITIVE_INFINITY;
+        if (lo != Double.NEGATIVE_INFINITY || hi != Double.POSITIVE_INFINITY)
+            crit.addDurCheckPeriod(new DurCheckPeriod('R', dur, lo, hi));
+
+        lo = rs.getDouble(7);
+        if (rs.wasNull())
+            lo = Double.NEGATIVE_INFINITY;
+        hi = rs.getDouble(8);
+        if (rs.wasNull())
+            hi = Double.POSITIVE_INFINITY;
+        if (lo != Double.NEGATIVE_INFINITY || hi != Double.POSITIVE_INFINITY)
+            crit.addDurCheckPeriod(new DurCheckPeriod('Q', dur, lo, hi));
+    }
+
+    /**
+     * Pass screening and day & month as they exist in the table.
+     * @param screening the screening
+     * @param day the day in the table (0 means null)
+     * @param month the month in the table (0 means null)
+     * @return the matching criteria object, or null if not found
+     */
+    private ScreeningCriteria getCritFor(Screening screening, int day, int month)
+    {
+        for (ScreeningCriteria crit : screening.getCriteriaSeasons())
+            if (crit.getSeasonStart() == null)
+            {
+                if (day == 0 || month == 0)
+                    return crit;
+            }
+            else if (crit.getSeasonStart().get(Calendar.MONTH)+1 == month
+                  && crit.getSeasonStart().get(Calendar.DAY_OF_MONTH) == day)
+                return crit;
+        return null;
+    }
+
+    /**
+     * Given a string screening ID, return the surrogate key, or null if none exists
+     * @param screeningId the unique string screening ID
+     * @return surrogate key or DbKey.NullKey if no match in database
+     * @throws DbIoException on database SQL error
+     */
+    @Override
+    public DbKey getKeyForId(String screeningId)
+        throws DbIoException
+    {
+        try
+        {
+            String P_SCREENING_ID = screeningId;
+            long P_DB_OFFICE_CODE = ((CwmsTimeSeriesDb)db).getDbOfficeCode().getValue();
+            BigDecimal O_RET = csdbio.getScreeningCode(getConnection(), P_SCREENING_ID, (double)P_DB_OFFICE_CODE);
+            return O_RET == null ? DbKey.NullKey : DbKey.createDbKey(O_RET.longValue());
+        }
+        catch (SQLException ex)
+        {
+            if (ex.toString().contains("DOES_NOT_EXIST"))
+                return DbKey.NullKey;
+
+            String msg = module + " getKeyForId(" + screeningId + ") error: " + ex;
+            Logger.instance().failure(msg);
+            System.err.println(msg);
+            ex.printStackTrace(System.err);
+            throw new DbIoException(msg);
+        }
+    }
+
+    /**
+     * Passed day & month as they are in the table, return a calendar set to
+     * midnight on the specified day/month. Return null if day or month are out of range.
+     * Day and month should be 0 (meaning they are null in the table) for criteria that
+     * should apply all year.
+     * @param day the day, or 0 if all-year
+     * @param month the month, or 0 if all-year
+     * @return the calender or null
+     */
+    private Calendar makeCal(int day, int month)
+    {
+        Calendar cal = null;
+        if (day >=1 && day <= 31
+         && month >= 1 && month <= 12)
+        {
+            cal = Calendar.getInstance();
+            cal.set(Calendar.MONTH, month-1);
+            cal.set(Calendar.DAY_OF_MONTH, day);
+            cal.set(Calendar.HOUR_OF_DAY, 0);
+            cal.set(Calendar.MINUTE, 0);
+            cal.set(Calendar.SECOND, 0);
+            cal.set(Calendar.MILLISECOND, 0);
+        }
+Logger.instance().debug1("ScreeningDAO.makeCal day=" + day + ", mon=" + month
 + ", calendar day=" + cal.get(Calendar.DAY_OF_MONTH) + ", cal.mon=" + cal.get(Calendar.MONTH));
-		return cal;
-	}
+        return cal;
+    }
 
-	@Override
-	public ArrayList<TsidScreeningAssignment> getTsidScreeningAssignments(boolean activeOnly)
-		throws DbIoException
-	{
-		String q = "select distinct screening_code, ts_code, active_flag "
-			+ "from CWMS_V_SCREENED_TS_IDS "
-			+ "where DB_OFFICE_ID = " + sqlString(((CwmsTimeSeriesDb)db).getDbOfficeId());
-		if (activeOnly)
-			q = q + " and (upper(ACTIVE_FLAG) = 'T' or upper(ACTIVE_FLAG) = 'Y')";
-		
-		ArrayList<TsidScreeningAssignment> ret = new ArrayList<TsidScreeningAssignment>();
-		
-		class TSA 
-		{
-			DbKey screeningCode; DbKey tsCode; boolean active; 
-			TSA(DbKey sc, DbKey tc, boolean ac) { screeningCode = sc; tsCode = tc; active=ac; }
-		};
-		
-		ArrayList<TSA> results = new ArrayList<TSA>();
-		ResultSet rs = doQuery(q);
-		TimeSeriesDAI timeSeriesDAO = db.makeTimeSeriesDAO();
-		try
-		{
-			// Collect results first, then lookup objects to avoid nested queries.
-			while(rs.next())
-			{
-				DbKey screeningCode = DbKey.createDbKey(rs, 1);
-				DbKey tsCode = DbKey.createDbKey(rs, 2);
-				boolean active = TextUtil.str2boolean(rs.getString(3));
-				results.add(new TSA(screeningCode, tsCode, active));
-			}
-			for(TSA p : results)
-			{
-				Screening screening = null;
-				try { screening = getByKey(p.screeningCode); }
-				catch(NoSuchObjectException ex)
-				{
-					warning("Screening Code " + p.screeningCode + " refers to non-existent screening.");
-					continue;
-				}
-				TimeSeriesIdentifier tsid = null;
-				try
-				{
-					tsid = timeSeriesDAO.getTimeSeriesIdentifier(p.tsCode);
-				}
-				catch (NoSuchObjectException ex)
-				{
-					warning("Time Series Code " + p.tsCode + " for screening Screening Code " + p.screeningCode 
-						+ " refers to non-existent time series.");
-					continue;
-				}
-				ret.add(new TsidScreeningAssignment(tsid, screening, p.active));
-			}
-		}
-		catch(SQLException ex)
-		{
-			warning(module + ".getTsidScreeningAssociations() error in query '" + q + "': " + ex);
-		}
-		finally
-		{
-			timeSeriesDAO.close();
-		}
-		return ret;
-	}
+    @Override
+    public ArrayList<TsidScreeningAssignment> getTsidScreeningAssignments(boolean activeOnly)
+        throws DbIoException
+    {
+        String q = "select distinct screening_code, ts_code, active_flag "
+            + "from CWMS_V_SCREENED_TS_IDS "
+            + "where DB_OFFICE_ID = " + sqlString(((CwmsTimeSeriesDb)db).getDbOfficeId());
+        if (activeOnly)
+            q = q + " and (upper(ACTIVE_FLAG) = 'T' or upper(ACTIVE_FLAG) = 'Y')";
 
-	@Override
-	public void assignScreening(Screening screening, TimeSeriesIdentifier tsid, boolean active)
-		throws DbIoException
-	{
-		// Note: CCP ignores the resultant TS ID in the table. Results are assigned via CCP output params.
-		
-		try
-		{
-			List<ScreenAssignT> screenAssignTS = Collections.singletonList(
-				new ScreenAssignT(tsid.getUniqueString(), active, null));
-			
-			csdbio.assignScreeningId(getConnection(),
-				screening.getScreeningName(),
-				screenAssignTS, ((CwmsTimeSeriesDb)db).getDbOfficeId());
-		}
-		catch (SQLException ex)
-		{
-			String msg = module + ".assignScreening() error assigning screening '"
-				+ screening.getScreeningName() + "' to tsid '" + tsid.getUniqueString() + " with activeFlag="
-				+ active + ": " + ex;
-			warning(msg);
-			PrintStream ps = Logger.instance().getLogOutput();
-			if (ps != null)
-			{
-				ps.println("Cause is: " + ex);
-				ex.printStackTrace(ps);
-			}
-			throw new DbIoException(msg);
-		}
-	}
+        ArrayList<TsidScreeningAssignment> ret = new ArrayList<TsidScreeningAssignment>();
 
-	@Override
-	public void unassignScreening(Screening screening, TimeSeriesIdentifier tsid) throws DbIoException
-	{
-		try
-		{
-			csdbio.unassignScreeningId(getConnection(),
-				screening.getScreeningName(),
-				Collections.singletonList(tsid != null ? tsid.getUniqueString() : null),
-				tsid == null, 
-				((CwmsTimeSeriesDb)db).getDbOfficeId());
-		}
-		catch (SQLException ex)
-		{
-			ex.printStackTrace();
-		}
-	}
+        class TSA
+        {
+            DbKey screeningCode; DbKey tsCode; boolean active;
+            TSA(DbKey sc, DbKey tc, boolean ac) { screeningCode = sc; tsCode = tc; active=ac; }
+        };
 
-	@Override
-	public void renameScreening(String oldId, String newId) throws DbIoException
-	{
-		try
-		{
-			Logger.instance().info("Renaming screening '" + oldId + "' to '" + newId + "'");
-			csdbio.renameScreeningId(getConnection(),
-				oldId, 
-				newId, 
-				((CwmsTimeSeriesDb)db).getDbOfficeId());
-		}
-		catch (SQLException ex)
-		{
-			throw new DbIoException(module + ".renameScreening(" + oldId + ", " + newId
-				+ ": Error: " + ex);
-		}
-	}
+        ArrayList<TSA> results = new ArrayList<TSA>();
+        ResultSet rs = doQuery(q);
+        TimeSeriesDAI timeSeriesDAO = db.makeTimeSeriesDAO();
+        try
+        {
+            // Collect results first, then lookup objects to avoid nested queries.
+            while(rs.next())
+            {
+                DbKey screeningCode = DbKey.createDbKey(rs, 1);
+                DbKey tsCode = DbKey.createDbKey(rs, 2);
+                boolean active = TextUtil.str2boolean(rs.getString(3));
+                results.add(new TSA(screeningCode, tsCode, active));
+            }
+            for(TSA p : results)
+            {
+                Screening screening = null;
+                try { screening = getByKey(p.screeningCode); }
+                catch(NoSuchObjectException ex)
+                {
+                    warning("Screening Code " + p.screeningCode + " refers to non-existent screening.");
+                    continue;
+                }
+                TimeSeriesIdentifier tsid = null;
+                try
+                {
+                    tsid = timeSeriesDAO.getTimeSeriesIdentifier(p.tsCode);
+                }
+                catch (NoSuchObjectException ex)
+                {
+                    warning("Time Series Code " + p.tsCode + " for screening Screening Code " + p.screeningCode
+                        + " refers to non-existent time series.");
+                    continue;
+                }
+                ret.add(new TsidScreeningAssignment(tsid, screening, p.active));
+            }
+        }
+        catch(SQLException ex)
+        {
+            warning(module + ".getTsidScreeningAssociations() error in query '" + q + "': " + ex);
+        }
+        finally
+        {
+            timeSeriesDAO.close();
+        }
+        return ret;
+    }
 
-	@Override
-	public void updateScreeningDescription(String screeningId, String desc) throws DbIoException
-	{
-		
-		try
-		{
-			csdbio.updateScreeningIdDesc(getConnection(),
-				screeningId, 
-				desc, 
-				((CwmsTimeSeriesDb)db).getDbOfficeId());
-		}
-		catch (SQLException ex)
-		{
-			throw new DbIoException(module + ".renameScreening(" + screeningId + ", " + desc
-				+ ": Error: " + ex);
-		}
-	}
+    @Override
+    public void assignScreening(Screening screening, TimeSeriesIdentifier tsid, boolean active)
+        throws DbIoException
+    {
+        // Note: CCP ignores the resultant TS ID in the table. Results are assigned via CCP output params.
+
+        try
+        {
+            List<ScreenAssignT> screenAssignTS = Collections.singletonList(
+                new ScreenAssignT(tsid.getUniqueString(), active, null));
+
+            csdbio.assignScreeningId(getConnection(),
+                screening.getScreeningName(),
+                screenAssignTS, ((CwmsTimeSeriesDb)db).getDbOfficeId());
+        }
+        catch (SQLException ex)
+        {
+            String msg = module + ".assignScreening() error assigning screening '"
+                + screening.getScreeningName() + "' to tsid '" + tsid.getUniqueString() + " with activeFlag="
+                + active + ": " + ex;
+            warning(msg);
+            PrintStream ps = Logger.instance().getLogOutput();
+            if (ps != null)
+            {
+                ps.println("Cause is: " + ex);
+                ex.printStackTrace(ps);
+            }
+            throw new DbIoException(msg);
+        }
+    }
+
+    @Override
+    public void unassignScreening(Screening screening, TimeSeriesIdentifier tsid) throws DbIoException
+    {
+        try
+        {
+            csdbio.unassignScreeningId(getConnection(),
+                screening.getScreeningName(),
+                Collections.singletonList(tsid != null ? tsid.getUniqueString() : null),
+                tsid == null,
+                ((CwmsTimeSeriesDb)db).getDbOfficeId());
+        }
+        catch (SQLException ex)
+        {
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
+    public void renameScreening(String oldId, String newId) throws DbIoException
+    {
+        try
+        {
+            Logger.instance().info("Renaming screening '" + oldId + "' to '" + newId + "'");
+            csdbio.renameScreeningId(getConnection(),
+                oldId,
+                newId,
+                ((CwmsTimeSeriesDb)db).getDbOfficeId());
+        }
+        catch (SQLException ex)
+        {
+            throw new DbIoException(module + ".renameScreening(" + oldId + ", " + newId
+                + ": Error: " + ex);
+        }
+    }
+
+    @Override
+    public void updateScreeningDescription(String screeningId, String desc) throws DbIoException
+    {
+
+        try
+        {
+            csdbio.updateScreeningIdDesc(getConnection(),
+                screeningId,
+                desc,
+                ((CwmsTimeSeriesDb)db).getDbOfficeId());
+        }
+        catch (SQLException ex)
+        {
+            throw new DbIoException(module + ".renameScreening(" + screeningId + ", " + desc
+                + ": Error: " + ex);
+        }
+    }
 }

--- a/src/main/java/decodes/cwms/validation/dao/ScreeningDAO.java
+++ b/src/main/java/decodes/cwms/validation/dao/ScreeningDAO.java
@@ -121,7 +121,7 @@ public class ScreeningDAO
             Logger.instance().failure(msg);
             System.err.println(msg);
             ex.printStackTrace(System.err);
-            throw new DbIoException(msg);
+            throw new DbIoException(msg,ex);
         }
     }
 
@@ -758,7 +758,7 @@ public class ScreeningDAO
             Logger.instance().failure(msg);
             System.err.println(msg);
             ex.printStackTrace(System.err);
-            throw new DbIoException(msg);
+            throw new DbIoException(msg,ex);
         }
     }
 
@@ -899,7 +899,7 @@ Logger.instance().debug1("ScreeningDAO.makeCal day=" + day + ", mon=" + month
         }
         catch (SQLException ex)
         {
-            ex.printStackTrace();
+            throw new DbioException("Unable to unassign screening", ex);
         }
     }
 
@@ -932,7 +932,7 @@ Logger.instance().debug1("ScreeningDAO.makeCal day=" + day + ", mon=" + month
         catch (SQLException ex)
         {
             throw new DbIoException(module + ".renameScreening(" + screeningId + ", " + desc
-                + ": Error: " + ex);
+                + ": Error: " + ex,ex);
         }
     }
 }

--- a/src/main/java/decodes/cwms/validation/gui/ScreeningIdListTab.java
+++ b/src/main/java/decodes/cwms/validation/gui/ScreeningIdListTab.java
@@ -1,8 +1,8 @@
 /**
  * $Id$
- * 
+ *
  * Copyright 2015 U.S. Army Corps of Engineers, Hydrologic Engineering Center.
- * 
+ *
  * $Log$
  * Revision 1.2  2016/11/03 18:58:48  mmaloney
  * Force reload when assessing TSIDs.
@@ -52,13 +52,13 @@ public class ScreeningIdListTab extends JPanel
 	ScreeningIdTableModel model = null;
 	ScreeningEditFrame frame = null;
 	private ArrayList<TimeSeriesIdentifier> allTsids = null;
-	
+
 	public ScreeningIdListTab(ScreeningEditFrame frame)
 	{
 		this.frame = frame;
 		guiInit();
 	}
-	
+
 	private void guiInit()
 	{
 		this.setLayout(new BorderLayout());
@@ -67,7 +67,7 @@ public class ScreeningIdListTab extends JPanel
 		JScrollPane scrollPane = new JScrollPane();
 		scrollPane.getViewport().add(screeningIdTable);
 		this.add(scrollPane, BorderLayout.CENTER);
-		
+
 		JPanel south = new JPanel(new GridBagLayout());
 		this.add(south, BorderLayout.SOUTH);
 		JButton editButton = new JButton("Edit");
@@ -84,7 +84,7 @@ public class ScreeningIdListTab extends JPanel
 			new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
 				GridBagConstraints.CENTER, GridBagConstraints.NONE,
 				new Insets(4, 10, 4, 5), 0, 0));
-		
+
 		JButton newButton = new JButton("New");
 		newButton.addActionListener(
 			new ActionListener()
@@ -99,7 +99,7 @@ public class ScreeningIdListTab extends JPanel
 			new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
 				GridBagConstraints.CENTER, GridBagConstraints.NONE,
 				new Insets(4, 5, 4, 5), 0, 0));
-	
+
 		JButton deleteButton = new JButton("Delete");
 		deleteButton.addActionListener(
 			new ActionListener()
@@ -145,7 +145,7 @@ public class ScreeningIdListTab extends JPanel
 				GridBagConstraints.EAST, GridBagConstraints.NONE,
 				new Insets(4, 5, 4, 10), 0, 0));
 
-		
+
 		screeningIdTable.addMouseListener(new MouseAdapter()
 		{
 			public void mouseClicked(MouseEvent e)
@@ -168,7 +168,7 @@ public class ScreeningIdListTab extends JPanel
 				+ "screening to one or more time series.");
 			return;
 		}
-		
+
 		Screening scr = (Screening)model.getRowObject(screeningIdTable.getSelectedRow());
 		TimeSeriesSelectDialog dlg = new TimeSeriesSelectDialog(frame.getTheDb(), false, frame);
 
@@ -267,12 +267,12 @@ public class ScreeningIdListTab extends JPanel
 	{
 		int row = screeningIdTable.getSelectedRow();
 		if (row == -1)
-		{	
+		{
 			frame.showError("Select table row, then press Edit");
 			return;
 		}
-		Screening scr = (Screening)model.getRowObject(row);
-		
+		Screening scr = (Screening)model.getRowObject(screeningIdTable.convertRowIndexToModel(row));
+
 		// If there are any assignments, issue error
 		if (frame.getTsidAssignTab().assignmentsExistFor(scr.getScreeningName()))
 		{
@@ -280,7 +280,7 @@ public class ScreeningIdListTab extends JPanel
 				+ "assignments on the TS Assignments tab. Then retry delete.");
 			return;
 		}
-		
+
 		int res = JOptionPane.showConfirmDialog(frame,
 			AsciiUtil.wrapString(
 			"This permanently delete the screening from the database. "
@@ -288,7 +288,7 @@ public class ScreeningIdListTab extends JPanel
 			"Confirm Overwrite Edit Database", JOptionPane.YES_NO_OPTION);
 		if (res != JOptionPane.YES_OPTION)
 			return;
-		
+
 
 		try (ScreeningDAI screeningDAO = frame.getTheDb().makeScreeningDAO();)
 		{
@@ -315,7 +315,7 @@ public class ScreeningIdListTab extends JPanel
 				frame.showError("A screening already exists with that name.");
 				return;
 			}
-		
+
 		Screening scr = new Screening();
 		scr.setScreeningName(id);
 		scr.add(new ScreeningCriteria());
@@ -326,12 +326,11 @@ public class ScreeningIdListTab extends JPanel
 	{
 		int row = screeningIdTable.getSelectedRow();
 		if (row == -1)
-		{	
+		{
 			frame.showError("Select table row, then press Edit");
 			return;
 		}
-		System.out.println("Edit pressed for row " + row);
-		Screening scr = (Screening)model.getRowObject(row);
+		Screening scr = (Screening)model.getRowObject(screeningIdTable.convertRowIndexToModel(row));
 		frame.open(scr);
 	}
 
@@ -382,7 +381,7 @@ class ScreeningIdTableModel
 	{
 		return getColumnValue(screenings.get(rowIndex), columnIndex);
 	}
-	
+
 	private String getColumnValue(Screening scr, int columnIndex)
 	{
 		switch(columnIndex)
@@ -395,7 +394,7 @@ class ScreeningIdTableModel
 		}
 		return scr.getUniqueName(); // won't happen
 	}
-	
+
 	private String briefDesc(String desc)
 	{
 		if (desc == null)
@@ -408,7 +407,7 @@ class ScreeningIdTableModel
 	@Override
 	public void sortByColumn(final int column)
 	{
-		Collections.sort(screenings, 
+		Collections.sort(screenings,
 			new Comparator<Screening>()
 			{
 				@Override
@@ -432,5 +431,5 @@ class ScreeningIdTableModel
 		this.screenings = screenings;
 		sortByColumn(sortColumn);
 	}
-	
+
 }

--- a/src/main/java/decodes/cwms/validation/gui/ScreeningIdListTab.java
+++ b/src/main/java/decodes/cwms/validation/gui/ScreeningIdListTab.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
 
 import javax.swing.JButton;
 import javax.swing.JOptionPane;
@@ -383,7 +384,7 @@ class ScreeningIdTableModel
 {
 	static String columnNames[] = { "Screening ID", "Description", "Param", "Param Type", "Duration" };
 	static int columnWidths[] = { 20, 41, 13, 13, 13 };
-	ArrayList<Screening> screenings = new ArrayList<Screening>();
+	List<Screening> screenings = new ArrayList<>();
 	private int sortColumn = 0;
 
 	@Override
@@ -455,11 +456,10 @@ class ScreeningIdTableModel
 		return screenings.get(row);
 	}
 
-	public void setScreenings(ArrayList<Screening> screenings)
+	public void setScreenings(List<Screening> screenings)
 	{
 		this.screenings = screenings;
 		sortByColumn(sortColumn);
 	}
 	
 }
-

--- a/src/main/java/decodes/cwms/validation/gui/TsidAssignTab.java
+++ b/src/main/java/decodes/cwms/validation/gui/TsidAssignTab.java
@@ -18,6 +18,7 @@ import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -270,7 +271,7 @@ class TsidAssignTableModel
 		{ "Screening ID", "Active?", "Location", "Param", "Param Type", "Interval", "Duration", "Version" };
 	static int columnWidths[] = { 28, 10, 12, 10, 10, 10, 10, 10 };
 	
-	ArrayList<TsidScreeningAssignment> assignments = new ArrayList<TsidScreeningAssignment>();
+	List<TsidScreeningAssignment> assignments = new ArrayList<TsidScreeningAssignment>();
 	private int sortColumn = 0;
 
 	@Override
@@ -279,7 +280,7 @@ class TsidAssignTableModel
 		return assignments.size();
 	}
 
-	public void setAssignments(ArrayList<TsidScreeningAssignment> tsidScreeningAssignments)
+	public void setAssignments(List<TsidScreeningAssignment> tsidScreeningAssignments)
 	{
 		this.assignments = tsidScreeningAssignments;
 		sortByColumn(sortColumn);


### PR DESCRIPTION
## Problem Description

ScreeningDAO wasn't closing connections after calls to getConnection as no references were held.

## Solution

Move getConnection to an assignment within a try-with-resources block.
Changed DAO/DAI returns to List instead of ArrayList to allow use of the new SQL query wrappers.

## how you tested the change

Manually, leaving Screening open and performing work.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
