### PR TITLE
Devops/integration test organization

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -131,6 +131,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 <!--<pathelement location="${build.classes}"/>-->
                 <path refid="runtime.classpath"/>
                 <path refid="test.classpath"/>
+                <path refid="junit.platform.libs.classpath"/>
             </classpath>
         </javac>
         <sync todir="${build.test-integration.resources}">
@@ -722,6 +723,10 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                     }
 
                     project.getReference("test.classpath").each {
+                        classpathentry(kind:"lib", path:it)
+                    }
+
+                    project.getReference("junit.platform.libs.classpath").each {
                         classpathentry(kind:"lib", path:it)
                     }
                 }

--- a/build.xml
+++ b/build.xml
@@ -225,6 +225,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                     <jvmarg value="-Dresource.dir=${build.test-integration.resources}"/>
                     <jvmarg value="-DDCSTOOL_HOME=${stage.dir}"/>
                     <jvmarg value="-Dopendcs.test.engine=${opendcs.test.engine}"/>
+                    <jvmarg value="-Djava.util.logging.config.file=${build.dir}/../src/test-integration/test-config/logging.properties"/>
                     <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
                 </fork>
                 <fileset dir="${build.test-integration.classes}"/>

--- a/src/test-integration/java/org/opendcs/fixtures/AppTestBase.java
+++ b/src/test-integration/java/org/opendcs/fixtures/AppTestBase.java
@@ -3,22 +3,13 @@ package org.opendcs.fixtures;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.lang.reflect.Field;
-import java.nio.file.Files;
-import java.util.Iterator;
-import java.util.ServiceLoader;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.platform.commons.PreconditionViolationException;
+import org.opendcs.fixtures.helpers.TestResources;
 import org.opendcs.spi.configuration.Configuration;
-import org.opendcs.spi.configuration.ConfigurationProvider;
 
-import decodes.util.DecodesSettings;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -27,11 +18,10 @@ import uk.org.webcompere.systemstubs.security.SystemExit;
 
 
 @ExtendWith(SystemStubsExtension.class)
+@ExtendWith(OpenDCSTestConfigExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class AppTestBase {
-
-    private static File resourceDir = new File(System.getProperty("resource.dir"),"data");
-
+public class AppTestBase
+{
     @SystemStub
     protected final EnvironmentVariables environment = new EnvironmentVariables();
 
@@ -41,46 +31,8 @@ public class AppTestBase {
     @SystemStub
     protected final SystemExit exit = new SystemExit();
 
-    protected final Configuration configuration;
-
-    public AppTestBase()
-    {
-        String engine = System.getProperty("opendcs.test.engine");
-        if (engine == null)
-        {
-            throw new PreconditionViolationException("You must set the provide 'opendcs.test.engine' in a system property to run the tests against");
-        }
-
-        ServiceLoader<ConfigurationProvider> loader = ServiceLoader.load(ConfigurationProvider.class);
-        Iterator<ConfigurationProvider> configs = loader.iterator();
-
-        ConfigurationProvider configProvider = null;
-        while(configs.hasNext())
-        {
-            ConfigurationProvider configProviderTmp = configs.next();
-            if (engine.equals(configProviderTmp.getImplementation()))
-            {
-                configProvider = configProviderTmp;
-            }
-        }
-
-        if (configProvider != null)
-        {
-            try
-            {
-                File tmp = Files.createTempDirectory("configs-"+configProvider.getImplementation()).toFile();
-                this.configuration = configProvider.getConfig(tmp);
-            }
-            catch (Exception ex)
-            {
-                throw new PreconditionViolationException("Unable to load load configuration for OpenDCS engine '" + engine + "'. Provider failed to initialize");
-            }
-        }
-        else
-        {
-            throw new PreconditionViolationException("No implementation found for engine '" + engine + "'.");
-        }
-    }
+    @ConfiguredField
+    protected Configuration configuration;
 
     protected void assertExitNullOrZero()
     {
@@ -94,41 +46,7 @@ public class AppTestBase {
      */
     public static String getResource(String file)
     {
-        return new File(resourceDir,file).getAbsolutePath();
-    }
-
-    @BeforeAll
-    public void beforeAll() throws Exception
-    {
-        configuration.start(exit,environment);
-        File userDir = configuration.getUserDir();
-        System.out.println("DCSTOOL_USERDIR="+userDir);
-        environment.set("DCSTOOL_USERDIR",userDir.getAbsolutePath());
-        if (configuration.getEnvironment() != null
-         && !configuration.getEnvironment().isEmpty())
-        {
-            environment.set(configuration.getEnvironment());
-        }
-        properties.set("DCSTOOL_USERDIR",userDir.getAbsolutePath());
-        properties.set("INPUT_DATA",new File(resourceDir,"/shared").getAbsolutePath());
-        properties.setup();
-        environment.setup();
-    }
-
-    @AfterAll
-    public void afterAll() throws Exception
-    {
-        environment.teardown();
-        properties.teardown();
-        DecodesSettings settings = DecodesSettings.instance();
-        Class<?> clazz = settings.getClass();
-        Field isLoaded = clazz.getDeclaredField("_isLoaded");
-        Field theInstance = clazz.getDeclaredField("_instance");
-        isLoaded.setAccessible(true);
-        isLoaded.setBoolean(settings, false);
-
-        theInstance.setAccessible(true);
-        theInstance.set(settings,null);
+        return new File(TestResources.resourceDir,file).getAbsolutePath();
     }
 
     /**

--- a/src/test-integration/java/org/opendcs/fixtures/ConfiguredField.java
+++ b/src/test-integration/java/org/opendcs/fixtures/ConfiguredField.java
@@ -1,0 +1,15 @@
+package org.opendcs.fixtures;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConfiguredField
+{
+    
+}

--- a/src/test-integration/java/org/opendcs/fixtures/ConfiguredField.java
+++ b/src/test-integration/java/org/opendcs/fixtures/ConfiguredField.java
@@ -11,5 +11,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ConfiguredField
 {
-    
 }

--- a/src/test-integration/java/org/opendcs/fixtures/EnableIfSql.java
+++ b/src/test-integration/java/org/opendcs/fixtures/EnableIfSql.java
@@ -1,0 +1,36 @@
+package org.opendcs.fixtures;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.opendcs.spi.configuration.Configuration;
+
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(EnableIfSql.EnableIfSqlCondition.class)
+public @interface EnableIfSql
+{
+    static class EnableIfSqlCondition implements ExecutionCondition
+    {
+        @Override
+        public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext ctx)
+        {
+            Object testInstance = ctx.getRequiredTestInstance();
+            List<Configuration> configs = AnnotationSupport.findAnnotatedFieldValues(testInstance, ConfiguredField.class, Configuration.class);
+            if (configs.size() == 1 && configs.get(0) != null) {
+                return configs.get(0).isTsdb() ? ConditionEvaluationResult.enabled("Is a Timeseries Db") : ConditionEvaluationResult.disabled("Not a Timeseries Db");
+            }
+            return ConditionEvaluationResult.disabled("No " + Configuration.class.getName() + " member fields present in Test class.");
+        }
+    }
+}

--- a/src/test-integration/java/org/opendcs/fixtures/OpenDCSTestConfigExtension.java
+++ b/src/test-integration/java/org/opendcs/fixtures/OpenDCSTestConfigExtension.java
@@ -1,0 +1,178 @@
+package org.opendcs.fixtures;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.opendcs.fixtures.helpers.TestResources;
+import org.opendcs.spi.configuration.Configuration;
+import org.opendcs.spi.configuration.ConfigurationProvider;
+
+import decodes.util.DecodesSettings;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+import uk.org.webcompere.systemstubs.security.SystemExit;
+
+public class OpenDCSTestConfigExtension implements BeforeAllCallback, AfterAllCallback
+{
+    private static final Logger logger = Logger.getLogger(OpenDCSTestConfigExtension.class.getName());
+
+    /**
+     * Perform initial or per test environment setup.
+     */
+    @Override
+    public void beforeAll(ExtensionContext ctx) throws Exception
+    {
+        logger.info("Searching for 'opendcs.test.engine'.");
+        final Configuration configuration = (Configuration)ctx.getRoot().getStore(Namespace.GLOBAL).getOrComputeIfAbsent("config", key -> 
+        {
+            String engine = System.getProperty("opendcs.test.engine");
+            if (engine == null)
+            {
+                throw new PreconditionViolationException("You must set the provide 'opendcs.test.engine' in a system property to run the tests against");
+            }
+
+            ServiceLoader<ConfigurationProvider> loader = ServiceLoader.load(ConfigurationProvider.class);
+            Iterator<ConfigurationProvider> configs = loader.iterator();
+
+            ConfigurationProvider configProvider = null;
+            while(configs.hasNext())
+            {
+                ConfigurationProvider configProviderTmp = configs.next();
+                if (engine.equals(configProviderTmp.getImplementation()))
+                {
+                    configProvider = configProviderTmp;
+                }
+            }
+            if (configProvider != null)
+            {
+                try
+                {
+                    File tmp = Files.createTempDirectory("configs-"+configProvider.getImplementation()).toFile();                
+                    return configProvider.getConfig(tmp);
+                }
+                catch (Exception ex)
+                {
+                    throw new PreconditionViolationException("Unable to initialize configuration.", ex);
+                }
+            }
+            else
+            {
+                throw new PreconditionViolationException("No implementation found for engine '" + engine + "'.");
+            }
+        });
+        
+
+        ctx.getTestInstance().ifPresent(testInstance -> 
+        {
+            List<Field> fields = AnnotationSupport.findAnnotatedFields(testInstance.getClass(),ConfiguredField.class);
+            for (Field f: fields)
+            {    
+                try
+                {            
+                    if( f.getType().equals(Configuration.class))
+                    {
+                        f.set(testInstance,configuration);
+                    }
+                    
+                }
+                catch (Exception ex)
+                {
+                    throw new PreconditionViolationException("Unable to assigned configuration to field.", ex);
+                }   
+            }
+        });
+
+        SystemExit exit = (SystemExit)getStub(ctx,SystemExit.class);
+        EnvironmentVariables environment = (EnvironmentVariables)getStub(ctx,EnvironmentVariables.class);
+        SystemProperties properties = (SystemProperties)getStub(ctx,SystemProperties.class);
+
+        if (!configuration.isRunning())
+        {
+            configuration.start(exit,environment);   
+        }
+
+        File userDir = configuration.getUserDir();
+        logger.info("DCSTOOL_USERDIR="+userDir);
+        environment.set("DCSTOOL_USERDIR",userDir.getAbsolutePath());
+        if (configuration.getEnvironment() != null
+        && !configuration.getEnvironment().isEmpty())
+        {
+            environment.set(configuration.getEnvironment());
+        }
+        properties.set("DCSTOOL_USERDIR",userDir.getAbsolutePath());
+        properties.set("INPUT_DATA",new File(TestResources.resourceDir,"/shared").getAbsolutePath());
+        properties.setup();
+        environment.setup();
+    }
+
+    /**
+     * Reset environment, properties, DecodesSettings, etc;
+     */
+    @Override
+    public void afterAll(ExtensionContext ctx) throws Exception 
+    {
+        EnvironmentVariables environment = (EnvironmentVariables)getStub(ctx,EnvironmentVariables.class);
+        SystemProperties properties = (SystemProperties)getStub(ctx,SystemProperties.class);
+        environment.teardown();
+        properties.teardown();
+        DecodesSettings settings = DecodesSettings.instance();
+        Class<?> clazz = settings.getClass();
+        Field isLoaded = clazz.getDeclaredField("_isLoaded");
+        Field theInstance = clazz.getDeclaredField("_instance");
+        isLoaded.setAccessible(true);
+        isLoaded.setBoolean(settings, false);
+
+        theInstance.setAccessible(true);
+        theInstance.set(settings,null);
+    }
+
+    /**
+     * Get the appropriate SystemStub instance from the extended class.
+     * 
+     * It is up to the calling code to perform proper conversions
+     * 
+     * @param ctx Junit ExtensionContext
+     * @param stubClass which stub to get
+     * @return The Stub Instance.
+     * @throws Exception Stub can't be found for any reason
+     */
+    private Object getStub(ExtensionContext ctx, Class<?> stubClass) throws Exception
+    {
+
+        Optional<Object> exit = ctx.getTestInstance().map(testInstance -> 
+        {
+            List<Field> fields = AnnotationSupport.findAnnotatedFields(testInstance.getClass(),SystemStub.class);
+            for (Field f: fields)
+            {    
+                try
+                {            
+                    Object obj = f.get(testInstance);
+                    if (obj.getClass().equals(stubClass))
+                    {
+                        return obj;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new PreconditionViolationException("Unable to acquire SystemExit Stub.", ex);
+                }
+            }
+            return null;
+        });
+        
+        return exit.orElseThrow(() -> new PreconditionViolationException("No SystemExit field annotated with @SystemStub are present."));
+    }
+}

--- a/src/test-integration/java/org/opendcs/fixtures/OpenDCSTestConfigExtension.java
+++ b/src/test-integration/java/org/opendcs/fixtures/OpenDCSTestConfigExtension.java
@@ -162,7 +162,7 @@ public class OpenDCSTestConfigExtension implements BeforeAllCallback, AfterAllCa
             {
                 try
                 {
-                    File tmp = Files.createTempDirectory("configs-"+configProvider.getImplementation()).toFile();                
+                    File tmp = Files.createTempDirectory("configs-"+configProvider.getImplementation()).toFile();
                     configuration = configProvider.getConfig(tmp);
                 }
                 catch (Exception ex)
@@ -192,9 +192,9 @@ public class OpenDCSTestConfigExtension implements BeforeAllCallback, AfterAllCa
 
     /**
      * Get the appropriate SystemStub instance from the extended class.
-     * 
+     *
      * It is up to the calling code to perform proper conversions
-     * 
+     *
      * @param ctx Junit ExtensionContext
      * @param stubClass which stub to get
      * @return The Stub Instance.
@@ -203,13 +203,13 @@ public class OpenDCSTestConfigExtension implements BeforeAllCallback, AfterAllCa
     private Object getStub(ExtensionContext ctx, Class<?> stubClass) throws Exception
     {
 
-        Optional<Object> exit = ctx.getTestInstance().map(testInstance -> 
+        Optional<Object> exit = ctx.getTestInstance().map(testInstance ->
         {
             List<Field> fields = AnnotationSupport.findAnnotatedFields(testInstance.getClass(),SystemStub.class);
             for (Field f: fields)
-            {    
+            {
                 try
-                {            
+                {
                     Object obj = f.get(testInstance);
                     if (obj.getClass().equals(stubClass))
                     {
@@ -223,7 +223,7 @@ public class OpenDCSTestConfigExtension implements BeforeAllCallback, AfterAllCa
             }
             return null;
         });
-        
+
         return exit.orElseThrow(() -> new PreconditionViolationException("No SystemExit field annotated with @SystemStub are present."));
     }
 }

--- a/src/test-integration/java/org/opendcs/fixtures/UserPropertiesBuilder.java
+++ b/src/test-integration/java/org/opendcs/fixtures/UserPropertiesBuilder.java
@@ -25,7 +25,7 @@ public class UserPropertiesBuilder
      */
     public UserPropertiesBuilder withDatabaseLocation(String dbLocation)
     {
-        props.setProperty("EditDatabaseLocation", dbLocation);
+        props.setProperty("editDatabaseLocation", dbLocation);
         return this;
     }
 
@@ -173,4 +173,9 @@ algoEditCompileOptions=
 routingStatusDir=$DCSTOOL_USERDIR/routstat
 decodesFormatLabelMode=f
 */
+
+    public void withDatabaseDriver(String driverString)
+    {
+        this.props.put("editDatabaseDriver",driverString);
+    }
 }

--- a/src/test-integration/java/org/opendcs/fixtures/configurations/opendcs/pg/OpenDCSPGConfiguration.java
+++ b/src/test-integration/java/org/opendcs/fixtures/configurations/opendcs/pg/OpenDCSPGConfiguration.java
@@ -5,6 +5,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
@@ -14,6 +15,8 @@ import org.opendcs.fixtures.UserPropertiesBuilder;
 import org.opendcs.fixtures.helpers.Programs;
 import org.opendcs.spi.configuration.Configuration;
 
+import decodes.tsdb.TimeSeriesDb;
+import opendcs.opentsdb.OpenTsdb;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.security.SystemExit;
 
@@ -51,6 +54,12 @@ public class OpenDCSPGConfiguration implements Configuration
 
     @Override
     public boolean isSql()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isTsdb()
     {
         return true;
     }
@@ -115,6 +124,7 @@ public class OpenDCSPGConfiguration implements Configuration
         UserPropertiesBuilder configBuilder = new UserPropertiesBuilder();
         configBuilder.withDatabaseLocation(dbUrl);
         configBuilder.withEditDatabaseType("OPENTSDB");
+        configBuilder.withDatabaseDriver("org.postgresql.Driver");
         configBuilder.withSiteNameTypePreference("CWMS");
         configBuilder.withDecodesAuth("env-auth-source:username=DB_USERNAME,password=DB_PASSWORD");
         // set username/pw (env)
@@ -133,7 +143,13 @@ public class OpenDCSPGConfiguration implements Configuration
     }
 
     @Override
-    public void close() throws Throwable {
-        log.info("Would close database.");
+    public TimeSeriesDb getTsdb() throws Throwable
+    {
+        OpenTsdb db = new OpenTsdb();
+        Properties credentials = new Properties();
+        credentials.put("username","dcs_proc");
+        credentials.put("password","dcs_proc");
+        db.connect("utility",credentials);
+        return db;
     }
 }

--- a/src/test-integration/java/org/opendcs/fixtures/configurations/opendcs/pg/OpenDCSPGConfiguration.java
+++ b/src/test-integration/java/org/opendcs/fixtures/configurations/opendcs/pg/OpenDCSPGConfiguration.java
@@ -128,13 +128,12 @@ public class OpenDCSPGConfiguration implements Configuration
     }
 
     @Override
-    public void stop() throws Exception
-    {
-        System.out.println("Stopping.");
+    public boolean isRunning() {
+        return started;
     }
 
     @Override
-    public boolean isRunning() {
-        return started;
+    public void close() throws Throwable {
+        log.info("Would close database.");
     }
 }

--- a/src/test-integration/java/org/opendcs/fixtures/configurations/opendcs/pg/OpenDCSPGConfiguration.java
+++ b/src/test-integration/java/org/opendcs/fixtures/configurations/opendcs/pg/OpenDCSPGConfiguration.java
@@ -124,7 +124,6 @@ public class OpenDCSPGConfiguration implements Configuration
             FileUtils.copyDirectory(new File("stage/edit-db"),editDb);
             FileUtils.copyDirectory(new File("stage/schema"),new File(userDir,"/schema/"));
             installDb(exit,environment);
-
         }
     }
 
@@ -132,5 +131,10 @@ public class OpenDCSPGConfiguration implements Configuration
     public void stop() throws Exception
     {
         System.out.println("Stopping.");
+    }
+
+    @Override
+    public boolean isRunning() {
+        return started;
     }
 }

--- a/src/test-integration/java/org/opendcs/fixtures/configurations/xml/XmlConfiguration.java
+++ b/src/test-integration/java/org/opendcs/fixtures/configurations/xml/XmlConfiguration.java
@@ -69,9 +69,4 @@ public class XmlConfiguration implements Configuration
     public boolean isRunning() {
         return started;
     }
-    
-    @Override
-    public void close() throws Throwable {
-        logger.info("Would close database.");
-    }
 }

--- a/src/test-integration/java/org/opendcs/fixtures/configurations/xml/XmlConfiguration.java
+++ b/src/test-integration/java/org/opendcs/fixtures/configurations/xml/XmlConfiguration.java
@@ -3,6 +3,7 @@ package org.opendcs.fixtures.configurations.xml;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
 import org.opendcs.fixtures.UserPropertiesBuilder;
@@ -16,6 +17,7 @@ import uk.org.webcompere.systemstubs.security.SystemExit;
  */
 public class XmlConfiguration implements Configuration
 {
+    private static final Logger logger = Logger.getLogger(XmlConfiguration.class.getName());
 
     File userDir;
     File propertiesFile;
@@ -68,4 +70,8 @@ public class XmlConfiguration implements Configuration
         return started;
     }
     
+    @Override
+    public void close() throws Throwable {
+        logger.info("Would close database.");
+    }
 }

--- a/src/test-integration/java/org/opendcs/fixtures/configurations/xml/XmlConfiguration.java
+++ b/src/test-integration/java/org/opendcs/fixtures/configurations/xml/XmlConfiguration.java
@@ -2,7 +2,6 @@ package org.opendcs.fixtures.configurations.xml;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
 
 import org.apache.commons.io.FileUtils;
@@ -20,6 +19,7 @@ public class XmlConfiguration implements Configuration
 
     File userDir;
     File propertiesFile;
+    private boolean started = false;
 
     public XmlConfiguration(File userDir) throws Exception
     {
@@ -59,7 +59,13 @@ public class XmlConfiguration implements Configuration
             FileUtils.copyDirectory(new File("stage/edit-db"),editDb);
             FileUtils.copyDirectory(new File("stage/schema"),new File(userDir,"/schema/"));
             configBuilder.build(out);
+            started = true;
         }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return started;
     }
     
 }

--- a/src/test-integration/java/org/opendcs/fixtures/helpers/TestResources.java
+++ b/src/test-integration/java/org/opendcs/fixtures/helpers/TestResources.java
@@ -1,0 +1,8 @@
+package org.opendcs.fixtures.helpers;
+
+import java.io.File;
+
+public class TestResources
+{
+    public static final File resourceDir = new File(System.getProperty("resource.dir"),"data");
+}

--- a/src/test-integration/java/org/opendcs/regression_tests/LoadingAppTestIT.java
+++ b/src/test-integration/java/org/opendcs/regression_tests/LoadingAppTestIT.java
@@ -1,0 +1,33 @@
+package org.opendcs.regression_tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.opendcs.fixtures.AppTestBase;
+import org.opendcs.fixtures.ConfiguredField;
+import org.opendcs.fixtures.EnableIfSql;
+
+import decodes.tsdb.CompAppInfo;
+import decodes.tsdb.TimeSeriesDb;
+import opendcs.dao.LoadingAppDao;
+
+
+
+public class LoadingAppTestIT extends AppTestBase
+{
+    @ConfiguredField
+    protected TimeSeriesDb db;
+
+    @Test
+    @EnableIfSql
+    public void test_utilityClassIsPresent() throws Exception
+    {
+        try(LoadingAppDao dao = new LoadingAppDao(db);)
+        {
+            CompAppInfo appInfo = dao.getComputationApp("utility");
+            assertNotNull(appInfo, "Utility loading application was not present in the database.");
+            assertEquals("utility",appInfo.getAppName(), "Returned application info is incorrect.");
+        }
+    }
+}

--- a/src/test-integration/java/org/opendcs/spi/configuration/Configuration.java
+++ b/src/test-integration/java/org/opendcs/spi/configuration/Configuration.java
@@ -6,15 +6,16 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.extension.Extension;
-import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 
+import decodes.tsdb.TimeSeriesDb;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.security.SystemExit;
 
 /**
  * Baseline of a test implementation configuration
  */
-public interface Configuration extends CloseableResource {
+public interface Configuration
+{
     /**
      * Do any configuration or initialization options that affect the system.
      * Such as:
@@ -33,9 +34,22 @@ public interface Configuration extends CloseableResource {
      */
     public boolean isRunning();
 
+    /**
+     * Close files, shutdown databases, etc
+     * @throws Exception
+     */
+    public default void stop() throws Throwable
+    {
+        // nothing to do by default
+    }
+
     public File getPropertiesFile();
     public File getUserDir();
     public boolean isSql();
+    default public boolean isTsdb()
+    {
+        return false;
+    }
     public default List<Extension> getExtensions()
     {
         return new ArrayList<>();
@@ -46,6 +60,18 @@ public interface Configuration extends CloseableResource {
      * @return
      */
     public default Map<String,String> getEnvironment()
+    {
+        return null;
+    }
+
+    /**
+     * If available return a valid instead of a TimeSeriesDb based on the current configuration.
+     *
+     * Default implementation returns null;
+     * @return The timeseries database if it can be made.
+     * @throws Throwable any issue with the creation of the TimeSeriesDb object
+     */
+    default public TimeSeriesDb getTsdb() throws Throwable
     {
         return null;
     }

--- a/src/test-integration/java/org/opendcs/spi/configuration/Configuration.java
+++ b/src/test-integration/java/org/opendcs/spi/configuration/Configuration.java
@@ -25,6 +25,13 @@ public interface Configuration {
      * @throws Exception
      */
     public void start(SystemExit exit, EnvironmentVariables environment) throws Exception;
+
+    /**
+     *
+     * @return true if required services/content are configured and running as appropriate
+     */
+    public boolean isRunning();
+
     public default void stop() throws Exception
     {
         // nothing to do by default

--- a/src/test-integration/java/org/opendcs/spi/configuration/Configuration.java
+++ b/src/test-integration/java/org/opendcs/spi/configuration/Configuration.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.security.SystemExit;
@@ -13,7 +14,7 @@ import uk.org.webcompere.systemstubs.security.SystemExit;
 /**
  * Baseline of a test implementation configuration
  */
-public interface Configuration {
+public interface Configuration extends CloseableResource {
     /**
      * Do any configuration or initialization options that affect the system.
      * Such as:
@@ -32,10 +33,6 @@ public interface Configuration {
      */
     public boolean isRunning();
 
-    public default void stop() throws Exception
-    {
-        // nothing to do by default
-    }
     public File getPropertiesFile();
     public File getUserDir();
     public boolean isSql();

--- a/src/test-integration/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test-integration/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+org.opendcs.fixtures.OpenDCSTestConfigExtension

--- a/src/test-integration/test-config/logging.properties
+++ b/src/test-integration/test-config/logging.properties
@@ -1,0 +1,15 @@
+handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
+
+.level = INFO
+
+
+java.util.logging.FileHandler.pattern = %t/integration-tests.log.%g
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 10
+java.util.logging.FileHandler.level = INFO
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter


### PR DESCRIPTION
## Problem Description

I've been struggling with how to handle certain integration level tests for each of the different implementations. For example the XML database can't do any of the time series things.

With this new framework in place it *should* be easier to standup the new lower level regressions tests (those not from the very high level direct application tests such as the existing DecodesTests) and reduce some boiler plate to get key instances of classes for specific testing.

## Solution

- Extracted the existing AppTestBase class to a Extension that implements a few different components to handle test database and configuration creation.
- Added logging to the integration tests to better see issues.
- Added a trivial test to verify resources were attempting to be recreated.

## how you tested the change

Running integration-tests. Only changes were to the build.xml and sources under `src/test-integration`

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [x] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
