### PR TITLE
Add call that was skipped due to a refactor.

### DIFF
--- a/src/main/java/decodes/datasource/DataSourceExec.java
+++ b/src/main/java/decodes/datasource/DataSourceExec.java
@@ -186,7 +186,9 @@ public abstract class DataSourceExec
 	/**
 	  Sets the dbDataSource member.
 	  @param ds the database data source record
+	  @deprecated this not be called directly, the DataSource is now passed in the constructor.
 	*/
+	@Deprecated
 	public void setDataSource(DataSource ds)
 		throws InvalidDatabaseException
 	{

--- a/src/main/java/decodes/db/DataSource.java
+++ b/src/main/java/decodes/db/DataSource.java
@@ -343,6 +343,7 @@ public class DataSource extends IdDatabaseObject
 					"newInstance for class '" + dsClass.getName()
 					+ "' returned null");
 			}
+			ret.processDataSource();
 		}
 		catch(Exception e)
 		{


### PR DESCRIPTION
## Problem Description

Fixes regression caused by RoutingScheduler changes that would cause DataSources not to be processed correctly before usage. (Specifically the HotbackupGroup, but likely others.)

## Solution

Required called added directly after creation of DataSourceExec. was previously in call to setDataSource which is no longer used.

## how you tested the change

Manually ran routingspec using hotbackup group to verify operation.

I'm not quite sure how to write a meaningful automated test of this yet. That will come later.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
