### PR TITLE
Add checks to cache build steps.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -230,7 +230,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <if>
             <isset property="test.failed"/>
             <then>
-                <delete file="${status.dir}/test.run" quite="true"/>
+                <delete file="${status.dir}/test.run" quiet="true"/>
                 <fail message="Tests have failures."/>
             </then>
             <else>
@@ -249,12 +249,34 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 </uptodate>
             </and>
         </condition>
+        <condition property="test.engine.set">
+            <isset property="opendcs.test.engine"/>
+        </condition>
     </target>
 
     <target name="integration-test" depends="check.it-run,compile-test-integration,stage,common.resolve"
             description="Run the integration test suite with available implementations."
             unless="integration.test.current"
             >
+        <if>
+            <not>
+                <isset property="opendcs.test.engine"/>
+            </not>
+            <then>
+                <echo level="error">
+To run the integration test you must specify -Dopendcs.test.engine=engine
+Where engine is currently one of the following: OpenDCS-XML, OpenDCS-Postgres
+
+Only OpenDCS-XML will currently work on windows."
+It is also recommend to pass -Dno.docs=true, however the build should now cache the build
+state of the docs correctly and not take an excessive amount of time.
+
+A given implementation may take additional parameters. See https://opendcs-dev.readthedocs.io for
+more information about each.
+                </echo>
+                <fail message="See above message and set correct settings."/>
+            </then>
+        </if>
         <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
         <mkdir dir="${build.dir}/test-integration/${opendcs.test.engine}/results"/>
         <mkdir dir="${build.dir}/test-integration/${opendcs.test.engine}/tmp"/>

--- a/build.xml
+++ b/build.xml
@@ -30,6 +30,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <mkdir dir="${build.dir}"/>
         <mkdir dir="${build.classes}"/>
         <mkdir dir="${build.lib}"/>
+        <mkdir dir="${status.dir}"/>
         <pathconvert property="junitlauncherPresent" setonempty="false" pathsep=" ">
             <path>
                 <fileset dir="${ant.home}">
@@ -51,7 +52,13 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <antcall target="docs.clean"/>
     </target>
 
-    <target name="compile" depends="prepare,common.resolve"
+    <target name="check.src">
+        <uptodate property="src.build.current" targetfile="${status.dir}/src.build.date">
+            <srcfiles dir="${src.main.dir}" includes="*"/>
+        </uptodate>
+    </target>
+
+    <target name="compile" depends="check.src,prepare,common.resolve" unless="src.build.current"
         description="Compiles all source code.">
 
         <!-- create build date -->
@@ -98,10 +105,22 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
             <classpath refid="runtime.classpath"/>
 			<compilerarg value="-parameters"/>
 		</javac>
-
+        <touch file="${status.dir}/src.build.date"/>
     </target>
 
-    <target name="compile-test" depends="compile,common.resolve">
+    <target name="check.test.src" depends="check.src">
+         <uptodate property="test.src.build.current.local" targetfile="${status.dir}/test.src.build.date">
+            <srcfiles dir="src/test" includes="*"/>
+        </uptodate>
+        <condition property="test.src.build.current">
+            <and>
+                <isset property="src.build.current"/>
+                <isset property="test.src.build.current.local"/>
+            </and>
+        </condition>
+    </target>
+
+    <target name="compile-test" depends="check.test.src,compile,common.resolve" unless="test.src.build.current">
         <mkdir dir="${build.test.classes}"/>
         <javac debug="true" destdir="${build.test.classes}"
             target="1.8" source="1.8" includeantruntime="false"
@@ -117,6 +136,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <sync todir="${build.test.resources}">
             <fileset dir="${resources.test.dir}"/>
         </sync>
+        <touch file="${status.dir}/test.src.build.date"/>
     </target>
 
     <target name="compile-test-integration" depends="stage,test,common.resolve,common.resolve.build">
@@ -137,6 +157,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <sync todir="${build.test-integration.resources}">
             <fileset dir="${resources.test-integration.dir}"/>
         </sync>
+        <touch file="${status.dir}/src.integration.build.date"/>
     </target>
 
     <target name="compile-test-gui" depends="jar,test,common.resolve,common.resolve.build">
@@ -156,9 +177,19 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
        <sync todir="${build.test-gui.resources}">
             <fileset dir="${resources.test-gui.dir}"/>
         </sync>
+        <touch file="${status.dir}/src.gui-test.build.date"/>
     </target>
 
-    <target name="test" depends="compile-test,jar,common.resolve.build">
+    <target name="check.run-tests" depends="check.test.src">
+        <condition property="test.run">
+            <and>
+                <available file="${status.dir}/test.run"/>
+                <isset property="test.src.build.current"/>
+            </and>
+        </condition>
+    </target>
+
+    <target name="test" depends="check.run-tests,compile-test,jar,common.resolve.build" unless="test.run">
         <mkdir dir="${junit.html.output.dir}"/>
         <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
         <echo message="platform path: ${platform_path}"/>
@@ -199,13 +230,31 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <if>
             <isset property="test.failed"/>
             <then>
+                <delete file="${status.dir}/test.run" quite="true"/>
                 <fail message="Tests have failures."/>
             </then>
+            <else>
+                <touch file="${status.dir}/test.run"/>
+            </else>
         </if>
     </target>
 
-    <target name="integration-test" depends="compile-test-integration,stage,common.resolve"
-            description="Run the integration test suite with available implementations.">
+    <target name="check.it-run" depends="check.src">
+        <condition property="integration.test.current">
+            <and>
+                <available file="${status.dir}/src.integration.run.${opendcs.test.engine}"/>
+                <isset property="src.build.current"/>
+                <uptodate property="integration.src.current" targetFile="${status.dir}/src.integration.build.date">
+                    <srcFiles dir="${src.test-integration.main.dir}" includes="*"/>
+                </uptodate>
+            </and>
+        </condition>
+    </target>
+
+    <target name="integration-test" depends="check.it-run,compile-test-integration,stage,common.resolve"
+            description="Run the integration test suite with available implementations."
+            unless="integration.test.current"
+            >
         <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
         <mkdir dir="${build.dir}/test-integration/${opendcs.test.engine}/results"/>
         <mkdir dir="${build.dir}/test-integration/${opendcs.test.engine}/tmp"/>
@@ -247,13 +296,30 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <if>
             <isset property="integration.failed"/>
             <then>
+                <delete file="${status.dir}/src.integration.run.${opendcs.test.engine}" quiet="true"/>
                 <fail message="Integration tests have failures."/>
             </then>
+            <else>
+                <touch file="${status.dir}/src.integration.run.${opendcs.test.engine}"/>
+            </else>
         </if>
     </target>
 
-    <target name="gui-test" depends="compile-test-gui,stage,common.resolve"
-            description="Run available GUI element tests">
+    <target name="check.gui-test" depends="check.src">
+        <condition property="gui.test.current">
+            <and>
+                <available file="${status.dir}/src.gui-test.run"/>
+                <isset property="src.build.current"/>
+                <uptodate property="gui-test.src.current" targetFile="${status.dir}/src.gui-test.build.date">
+                    <srcFiles dir="${src.test-gui.main.dir}" includes="*"/>
+                </uptodate>
+            </and>
+        </condition>
+    </target>
+
+    <target name="gui-test" depends="check.gui-test,compile-test-gui,stage,common.resolve"
+            description="Run available GUI element tests"
+            unless="gui.test.current">
         <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
         <mkdir dir="${build.dir}/test-gui/results"/>
         <mkdir dir="${build.dir}/test-gui/tmp"/>
@@ -293,13 +359,22 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <if>
             <isset property="gui.failed"/>
             <then>
+                <delete file="${status.dir}/src.gui-test.run" quiet="true"/>
                 <fail message="Gui tests have failures."/>
             </then>
+            <else>
+                <touch file="${status.dir}/src.gui-test.run"/>
+            </else>
         </if>
     </target>
 
+    <target name="check.jar">
+        <uptodate property="jar.current" targetFile="${dist.jar}">
+            <srcfiles dir="${src.main.dir}" includes="*"/>
+        </uptodate>
+    </target>
 
-    <target name="jar" depends="compile" description="Generates opendcs.jar.">
+    <target name="jar" depends="check.jar" description="Generates opendcs.jar." unless="jar.current">
 
         <!-- copy the resource files to the build directory. -->
         <copy todir="${build.classes}">

--- a/build.xml
+++ b/build.xml
@@ -54,7 +54,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
 
     <target name="check.src">
         <uptodate property="src.build.current" targetfile="${status.dir}/src.build.date">
-            <srcfiles dir="${src.main.dir}" includes="*"/>
+            <srcfiles dir="${src.main.dir}" includes="**/*"/>
         </uptodate>
     </target>
 
@@ -110,7 +110,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
 
     <target name="check.test.src" depends="check.src">
          <uptodate property="test.src.build.current.local" targetfile="${status.dir}/test.src.build.date">
-            <srcfiles dir="src/test" includes="*"/>
+            <srcfiles dir="src/test" includes="**/*"/>
         </uptodate>
         <condition property="test.src.build.current">
             <and>
@@ -245,7 +245,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 <available file="${status.dir}/src.integration.run.${opendcs.test.engine}"/>
                 <isset property="src.build.current"/>
                 <uptodate property="integration.src.current" targetFile="${status.dir}/src.integration.build.date">
-                    <srcFiles dir="${src.test-integration.main.dir}" includes="*"/>
+                    <srcFiles dir="${src.test-integration.main.dir}" includes="**/*"/>
                 </uptodate>
             </and>
         </condition>
@@ -311,7 +311,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 <available file="${status.dir}/src.gui-test.run"/>
                 <isset property="src.build.current"/>
                 <uptodate property="gui-test.src.current" targetFile="${status.dir}/src.gui-test.build.date">
-                    <srcFiles dir="${src.test-gui.main.dir}" includes="*"/>
+                    <srcFiles dir="${src.test-gui.main.dir}" includes="**/*"/>
                 </uptodate>
             </and>
         </condition>
@@ -368,9 +368,9 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         </if>
     </target>
 
-    <target name="check.jar">
+    <target name="check.jar" depends="check.src">
         <uptodate property="jar.current" targetFile="${dist.jar}">
-            <srcfiles dir="${src.main.dir}" includes="*"/>
+            <srcfiles dir="${src.main.dir}" includes="**/*"/>
         </uptodate>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -374,7 +374,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         </uptodate>
     </target>
 
-    <target name="jar" depends="check.jar" description="Generates opendcs.jar." unless="jar.current">
+    <target name="jar" depends="check.jar,compile" description="Generates opendcs.jar." unless="jar.current">
 
         <!-- copy the resource files to the build directory. -->
         <copy todir="${build.classes}">

--- a/common.xml
+++ b/common.xml
@@ -20,19 +20,23 @@
     </tstamp>
 
     <property name="project.dir" value="${basedir}"/>
+    <property name="src.main.dir" value="src/main"/>
     <property name="src.dir" value="src/main/java"/>
     <property name="resources.dir" value="src/main/resources"/>
     <property name="src.test.dir" value="src/test/java"/>
     <property name="resources.test.dir" value="src/test/resources"/>
     <property name="src.test-integration.dir" value="src/test-integration/java"/>
+    <property name="src.test-integration.main.dir" value="src/test-integration"/>
     <property name="resources.test-integration.dir" value="src/test-integration/resources"/>
     <property name="src.test-gui.dir" value="src/test-gui/java"/>
     <property name="resources.test-gui.dir" value="src/test-gui/resources"/>
+    <property name="src.test-gui.main.dir" value="src/test-gui"/>
 
     <property name="build.dir" value="build"/>
     <property name="build.classes" value="${build.dir}/classes"/>
     <property name="build.resources" value="${build.dir}/resources"/>
     <property name="build.lib" value="${build.dir}/lib"/>
+    <property name="status.dir" value="${build.dir}/.status"/>
     <property name="stage.dir" value="stage"/>
     <property name="build.test.classes" value="${build.dir}/test-classes"/>
     <property name="build.test.resources" value="${build.dir}/test-resources"/>
@@ -82,7 +86,26 @@
                     uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path"/>
     </target>
 
-    <target name="resolve" description="--> retreive dependencies with ivy" depends="init-ivy">
+    <target name="check.ivy.src">
+        <uptodate property="ivy.current" targetFile="${status.dir}/src.deps">
+            <srcfiles dir=".">
+                <filename name="ivy.xml"/>
+                <filename name="ivysettings.xml"/>
+            </srcfiles>
+            <mapper type="merge" to="${status.dir}/src.deps"/>
+        </uptodate>
+    </target>
+    <target name="check.ivy.build">
+        <uptodate property="ivy.build.current" targetFile="${status.dir}/build.deps">
+            <srcfiles dir=".">
+                <filename name="ivy.xml"/>
+                <filename name="ivysettings.xml"/>
+            </srcfiles>
+            <mapper type="merge" to="${status.dir}/build.deps"/>
+        </uptodate>
+    </target>
+
+    <target name="resolve.real" depends="init-ivy" unless="ivy.current">
         <ivy:retrieve conf="runtime,test,test_platform"
                       sync="true"
                       pattern="build/ivy/[conf]/[artifact].[ext]"
@@ -90,9 +113,70 @@
         <ivy:cachepath pathid="runtime.classpath" conf="runtime"/>
         <ivy:cachepath pathid="test.classpath" conf="test"/>
         <ivy:cachepath pathid="junit.platform.libs.classpath" conf="test_platform"/>
+
+        <pathconvert property="runtime.classpath">
+            <path refid="runtime.classpath"/>
+        </pathconvert>
+
+        <pathconvert property="test.classpath">
+            <path refid="test.classpath"/>
+        </pathconvert>
+
+        <pathconvert property="junit.platform.libs.classpath">
+            <path refid="junit.platform.libs.classpath"/>
+        </pathconvert>
+        <propertyfile file="${status.dir}/src.deps">
+            <entry key="runtime.classpath" value="${runtime.classpath}"/>
+            <entry key="test.classpath" value="${test.classpath}"/>
+            <entry key="junit.platform.libs.classpath" value="${junit.platform.libs.classpath}"/>
+        </propertyfile>
     </target>
 
-    <target name="resolve.build" depends="init-ivy" description="--> retrieve build script dependencies">
+    <target name="resolve.cached" if="ivy.current" depends="check.ivy.src">
+        <echo message="Loading cached deps (src)."/>
+        <loadproperties prefix="cached" srcFile="${status.dir}/src.deps"/>
+        <path id="junit.platform.libs.classpath">
+            <pathelement path="${cached.junit.platform.libs.classpath}"/>
+        </path>
+
+        <path id="test.classpath">
+            <pathelement path="${cached.test.classpath}"/>
+        </path>
+
+        <path id="runtime.classpath">
+            <pathelement path="${cached.runtime.classpath}"/>
+        </path>
+    </target>
+
+    <target name="resolve" description="--> retreive dependencies with ivy" depends="check.ivy.src,resolve.real,resolve.cached">
+
+    </target>
+
+    <target name="resolve.build.cached" if="ivy.build.current" depends="check.ivy.build">
+        <echo message="Loading cached deps (build)."/>
+        <loadproperties prefix="cached" srcFile="${status.dir}/build.deps"/>
+        <path id="build.classpath">
+            <pathelement path="${cached.build.classpath}"/>
+        </path>
+
+        <path id="izpack.classpath">
+            <pathelement path="${cached.izpack.classpath}"/>
+        </path>
+
+        <path id="groovy.classpath">
+            <pathelement path="${cached.groovy.classpath}"/>
+        </path>
+
+        <path id="spotbugs.classpath">
+            <pathelement path="${cached.spotbugs.classpath}"/>
+        </path>
+
+        <path id="pmd.classpath">
+            <pathelement path="${cached.pmd.classpath}"/>
+        </path>
+    </target>
+
+    <target name="resolve.build.real" depends="init-ivy,check.ivy.build" description="--> retrieve build script dependencies" unless="ivy.build.current">
         <ivy:retrieve conf="build,groovy,izpack,spotbugs,pmd"
                       sync="true"
                       pattern="build/ivy-build/[conf]/[artifact](-[classifier]).[ext]"
@@ -102,6 +186,38 @@
         <ivy:cachepath pathid="build.classpath" conf="build"/>
         <ivy:cachepath pathid="spotbugs.classpath" conf="spotbugs"/>
         <ivy:cachepath pathid="pmd.classpath" conf="pmd"/>
+
+        <pathconvert property="izpack.classpath">
+            <path refid="izpack.classpath"/>
+        </pathconvert>
+
+        <pathconvert property="groovy.classpath">
+            <path refid="groovy.classpath"/>
+        </pathconvert>
+
+        <pathconvert property="build.classpath">
+            <path refid="build.classpath"/>
+        </pathconvert>
+
+        <pathconvert property="spotbugs.classpath">
+            <path refid="spotbugs.classpath"/>
+        </pathconvert>
+
+        <pathconvert property="pmd.classpath">
+            <path refid="pmd.classpath"/>
+        </pathconvert>
+
+
+        <propertyfile file="${status.dir}/build.deps">
+            <entry key="izpack.classpath" value="${izpack.classpath}"/>
+            <entry key="groovy.classpath" value="${groovy.classpath}"/>
+            <entry key="build.classpath" value="${build.classpath}"/>
+            <entry key="spotbugs.classpath" value="${spotbugs.classpath}"/>
+            <entry key="pmd.classpath" value="${pmd.classpath}"/>
+        </propertyfile>
+    </target>
+
+    <target name="resolve.build" description="--> retreive dependencies with ivy" depends="check.ivy.build,resolve,resolve.build.real,resolve.build.cached">
         <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="build.classpath"/>
         <taskdef resource="net/sf/antcontrib/antlib.xml" classpathref="build.classpath"/>
 

--- a/docs/build.xml
+++ b/docs/build.xml
@@ -17,7 +17,7 @@
 
     <target name="check.docs">
         <uptodate property="no.docs" targetFile="${status.dir}/docs.build.date">
-            <srcFiles dir="." includes="**/*" excludes="build"/>
+            <srcFiles dir="docs" includes="source/**,build.xml,Makefile,make.bat"/>
         </uptodate>
     </target>
 

--- a/docs/build.xml
+++ b/docs/build.xml
@@ -17,7 +17,7 @@
 
     <target name="check.docs">
         <uptodate property="no.docs" targetFile="${status.dir}/docs.build.date">
-            <srcFiles dir="." excludes="build"/>
+            <srcFiles dir="." includes="**/*" excludes="build"/>
         </uptodate>
     </target>
 

--- a/docs/build.xml
+++ b/docs/build.xml
@@ -15,7 +15,13 @@
     <available property="have.python" file="${PYTHON_EXE}" filepath="${PATH}"/>
     <available property="have.latexmk" file="latexmk" filepath="${PATH}"/>
 
-    <target name="check.prereqs" depends="common.resolve.build" unless="no.docs" description="Determine if we have what we need and inform the user if we don't.">        
+    <target name="check.docs">
+        <uptodate property="no.docs" targetFile="${status.dir}/docs.build.date">
+            <srcFiles dir="." excludes="build"/>
+        </uptodate>
+    </target>
+
+    <target name="check.prereqs" depends="check.docs,common.resolve.build" unless="no.docs" description="Determine if we have what we need and inform the user if we don't.">
         <echo message="${PYTHON_EXE}"/>
         <if>
             <not>
@@ -79,10 +85,10 @@
         </sequential>
     </macrodef>
 
-
     <target name="build" depends="check.prereqs" if="canbuilddocs">
         <builddocs target="html" musthaveprop="canbuilddocs"/>
         <builddocs target="latexpdf" musthaveprop="have.latexmk"/>
+        <touch file="${status.dir}/docs.build.date"/>
     </target>
 
     <target name="clean">

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,8 +6,8 @@ project = 'OpenDCS'
 copyright = '2022, OpenDCS Consortium'
 author = 'OpenDCS Consortium'
 
-release = '7.1'
-version = '7.1.0'
+release = '7.0'
+version = '7.0.10'
 
 # -- General configuration
 

--- a/docs/source/dev-docs.rst
+++ b/docs/source/dev-docs.rst
@@ -18,6 +18,114 @@ Overview
 The purpose of this document is to describe how different technologies are used for OpenDCS development.
 Extra attention is given to testing and using OpenDCS within containers.
 
+The Ant Build
+=============
+
+Basics
+------
+
+Primarily due to history ant is used to manage the build of OpenDCS. The minimum version of Ant required 1.10.12 due to the use 
+of a setting to generate friendlier reports from the junit tests.
+
+The simplest way to verify the build is working is to run the following 'target':
+
+.. code-block:: bash
+
+    ant test
+
+This will download all of the required dependencies, compile the code and run the available unit tests.
+An html report of the tests will be available in :code:`build/reports/junit/test/`
+
+The bulk of output from various targets will go into directories under :code:`build`
+
+The basic workflow of the build is to do the following in the order of the following table. NOTE:
+See build.xml and common.xml for full details. common.xml lists created paths in properties at 
+the top of the file.
+
++-------------------------+----------------------------------------------------------------------+
+|Target                   |Purpose                                                               |
++=========================+======================================================================+
+|download-ivy             |Download the required Apache Ivy jars to handle dependency management.|
++-------------------------+----------------------------------------------------------------------+
+|init-ivy                 |Setup ant task from ivy jars                                          |
++-------------------------+----------------------------------------------------------------------+
+|resolve                  |Retrieve dependencies and organize classpaths for build               |
++-------------------------+----------------------------------------------------------------------+
+|compile                  |Compiles the OpenDCS source from `src/main/java` and syncs resource   |
+|                         |files into output directories under `build`                           |
++-------------------------+----------------------------------------------------------------------+
+|jar                      |Bundles the main OpenDCS compiled code and resources into a .jar file.|
++-------------------------+----------------------------------------------------------------------+
+|compile-test             |Compiles the test source code into class files                        |
++-------------------------+----------------------------------------------------------------------+
+|test                     |Runs the junit5 test system and generates a report. The exit code of  |
+|                         |the build will be 0 on success, and 1 on failure                      |
++-------------------------+----------------------------------------------------------------------+
+
+Additional targets that can be run for testing.
+
++-------------------------+-------------------------------------------------------------------------+
+|Target                   |Purpose                                                                  |
++=========================+=========================================================================+
+|gui-test                 |Runs available tests on GUI elements. Requires an active                 |
+|                         | desktop/windowing system or something like xvfb (X virtual frame buffer)|
++-------------------------+-------------------------------------------------------------------------+
+|integration-test         |Runs tests against an active complete system.                            |
+|                         | See `integration_test_infra`_ for more details                          |
++-------------------------+-------------------------------------------------------------------------+
+
+During general development work you can pass :code:`-Dno.docs=true` on the ant commandline to skip doc generation
+
+Other targets of integration-test
+
++-------------------------+-------------------------------------------------------------------------+
+|Target                   |Purpose                                                                  |
++=========================+=========================================================================+
+|stage                    |Preps the directory `stage` for creating the installer jar               |
++-------------------------+-------------------------------------------------------------------------+
+|opendcs                  |Generates the install jar using izpack                                   |
++-------------------------+-------------------------------------------------------------------------+
+|release                  |Generates and signs release artifacts for upload                         |
+|                         |requires `-Dgpg.key.id` command line option                              |
++-------------------------+-------------------------------------------------------------------------+
+
+Debugging OpenDCS
+-----------------
+
+All of the test tasks above can have :code:`-DdebugPort=<port number>`, where :code:`<port number>` is 
+an integer between 1025 and 65534 without the < and > added to the ant command line. Thyen Your IDE can then attach to the JVM running 
+the tests.
+
+While we are trying to add more formal unit tests it is still often easier, and generally required while development, to step through
+the code while manually testing things.
+
+If you have an installation of OpenDCS already it can also be debugged in a similar way. NOTE: this is
+known to work on linux/mac.
+
+After you have an installation otherwise working start applications with the following:
+
+.. code-block:: bash
+
+    # For testing dbedit.
+    DECJ_MAXHEAP="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=<port>" dbedit
+
+    # For testing dbedit, but you're trying to figured out an issue during startup.
+    DECJ_MAXHEAP="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=<port>" dbedit
+
+
+You can then have your IDE attach to the JVM and it will stop on break points appropriately.
+
+The following workflow can be used:
+
+.. code-block:: bash
+
+    # <see issue and make tweaks to code>
+    ant jar
+    cp build/lib/opendcs.jar <your current $DCSTOOL_HOME>/bin
+    DECJ_MAXHEAP="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=<port>" <app>
+
+
+And repeat as required. This works for the GUI and nogui applications.
 
 MBeans
 ======
@@ -40,6 +148,8 @@ Connection pool
 
 CwmsDb using a connection pool mechanism. Leaks are a concern, if you working against a CWMS
 system you can turn pool tracing on for an application with the following java flags:
+
+.. code-block:: bash
 
     DECJ_MAXHEAP="-Dcwms.connection.pool.trace=true" routsched ...
 
@@ -109,8 +219,7 @@ Checkstyle, Spotbugs, and the PMD/CPD tools are available for anaylzing the code
 
 to run each do the following:
 
-
-.. code-block: bash
+.. code-block:: bash
 
     # SpotBugs
     ant spotbugs
@@ -126,6 +235,7 @@ to run each do the following:
 
 Only CPD is fast. checkstyle and SpotBugs are rather slow.
 
+.. _integration_test_infra:
 Integration Test infrastructure
 ===============================
 
@@ -150,7 +260,9 @@ Application logs are all written into this directory.
 Currently Implemented are OpenDCS-XML and OpenDCS-Postgres. OpenDCS-Postgres uses the (Testcontainers)[https://java.testcontainers.org] library
 which requires docker. OpenDCS-XML only depends on the file system.
 
-To run either use the following command::
+To run either use the following command:
+
+.. code-block:: bash
 
     ant integration-test -Dno.doc=true -Dopendcs.test.engine=OpenDCS-XML
     # or 
@@ -234,12 +346,16 @@ application will only be a minor additional layer.
 
 Some applications like LRGS, RoutingScheduler, CompProc will have a default CMD and parameters and be suitable for:
 
+.. code-block:: bash
+
    docker run -d ...
 
 To run as a service.
 
 Other applications, like importts, complocklist, etc, will have an ENTRYPOINT and a user can call it like they normally would except prefixing with:
-   
+
+.. code-block:: bash
+
    docker run -v `pwd`/decodes.properties:/dcs_user/decodes.properties complocklist
 
 NOTE: this is still a work in progress, we may switch or there will also be support for environment variables. However, the commandline apps will


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Often when cycling through implementing tests, or really any other portion sections of the build are repeated that really don't need to be, at least until forced for some reason.

## Solution

I went through the ant build and added checks for whether certain elements were sufficiently up-to-date to skip.

## how you tested the change

Running the build on Linux and Windows

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [x] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

I'll be adding to the docs, currently waiting for the windows build to finish the first time.
