### PR TITLE
Fix issue that caused routingspec threads to fail incorrectly.

### DIFF
--- a/src/main/java/decodes/routing/ScheduleEntryExecutive.java
+++ b/src/main/java/decodes/routing/ScheduleEntryExecutive.java
@@ -148,7 +148,7 @@ private long lastDebug = 0L;
 				Logger.instance().failure("Thread " + getName() + " has failed.");
 				seThread.shutdown();
 				seThread.quit(); // TODO: shutdown AND quit? why?
-				seThread = null;
+				//seThread = null; // can't set seThread null here as it is within rsFinished
 				runState = RunState.shutdown;
 				seStatus.setRunStatus("ERROR-system");
 			}


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #. 

<!-- if you are referencing a specific issue a problem description is not required -->
RoutingScheduler was not behaving correctly for Postgres implementation after #254 changes.

## Solution

Remove setting of `seThread` to null as it is handled later.

## how you tested the change

Running OpenDCS Postgres implementation in homelab. Working for about 5 days now.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
