### PR TITLE
Add annotation for setting required setup data.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,9 @@ jobs:
         run: |
           sudo apt install xvfb
           xvfb-run ant gui-test -D"no.docs=true"
+      - name: Code Coverage
+        run: |
+          ant coverage.report
       - name: Documentation and Create installer jar
         run: |
           ant opendcs

--- a/build.xml
+++ b/build.xml
@@ -18,6 +18,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
 <project name="OPENDCS Toolkit" default="jar" basedir="."
     xmlns:artifact="antlib:org.apache.maven.artifact.ant" xmlns:resolver="antlib:org.apache.maven.resolver.ant"
     xmlns:if="ant:if" xmlns:unless="ant:unless"
+    xmlns:jacoco="antlib:org.jacoco.ant"
     >
     <description>Open DCS</description>
 
@@ -195,6 +196,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <echo message="platform path: ${platform_path}"/>
         <mkdir dir="${build.dir}/test-results"/>
         <mkdir dir="${build.dir}/test-tmp"/>
+        <jacoco:agent property="coverage.agent.param.test" destfile="${coverage.dir}/jacoco.test.exec"/>
         <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="test.failed">
             <classpath refid="test.classpath"/>
             <classpath refid="runtime.classpath"/>
@@ -208,6 +210,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
 
             <testclasses outputdir="${build.dir}/test-results">
                 <fork>
+                    <jvmarg value="${coverage.agent.param.test}"/>
                     <jvmarg value="-Dbuild.dir=${build.dir}"/>
                     <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-tmp"/>
                     <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
@@ -280,6 +283,7 @@ more information about each.
         <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
         <mkdir dir="${build.dir}/test-integration/${opendcs.test.engine}/results"/>
         <mkdir dir="${build.dir}/test-integration/${opendcs.test.engine}/tmp"/>
+        <jacoco:agent property="coverage.agent.param.it" destfile="${coverage.dir}/jacoco.test-it-${opendcs.test.engine}.exec"/>
         <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="integration.failed">
             <classpath refid="test.classpath"/>
             <classpath refid="runtime.classpath"/>
@@ -292,6 +296,7 @@ more information about each.
 
             <testclasses outputdir="${build.dir}/test-integration/${opendcs.test.engine}/results">
                 <fork>
+                    <jvmarg value="${coverage.agent.param.it}"/>
                     <jvmarg value="-Dbuild.dir=${build.dir}"/>
                     <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-integration/${opendcs.test.engine}/tmp"/>
                     <jvmarg value="-Dresource.dir=${build.test-integration.resources}"/>
@@ -345,6 +350,7 @@ more information about each.
         <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
         <mkdir dir="${build.dir}/test-gui/results"/>
         <mkdir dir="${build.dir}/test-gui/tmp"/>
+        <jacoco:agent property="coverage.agent.param.gui" destfile="${coverage.dir}/jacoco.test-gui.exec"/>
         <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="gui.failed">
             <classpath refid="test.classpath"/>
             <classpath refid="runtime.classpath"/>
@@ -358,6 +364,7 @@ more information about each.
 
             <testclasses outputdir="${build.dir}/test-gui/results">
                 <fork>
+                    <jvmarg value="${coverage.agent.param.gui}"/>
                     <jvmarg value="-Dbuild.dir=${build.dir}"/>
                     <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-gui/tmp"/>
                     <jvmarg value="-Dresource.dir=${build.test-gui.resources}"/>
@@ -886,4 +893,30 @@ more information about each.
     </target>
 
     <target name="code-anaylsis" depends="spotbugs,cpd" description="Run all available code anaylsis"/>
+
+    <!-- Still debating on if this should depend on all the tests, but it's perfectly valid to only want to see
+         coverage for what's actually been generated. -->
+    <target name="coverage.report" depends="common.resolve.build">
+        <jacoco:merge destfile="${reports.dir}/coverage.exec">
+            <fileset dir="${coverage.dir}" includes="*.exec"/>
+        </jacoco:merge>
+
+        <jacoco:report>
+            <executiondata>
+                <file file="${reports.dir}/coverage.exec"/>
+            </executiondata>
+
+            <structure name="OpenDCS">
+                <classfiles>
+                    <fileset dir="${build.classes}"
+                             excludes="**/python_packages,**/certifi/**,**/chardet/**,**/urllib3/**,**/requests/**,**/chardet/**,**/urllib3/**,**/idna/**,**/pkg_resources/**"/>
+                </classfiles>
+                <sourcefiles encoding="UTF-8">
+                    <fileset dir="${src.dir}"/>
+                </sourcefiles>
+            </structure>
+
+            <html destdir="${build.dir}/reports/coverage"/>
+        </jacoco:report>
+    </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -909,14 +909,32 @@ more information about each.
             <structure name="OpenDCS">
                 <classfiles>
                     <fileset dir="${build.classes}"
-                             excludes="**/python_packages,**/certifi/**,**/chardet/**,**/urllib3/**,**/requests/**,**/chardet/**,**/urllib3/**,**/idna/**,**/pkg_resources/**"/>
+                             excludes="**/easy_install/**,**/python_packages,**/certifi/**,**/chardet/**,**/urllib3/**,**/requests/**,**/chardet/**,**/urllib3/**,**/idna/**,**/pkg_resources/**"/>
                 </classfiles>
                 <sourcefiles encoding="UTF-8">
                     <fileset dir="${src.dir}"/>
                 </sourcefiles>
             </structure>
 
-            <html destdir="${build.dir}/reports/coverage"/>
+            <html destdir="${reports.dir}/coverage.html"/>
         </jacoco:report>
+        <!--
+
+            Thank you to
+            https://stackoverflow.com/a/71917464
+            and
+            https://stackoverflow.com/a/28476028
+        -->
+        <loadfile encoding="UTF-8" property="coverage.percentage"
+                srcFile="${reports.dir}/coverage.html/index.html">
+            <filterchain>
+                <tokenfilter>
+                    <containsregex
+                        pattern="^.*&lt;td>Total&lt;([^>]+>){4}([^&lt;]*).*"
+                        replace="\2"/>
+                </tokenfilter>
+            </filterchain>
+        </loadfile>
+        <echo message="Total coverage = ${coverage.percentage}"/>
     </target>
 </project>

--- a/common.xml
+++ b/common.xml
@@ -33,6 +33,7 @@
     <property name="src.test-gui.main.dir" value="src/test-gui"/>
 
     <property name="build.dir" value="build"/>
+    <property name="reports.dir" value="${build.dir}/reports"/>
     <property name="build.classes" value="${build.dir}/classes"/>
     <property name="build.resources" value="${build.dir}/resources"/>
     <property name="build.lib" value="${build.dir}/lib"/>
@@ -48,9 +49,10 @@
     <property name="build.test.lib" value="${build.dir}/test-integration/libs"/>
     <property name="dist.jar" value="${build.lib}/opendcs.jar"/>
     <property name="build.release.dir" value="${build.dir}/release"/>
-    <property name="spotbugs.output.dir" value="${build.dir}/reports/spotbugs"/>
+    <property name="spotbugs.output.dir" value="${reports.dir}/spotbugs"/>
     <property name="pmd.output.dir" value="${build.dir}/reports/pmd"/>
     <property name="junit.html.output.dir" value="${build.dir}/reports/junit"/>
+    <property name="coverage.dir" value="${build.dir}/coverage/"/>
 
     <!-- VERSION NUMBERS -->
     <property name="MAJ_VER" value="7"/>
@@ -228,6 +230,11 @@
                  classpathref="build.classpath"/>
         <taskdef name="cpd" classname="net.sourceforge.pmd.cpd.CPDTask"
                  classpathref="pmd.classpath"/>
+
+        <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml"
+                 classpathref="build.classpath"/>
+
+        <mkdir dir="${coverage.dir}"/>
     </target>
 
     <target name="report" depends="resolve,resolve.build" description="--> generates a report of dependencies">

--- a/docs/source/dev-docs.rst
+++ b/docs/source/dev-docs.rst
@@ -236,6 +236,7 @@ to run each do the following:
 Only CPD is fast. checkstyle and SpotBugs are rather slow.
 
 .. _integration_test_infra:
+
 Integration Test infrastructure
 ===============================
 
@@ -301,6 +302,20 @@ Integration tests inherit from :code:AppTestBase. This simplifies access to reso
 |                                            |user.properties file            |
 +--------------------------------------------+--------------------------------+
  
+
+At the Class and method level the following annotations are available.
+
++--------------------------------------------+--------------------------------+
+|Annotation                                  |Description                     |
++============================================+================================+
+|DecodesConfigurationRequired                |List of database import files   |
+|                                            |needs for tests to succeed.     |
+|                                            |Can be set at the Class level,  |
+|                                            |Method level, or both in which  |
+|                                            |case the sets will be merged    |
++--------------------------------------------+--------------------------------+
+
+
 Extension and other Junit information
 -------------------------------------
 

--- a/docs/source/dev-docs.rst
+++ b/docs/source/dev-docs.rst
@@ -309,7 +309,7 @@ At the Class and method level the following annotations are available.
 |Annotation                                  |Description                     |
 +============================================+================================+
 |DecodesConfigurationRequired                |List of database import files   |
-|                                            |needs for tests to succeed.     |
+|                                            |needed for tests to succeed.     |
 |                                            |Can be set at the Class level,  |
 |                                            |Method level, or both in which  |
 |                                            |case the sets will be merged    |

--- a/ivy.xml
+++ b/ivy.xml
@@ -114,6 +114,9 @@
             does not. Downgrade for now to people can review.-->
         <dependency org="com.puppycrawl.tools" name="checkstyle" rev="9.3" conf="build->default"/>
         <dependency org="com.github.spotbugs" name="spotbugs-ant" rev="4.7.3" conf="build->default"/>
+        <dependency org="org.jacoco" name="org.jacoco.ant" rev="0.8.11" conf="build->default"/>
+
+        <!-- Spotbugs -->
         <dependency org="com.github.spotbugs" name="spotbugs" rev="4.7.3" conf="spotbugs->default">
             <!-- Ivy wasn't pulling the dependency in directly. Instead of the actual jar
                 it was getting only the "-data" artifact and spotbugs was unable to use it.

--- a/src/test-integration/java/org/opendcs/fixtures/AppTestBase.java
+++ b/src/test-integration/java/org/opendcs/fixtures/AppTestBase.java
@@ -7,6 +7,7 @@ import java.io.File;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.opendcs.fixtures.annotations.ConfiguredField;
 import org.opendcs.fixtures.helpers.TestResources;
 import org.opendcs.spi.configuration.Configuration;
 

--- a/src/test-integration/java/org/opendcs/fixtures/AppTestBase.java
+++ b/src/test-integration/java/org/opendcs/fixtures/AppTestBase.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.opendcs.fixtures.helpers.TestResources;
 import org.opendcs.spi.configuration.Configuration;
 
+import ilex.util.EnvExpander;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -46,7 +47,14 @@ public class AppTestBase
      */
     public static String getResource(String file)
     {
-        return new File(TestResources.resourceDir,file).getAbsolutePath();
+        if ( !file.startsWith("$"))
+        {
+            return new File(TestResources.resourceDir,file).getAbsolutePath();
+        }
+        else
+        {
+            return new File(EnvExpander.expand(file,System.getProperties())).getAbsolutePath();
+        }
     }
 
     /**

--- a/src/test-integration/java/org/opendcs/fixtures/OpenDCSTestConfigExtension.java
+++ b/src/test-integration/java/org/opendcs/fixtures/OpenDCSTestConfigExtension.java
@@ -22,6 +22,7 @@ import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
+import org.opendcs.fixtures.annotations.ConfiguredField;
 import org.opendcs.fixtures.annotations.DecodesConfigurationRequired;
 import org.opendcs.fixtures.helpers.Programs;
 import org.opendcs.fixtures.helpers.TestResources;

--- a/src/test-integration/java/org/opendcs/fixtures/annotations/ConfiguredField.java
+++ b/src/test-integration/java/org/opendcs/fixtures/annotations/ConfiguredField.java
@@ -1,4 +1,4 @@
-package org.opendcs.fixtures;
+package org.opendcs.fixtures.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/test-integration/java/org/opendcs/fixtures/annotations/DecodesConfigurationRequired.java
+++ b/src/test-integration/java/org/opendcs/fixtures/annotations/DecodesConfigurationRequired.java
@@ -6,10 +6,23 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Specify a list of confiugration xml files that need to 
+ * be imported before any tests in this test class are run.
+ * 
+ * Values that start with $ will have {@code EnvExpander.expand(string,System.getProperties())}
+ * run on them to expand any properties; the properties used will be those set by the configuration and 
+ * passed in to the integration-test junitlauncher task.
+ * 
+ * Other wise values are relative to @see TestResources.resourceDir
+ */
 @Documented
 @Target({ElementType.METHOD,ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DecodesConfigurationRequired
 {
+    /**
+     * List of resource file values
+     */
     String[] value();
 }

--- a/src/test-integration/java/org/opendcs/fixtures/annotations/EnableIfSql.java
+++ b/src/test-integration/java/org/opendcs/fixtures/annotations/EnableIfSql.java
@@ -1,4 +1,4 @@
-package org.opendcs.fixtures;
+package org.opendcs.fixtures.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/test-integration/java/org/opendcs/regression_tests/DecodesTest.java
+++ b/src/test-integration/java/org/opendcs/regression_tests/DecodesTest.java
@@ -6,12 +6,10 @@ import java.io.File;
 import java.util.logging.Logger;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.opendcs.fixtures.AppTestBase;
-import org.opendcs.fixtures.helpers.Programs;
+import org.opendcs.fixtures.annotations.DecodesConfigurationRequired;
 import org.opendcs.spi.configuration.Configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,27 +17,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import decodes.routing.RoutingSpecThread;
 import uk.org.webcompere.systemstubs.SystemStubs;
 
+@DecodesConfigurationRequired({
+        "shared/test-sites.xml",
+        "shared/ROWI4.xml",
+        "${DCSTOOL_HOME}/schema/cwms/cwms-import.xml",
+        "shared/presgrp-regtest.xml",
+        "HydroJsonTest/HydroJSON-rs.xml",
+        "SimpleDecodesTest/site-OKVI4.xml",
+        "SimpleDecodesTest/OKVI4-decodes.xml"
+})
 public class DecodesTest extends AppTestBase
 {
     private static final Logger log = Logger.getLogger(DecodesTest.class.getName());
-
-
-    @BeforeAll
-    public void load_sites() throws Exception
-    {
-        log.info("Importing shared data.");
-        Configuration config = this.configuration;
-        File propertiesFile = config.getPropertiesFile();
-        File logFile = new File(config.getUserDir(),"/decodes-test-setup.log");
-        Programs.DbImport(logFile, propertiesFile, environment, exit,
-                                getResource("shared/test-sites.xml"),
-                                getResource("shared/ROWI4.xml"),
-                                new File(config.getUserDir(),"/schema/cwms/cwms-import.xml").getAbsolutePath(),
-                                getResource("shared/presgrp-regtest.xml"),
-                                getResource("HydroJsonTest/HydroJSON-rs.xml"),
-                                getResource("SimpleDecodesTest/site-OKVI4.xml"),
-                                getResource("SimpleDecodesTest/OKVI4-decodes.xml"));
-    }
 
     @ParameterizedTest
     @CsvSource({

--- a/src/test-integration/java/org/opendcs/regression_tests/LoadingAppTestIT.java
+++ b/src/test-integration/java/org/opendcs/regression_tests/LoadingAppTestIT.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 import org.opendcs.fixtures.AppTestBase;
-import org.opendcs.fixtures.ConfiguredField;
-import org.opendcs.fixtures.EnableIfSql;
+import org.opendcs.fixtures.annotations.ConfiguredField;
+import org.opendcs.fixtures.annotations.EnableIfSql;
 
 import decodes.tsdb.CompAppInfo;
 import decodes.tsdb.TimeSeriesDb;


### PR DESCRIPTION
## Problem Description

While working on the LoadingAppDao PR I thought setting up annotation instead of using before handlers would make more sense, it would certainly alleviate the additional "if sql/tsdb" checks within those blocks.

## Solution

Created a new annotation for the developer to specify decodes database setup files required for these tests
Additionally, I setup code coverage for helping to track test progress.

I'd like to add a status badge, as I did for the actual build success status, but still reviewing the best way.

## how you tested the change

Manually ran OpenDCS-XML and OpenDCS-Postgres integration tests

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [x] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [x] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
