### PR TITLE
Additional Oracle connection usages in HDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ doc-source/*.rst
 *.log
 *.iml
 .idea/
+/cwmsSystemJars/
+/3rd_party

--- a/src/main/java/decodes/hdb/HdbSqlDatabaseIO.java
+++ b/src/main/java/decodes/hdb/HdbSqlDatabaseIO.java
@@ -9,6 +9,7 @@ import opendcs.dai.SiteDAI;
 import decodes.db.DatabaseException;
 import decodes.sql.OracleDateParser;
 import decodes.sql.SqlDatabaseIO;
+import oracle.jdbc.OracleConnection;
 
 public class HdbSqlDatabaseIO extends SqlDatabaseIO
 {
@@ -46,8 +47,7 @@ public class HdbSqlDatabaseIO extends SqlDatabaseIO
 		throws SQLException
 	{
 		super.setDBDatetimeFormat(conn);
-		oracle.jdbc.OracleConnection ocon = (oracle.jdbc.OracleConnection)getConnection();
-		ocon.setSessionTimeZone(databaseTimeZone);
+		conn.unwrap(OracleConnection.class).setSessionTimeZone(databaseTimeZone);
 	}
 	
 	@Override

--- a/src/main/java/decodes/hdb/HdbTimeSeriesDb.java
+++ b/src/main/java/decodes/hdb/HdbTimeSeriesDb.java
@@ -235,7 +235,6 @@ public class HdbTimeSeriesDb
 		Statement st = null;
 		try
 		{
-			oracle.jdbc.OracleConnection ocon = (oracle.jdbc.OracleConnection)getConnection();
 			st = conn.createStatement();
 			
 			q = "SELECT PARAM_VALUE FROM REF_DB_PARAMETER WHERE PARAM_NAME = 'TIME_ZONE'";
@@ -264,9 +263,8 @@ public class HdbTimeSeriesDb
 				try { rs.close(); } catch(Exception ex) {}
 				rs = null;
 			}
-			
-			ocon.setSessionTimeZone(databaseTimezone);
-			
+			conn.unwrap(oracle.jdbc.OracleConnection.class).setSessionTimeZone(databaseTimezone);
+
 			// Hard-code date & timestamp format for reads. Always use GMT.
 			q = "ALTER SESSION SET TIME_ZONE = '" + databaseTimezone + "'";
 			info(q);
@@ -285,7 +283,7 @@ public class HdbTimeSeriesDb
 			st.execute(q);
 			
 			// MJM 2018-2/21 Force autoCommit on.
-			try { ocon.setAutoCommit(true);}
+			try { conn.setAutoCommit(true);}
 			catch(SQLException ex)
 			{
 				Logger.instance().warning("Cannot set SQL AutoCommit to true: " + ex);


### PR DESCRIPTION
## Problem Description
Found these two connection usages that broke HDB usage for Routing Specs.

Fixes #398, fixes #397. 

## Solution

Updated usages, concerned that I'm using the passed in Connection variable instead of internal getConnection() where I shouldn't. Unclear to me which makes sense.

## how you tested the change

Ran routing spec to a test HDB instance. Works now and didn't before. Speed still seems to be an issue. 