### PR TITLE
Correction DecodesScript processing for given situation

### DIFF
--- a/src/main/java/decodes/db/DecodesScript.java
+++ b/src/main/java/decodes/db/DecodesScript.java
@@ -672,11 +672,27 @@ public class DecodesScript extends IdDatabaseObject
         /**
          * Finalize the creation of a decodes script. After this 
          * the script should be ready for decoding operations.
+         *
+         * Defaults to <b>NOT</b> throwing an exception on a script processing error.
+         *
          * @return DecodesScript
          * @throws DecodesScriptException Any issues preparing the script
          * @throws IOException any issues retrieving format statements
          */
         public DecodesScript build() throws DecodesScriptException, IOException
+        {
+            return build(false);
+        }
+
+        /**
+         * Finalize the creation of a decodes script. After this
+         * the script should be ready for decoding operations.
+         * @param failOnError Whether to throw an exception if formatstatement processing fails
+         * @return DecodesScript
+         * @throws DecodesScriptException Any issues preparing the script
+         * @throws IOException any issues retrieving format statements
+         */
+        public DecodesScript build(boolean failOnError) throws DecodesScriptException, IOException
         {
             Objects.requireNonNull(platformSupplier, "PlatformConfig cannot be null. Set before calling build.");
             DecodesScript script = new DecodesScript(nameSupplier.get());
@@ -691,12 +707,20 @@ public class DecodesScript extends IdDatabaseObject
                     script.formatStatements.add(fs.get());
                 }
                 script.prepareForExec();
-                return script;
             }
             catch(Exception ex)
             {
-                throw new DecodesScriptException("Unable to finalize Decodes Script (" + script.scriptName + ") for use.",ex);
+                final String msg = "Unable to finalize Decodes Script (" + script.scriptName + ") for use.";
+                if (failOnError)
+                {
+                    throw new DecodesScriptException(msg, ex);
+                }
+                else
+                {
+                    logger.failure(msg + " " + ex.getLocalizedMessage());
+                }
             }
+            return script;
         }
 
         /**

--- a/src/main/java/decodes/dbeditor/DecodesScriptEditPanel.java
+++ b/src/main/java/decodes/dbeditor/DecodesScriptEditPanel.java
@@ -1233,6 +1233,14 @@ public class DecodesScriptEditPanel
 	{
 		this.parentDialog = parentDialog;
 	}
+
+	/**
+	 * Get the edited scripted.
+	 * @return
+	 */
+	public DecodesScript getScript() {
+		return this.theScript;
+	}
 }
 
 class FormatStatementTableModel extends AbstractTableModel

--- a/src/main/java/decodes/dbeditor/DecodingScriptEditDialog.java
+++ b/src/main/java/decodes/dbeditor/DecodingScriptEditDialog.java
@@ -126,17 +126,10 @@ public class DecodingScriptEditDialog
 	{
 		panel1.setLayout(borderLayout1);
 		okButton.setText(genericLabels.getString("OK"));
-		okButton.addActionListener(new java.awt.event.ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				okButton_actionPerformed(e);
-			}
-		});
+		okButton.addActionListener(e -> okButton_actionPerformed(e));
+
 		cancelButton.setText(genericLabels.getString("cancel"));
-		cancelButton.addActionListener(new java.awt.event.ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				cancelButton_actionPerformed(e);
-			}
-		});
+		cancelButton.addActionListener(e -> cancelButton_actionPerformed(e));
 		jPanel4.setLayout(flowLayout3);
 		flowLayout3.setHgap(35);
 		flowLayout3.setVgap(10);
@@ -169,10 +162,21 @@ public class DecodingScriptEditDialog
 			return;
 		}
 
-		PlatformConfig pc = decodingScriptEditPanel.theScript.platformConfig;
-		pc.rmScript(decodingScriptEditPanel.origScript);
-		pc.addScript(decodingScriptEditPanel.theScript);
-		closeDlg();
+		try
+		{
+			final DecodesScript theScript = decodingScriptEditPanel.getScript();
+			theScript.prepareForExec();
+
+			PlatformConfig pc = decodingScriptEditPanel.theScript.platformConfig;
+			pc.rmScript(decodingScriptEditPanel.origScript);
+			pc.addScript(decodingScriptEditPanel.theScript);
+			closeDlg();
+		}
+		catch (DecodesException ex)
+		{
+			TopFrame.instance().showError(
+				dbeditLabels.getString("DecodingScriptEditPanel.errorDecoding") + ex.getLocalizedMessage());
+		}
 	}
 
 	/** Closes the dialog */

--- a/src/main/java/decodes/decoder/FormatStatementTokenizer.java
+++ b/src/main/java/decodes/decoder/FormatStatementTokenizer.java
@@ -73,7 +73,8 @@ public class FormatStatementTokenizer
 			c = nextChar();
 		}
 		if (c == (char)0)
-			throw new ScriptFormatException("Sign with no repetitions.");
+			throw new ScriptFormatException("Sign with no repetitions.", this.fmtStatementText,
+											"-", lastTokenStart);
 
 		// Optional number of repetitions preceding the op code
 		int repetitions = 0;
@@ -92,7 +93,8 @@ public class FormatStatementTokenizer
 		while(Character.isWhitespace(c))
 			c = nextChar();
 		if (c == (char)0)
-			throw new ScriptFormatException("Repetition factor without operator");
+			throw new ScriptFormatException("Repetition factor without operator",
+											fmtStatementText,"" + repetitions,lastTokenStart);
 
 		// Current char is now the beginning of the operator
 		StringBuilder opName = new StringBuilder();
@@ -134,7 +136,8 @@ public class FormatStatementTokenizer
 					ret = func;
 				}
 				else
-					throw new ScriptFormatException("Function '" + op + "' unknown.");
+					throw new ScriptFormatException("Function '" + op + "' unknown.",
+												    fmtStatementText,op,lastTokenStart);
 			}
 		}
 		else if (op.equals("x"))
@@ -182,7 +185,8 @@ public class FormatStatementTokenizer
 		{
 			throw new ScriptFormatException(
 				"Unknown operator '" + op + "', in '" + fmtStatementText 
-				+ "', position=" + lastTokenStart);
+				+ "', position=" + lastTokenStart,
+				fmtStatementText, op, lastTokenStart);
 		}
 
 		// After the above, the last char processed is one of:

--- a/src/main/java/decodes/decoder/ScriptFormatException.java
+++ b/src/main/java/decodes/decoder/ScriptFormatException.java
@@ -21,6 +21,12 @@ This exception indicates a syntax error in a format statement.
 */
 public class ScriptFormatException extends DecoderException
 {
+	private static final String NO_STATEMENT = "not_set";
+	private static final String NO_OPERATION = "unknown";
+	private final String statement;
+	private final String operation;
+	private final int idx;
+
 	/**
 	  Construct the exception.
 	  @param msg the message
@@ -28,5 +34,57 @@ public class ScriptFormatException extends DecoderException
 	public ScriptFormatException(String msg)
 	{
 		super(msg);
+		statement = NO_STATEMENT;
+		operation = NO_OPERATION;
+		idx = -1;
+
+	}
+
+	/**
+	 * Contains information about an error on a format statement.
+	 *
+	 * @param msg Friendly message
+	 * @param fmtStatement actual format statement text
+	 * @param operation last processed operator
+	 * @param idx index in the format statement string of the error
+	 */
+	public ScriptFormatException(String msg, String fmtStatement, String operation, int idx)
+	{
+		super(msg);
+		this.statement = fmtStatement;
+		this.operation = operation;
+		this.idx = idx;
+	}
+
+	public String getStatement()
+	{
+		return statement;
+	}
+
+	public String getOperation()
+	{
+		return operation;
+	}
+
+	public int getErrorIndex()
+	{
+		return idx;
+	}
+
+	@Override
+	public String getMessage()
+	{
+		StringBuilder sb = new StringBuilder();
+		sb.append(super.getMessage()).append("");
+		if (!NO_STATEMENT.equals(getStatement()))
+		{
+			sb.append("In Statement {").append(getStatement()).append("} ");
+			sb.append("Nearest offset at column").append(idx).append(".");
+		}
+		if (!NO_OPERATION.equals(getOperation()))
+		{
+			sb.append(" Last processed operation was {").append(getOperation()).append("}");
+		}
+		return sb.toString();
 	}
 }


### PR DESCRIPTION

## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #359. 

There are better improvements to the error message; they'll be done later this actual fix is more important.

## Solution

- Allow usages of DecodesScriptBuilder::build to decide if fatal error or log message.
- DbEdit (e.g. DECODES database can load *existing* bad statements
- Expanded ScriptFormatException to contain more data.
- DecodesScriptEditor will not allow leaving if the script is bad - preventing future incorrect statements. (User can cancel to leave existing bad to work on later.)


## how you tested the change

Manually:

- Attempted to save bad format statement, was prevented from doing so (dialog doesn't close, error message contains correct information.)
- Inserted bad format statement into database, verified it was read back in.
- sample Decoding and check on "OK" pressed present the same error data.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [x] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
