### PR TITLE
Bugfix/413 decodes message browser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,20 @@ jobs:
         platform: [ubuntu-latest,macos-latest,windows-latest]
     runs-on: ${{matrix.platform}}
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4.1.1
       - name: Set up JDK
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v4.0.0
         with:
           java-version: '8'
-          distribution: adopt
-      - uses: actions/setup-python@v3.1.3
+          distribution: temurin
+      - uses: actions/setup-python@v4.0.0
         with:
           python-version: "3.8"
+      - uses: actions/cache@v3.3.2
+        with:
+          path: ~/.ant
+          key: ${{ matrix.platform }}-ivy-${{hashFiles('ivy.xml')}}
+          restore-keys: ${{ matrix.platform }}-ivy
       - name: units tests
         run: |
           ant test -D"no.docs=true"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
         shell: bash {0}
         run: |
           sudo apt install xvfb ffmpeg
+          # Precompile the test code so the recording isn't as long.
+          ant compile-test-gui -D"no.docs=true"
           export DISPLAY=:99.0
           Xvfb $DISPLAY -screen 0 1920x1080x24 &
           ffmpeg -nostdin -y -f x11grab -video_size 1920x1080 -i "$DISPLAY" build/test-gui.webm &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           ant opendcs
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4.0.0
         if: success() || failure()
         with:
           name: test-results-${{matrix.platform}}

--- a/src/main/java/lrgs/gui/DcpMsgOutputThread.java
+++ b/src/main/java/lrgs/gui/DcpMsgOutputThread.java
@@ -24,6 +24,7 @@ import lrgs.common.*;
 import lrgs.ldds.*;
 
 import decodes.consumer.OutputFormatter;
+import decodes.db.Database;
 
 /**
 This works with DcpMsgOutputMonitor. This Thread will do the actual message
@@ -325,7 +326,11 @@ class DcpMsgOutputThread extends Thread
 	{
 		Logger.instance().log(Logger.E_DEBUG1, 
 			"Initializing msgaccess DECODES refs");
-		try { decodesIf = new DecodesInterface(); }
+		try
+		{
+			/* by the time this is called the Database instance is valid or will be appropriately created. */
+			decodesIf = new DecodesInterface(Database.getDb());
+		}
 		catch(NoClassDefFoundError ex)
 		{
 			PrintStream ps = new PrintStream(outs);

--- a/src/main/java/lrgs/gui/DecodesInterface.java
+++ b/src/main/java/lrgs/gui/DecodesInterface.java
@@ -110,13 +110,14 @@ public class DecodesInterface
 	StringBufferConsumer consumer;
 	StringBuffer decodeBuf;
 
-	/** 
-	  default constructor.
-	  Call initDecodes after construction.
+	/**
+	   Call initDecodes before construction.
+	   This is currently only used by the Message Browser, usage else where
+	   is discouraged.
 	*/
-	DecodesInterface()
+	DecodesInterface(Database db)
 	{
-		dataSource = new LrgsDataSource(null,null);
+		dataSource = new LrgsDataSource(null,db);
 		decodeBuf = new StringBuffer();
 		consumer = new StringBufferConsumer(decodeBuf);
 		timeZone = null;


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #413. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Inject Instance of Database. 
NOTE: Still using the Deprecated `Database::getDb`, removal of such usage will require larger structural changes to
that that interface.

## how you tested the change

1. Opened Message Browser (launcher_start/dcstool_start or `msgaccess`) connecting to a database of some sort
2. Configure search criteria to known data (you have platforms and decodes scripts configured)
3. Change "Show" to `Raw and Decoded` or `Decoded`
4. Choose display all or next and see appropriately decoded output.



## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [x] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
