### PR TITLE
Cache .ant directory to cache ivy dependencies for build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,11 @@ jobs:
       - uses: actions/setup-python@v3.1.3
         with:
           python-version: "3.8"
+      - uses: actions/cache@v3.3.2
+        with:
+          path: ~/.ant
+          key: $${{ matrix.platform }}-ivy-${{hashFiles('ivy.xml')}}
+          restore-keys: ${{ matrix.platform }}-ivy
       - name: units tests
         run: |
           ant test -D"no.docs=true"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           ant opendcs
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4.0.0
         if: success() || failure()
         with:
           name: test-results-${{matrix.platform}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/cache@v3.3.2
         with:
           path: ~/.ant
-          key: $${{ matrix.platform }}-ivy-${{hashFiles('ivy.xml')}}
+          key: ${{ matrix.platform }}-ivy-${{hashFiles('ivy.xml')}}
           restore-keys: ${{ matrix.platform }}-ivy
       - name: units tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,13 @@ jobs:
         platform: [ubuntu-latest,macos-latest,windows-latest]
     runs-on: ${{matrix.platform}}
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4.1.1
       - name: Set up JDK
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v4.0.0
         with:
           java-version: '8'
-          distribution: adopt
-      - uses: actions/setup-python@v3.1.3
+          distribution: temurin
+      - uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.8"
       - uses: actions/cache@v3.3.2


### PR DESCRIPTION
## Problem Description

Describe the problem you are trying to solve.

Builds are slower than they need to be, often have issues downloading the CWMS Deps due to network issues.

## Solution

Cache the ivy dependencies so that there is less network traffic during the builds.

## how you tested the change

Will repeat action manually after it runs during this PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
