### PR TITLE
Additional support for multiple offices.

### DIFF
--- a/schema/cwms/update68to_70.sql
+++ b/schema/cwms/update68to_70.sql
@@ -1,0 +1,32 @@
+create or replace procedure set_office_column(new_office IN OUT cwms_20.av_office.office_code%type,
+                                              old_office cwms_20.av_office.office_code%type)
+is
+begin
+    if new_office is null and old_office is null
+    then
+        new_office := cwms_20.cwms_util.get_office_code(null);
+    elsif new_office is null and old_office is not null
+    then
+        new_office := old_office;
+    end if;
+end set_office_column;
+/
+set serveroutput on;
+declare
+    the_sql varchar2(4000);
+begin
+
+  for rec in (
+    select table_name from user_tab_columns where column_name in ('DB_OFFICE_CODE')
+    )
+  loop
+    execute immediate 'alter table ' || rec.table_name || ' modify db_office_code default null';
+    the_sql := 
+    'create or replace trigger ' || rec.table_name || '_get_office' ||
+    ' before insert or update on ' || rec.table_name ||
+    ' for each row begin set_office_column(:new.db_office_code,:old.db_office_code); end;';
+    dbms_output.put_line(the_sql);
+    execute immediate the_sql;
+  end loop;
+end;
+/


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
The CWMS implementation includes an office_code column on any directly referenced tables.
Previously a default office code was set. This worked fine for reading data, however when writing, regardless of which offices was set in user.properties, the default would always be used preventing any actual multi office use.

## Solution

Create an insert/update trigger on each table to verify that either a value is provided or pull it from the current session.

## how you tested the change

Tested on a database database inserting data to verify the correct office was set.


## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
