### PR TITLE
Devops/switch to tightvnc for auto gui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
           ant gui-test -D"no.docs=true"
           exit_val=$?
           vncserver -kill "$DISPLAY"
+          kill -INT $FF_ID
           wait $FF_ID # give ffmpeg a chance to figure it out and finish writing the file.
           exit $exit_val
       - name: Code Coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,9 @@ jobs:
           sudo apt update -y && sudo apt upgrade -y
           sudo apt install tightvncserver ffmpeg
           # Precompile the test code so the recording isn't as long.
+          mkdir ~/.vnc
+          echo 123456 | vncpasswd -f > ~/.vnc/passwd
+          chmod -v 0600 ~/.vnc/passwd
           ant compile-test-gui -D"no.docs=true"
           export DISPLAY=:99
           vncserver "$DISPLAY" -localhost -geometry 1920x1080 -depth 16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           chmod -v 0600 ~/.vnc/passwd
           ant compile-test-gui -D"no.docs=true"
           export DISPLAY=:99
-          vncserver "$DISPLAY" -localhost -geometry 1920x1080 -depth 16
+          vncserver "$DISPLAY" -localhost -geometry 1920x1080 -depth 24
           ffmpeg -nostdin -y -f x11grab -video_size 1920x1080 -i "$DISPLAY" build/test-gui.webm &
           ant gui-test -D"no.docs=true"
           exit_val=$?

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,10 +55,11 @@ jobs:
           export DISPLAY=:99
           vncserver "$DISPLAY" -localhost -geometry 1920x1080 -depth 24
           ffmpeg -nostdin -y -f x11grab -video_size 1920x1080 -i "$DISPLAY" build/test-gui.webm &
+          FF_ID=$!
           ant gui-test -D"no.docs=true"
           exit_val=$?
           vncserver -kill "$DISPLAY"
-          sleep 1 # give ffmpeg a chance to figure it out and finish writing the file.
+          wait $FF_ID # give ffmpeg a chance to figure it out and finish writing the file.
           exit $exit_val
       - name: Code Coverage
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           echo 123456 | vncpasswd -f > ~/.vnc/passwd
           chmod -v 0600 ~/.vnc/passwd
           ant compile-test-gui -D"no.docs=true"
-          export DISPLAY=:99
+          export DISPLAY=:99.0
           vncserver "$DISPLAY" -localhost -geometry 1920x1080 -depth 24
           ffmpeg -nostdin -y -f x11grab -video_size 1920x1080 -i "$DISPLAY" build/test-gui.webm &
           FF_ID=$!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,16 +46,16 @@ jobs:
         shell: bash {0}
         run: |
           sudo apt update -y && sudo apt upgrade -y
-          sudo apt install xvfb ffmpeg
+          sudo apt install tightvncserver ffmpeg
           # Precompile the test code so the recording isn't as long.
           ant compile-test-gui -D"no.docs=true"
-          export DISPLAY=:99.0
-          Xvfb $DISPLAY -screen 0 1920x1080x24 &
+          export DISPLAY=:99
+          vncserver "$DISPLAY" -localhost -geometry 1920x1080 -depth 16
           ffmpeg -nostdin -y -f x11grab -video_size 1920x1080 -i "$DISPLAY" build/test-gui.webm &
           ant gui-test -D"no.docs=true"
           exit_val=$?
-          pkill Xvfb
-          sleep 1
+          vncserver -kill "$DISPLAY"
+          sleep 1 # give ffmpeg a chance to figure it out and finish writing the file.
           exit $exit_val
       - name: Code Coverage
         run: |


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #419 . ... maybe.

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Instead of Xfvb, use tightvnc. May still need to add a window manager.

## how you tested the change

Test failure is only happening during github action automation. Will test by re-running the action a few times.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
