### PR TITLE
Gui Apps in CWMS will now use auth source regardless of environment.

### DIFF
--- a/src/main/java/decodes/cwms/CwmsSqlDatabaseIO.java
+++ b/src/main/java/decodes/cwms/CwmsSqlDatabaseIO.java
@@ -133,8 +133,23 @@ public class CwmsSqlDatabaseIO
 
 		String password = null;
 
+		String afn = DecodesSettings.instance().DbAuthFile;
+		Properties credentials = null;
+		try
+		{
+			credentials = AuthSourceService.getFromString(afn)
+											.getCredentials();
+			_dbUser = credentials.getProperty("username");
+			password = credentials.getProperty("password");
+		}
+		catch(AuthException ex)
+		{
+			Logger.instance().warning("Cannot read auth source. If this is from a GUI app please update DbAuthFile in " +
+					" user.properties, decodes.properties, or your .profile to 'DbAuthFile=gui-auth-source:<Prompt>'" +
+					" where <Prompt> should be what you want to see to explain what credentials to use.");
+		}
 		CwmsGuiLogin cgl = CwmsGuiLogin.instance();
-		if (DecodesInterface.isGUI())
+		if (credentials == null && DecodesInterface.isGUI())
 		{
 			try 
 			{
@@ -160,25 +175,11 @@ public class CwmsSqlDatabaseIO
 				throw new DatabaseException(msg);
 			}
 		}
-		else // Non-GUI can try auth file mechanism.
+		if (_dbUser == null)
 		{
-			Logger.instance().info("This is not a GUI app.");
-			
-			// Retrieve username and password for database
-			String authFileName = DecodesSettings.instance().DbAuthFile;
-			try
-			{
-				AuthSource as = AuthSourceService.getFromString(authFileName);
-				Properties props = as.getCredentials();
-				_dbUser = props.getProperty("username");
-				password = props.getProperty("password");
-			}
-			catch(AuthException ex)
-			{
-				String msg = "Cannot process credential information provided";				
-				throw new DatabaseConnectException(msg,ex);
-			}
+			throw new DatabaseException("Unable to retrieve any credentials.");
 		}
+
 		if( conInfo == null)
 		{
 			conInfo = new CwmsConnectionInfo();

--- a/src/main/java/decodes/cwms/CwmsSqlDatabaseIO.java
+++ b/src/main/java/decodes/cwms/CwmsSqlDatabaseIO.java
@@ -146,7 +146,7 @@ public class CwmsSqlDatabaseIO
 		{
 			Logger.instance().warning("Cannot read auth source. If this is from a GUI app please update DbAuthFile in " +
 					" user.properties, decodes.properties, or your .profile to 'DbAuthFile=gui-auth-source:<Prompt>'" +
-					" where <Prompt> should be what you want to see to explain what credentials to use.");
+					" where <Prompt> is the title to the login dialog.");
 		}
 		CwmsGuiLogin cgl = CwmsGuiLogin.instance();
 		if (credentials == null && DecodesInterface.isGUI())

--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
@@ -836,7 +836,11 @@ public class CwmsTimeSeriesDb
 		}
 		else if(credentials == null)
 		{
-			throw new BadConnectException("Cannot connect to CWMS without credentials.");
+			throw new BadConnectException(
+				"Cannot connect to CWMS without credentials." +
+				" If you are seeing this from a GUI app please change" +
+				" your properties file 'DbAuthFile' entry to:" +
+				" DbAuthFile=gui-auth-source:Login Prompt");
 		}
 		else
 		{	// use the provided credentials


### PR DESCRIPTION
## Problem Description

Primarily this is to avoid needing users to enter credentials on a shared system. However it also helps reduce certain edge cases.
e.g. TsdbAppTemplate shouldn't have a clue that "CWMS" even exists.

## Solution

Allow successful retreieval of "AuthSource" credentials to be used for any type of application.
NOTE: current solution requires user to login twice. This is due to LoginDialog not caching credentials and the system needs to login twice. the long term solution is to not have a "DECODES" and "TimeSeries" database but instead "A database."
In the meantime we have have to cache credentials. I will investigate later. 

NOTE: Do not merge during 7.0.12 cycle, this is primarily for commentary and CWMS usage.

## how you tested the change

Manually in VM/Linux.


## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
