### PR TITLE
Fixed column sorting issues for copy and delete functions

### DIFF
--- a/src/main/java/decodes/tsdb/compedit/AlgorithmsListPanel.java
+++ b/src/main/java/decodes/tsdb/compedit/AlgorithmsListPanel.java
@@ -176,7 +176,10 @@ public class AlgorithmsListPanel extends ListPanel
 			CAPEdit.instance().getFrame().showError(cpyErr1);
 			return;
 		}
-		DbCompAlgorithm dca = algoListTableModel.getRowAlgorithm(r);
+		//Get the correct row from the table model
+		int modelrow = algoListTable.convertRowIndexToModel(r);
+		AlgoListTableModel tablemodel = (AlgoListTableModel)algoListTable.getModel();
+		DbCompAlgorithm dca = (DbCompAlgorithm)tablemodel.getRowAlgorithm(modelrow);
 
 	    String newName = JOptionPane.showInputDialog(cpyInput);
 		if (newName == null)
@@ -201,7 +204,11 @@ public class AlgorithmsListPanel extends ListPanel
 				deleteErr1);
 			return;
 		}
-		DbCompAlgorithm dca = algoListTableModel.getRowAlgorithm(r);
+		//Get the correct row from the table model
+		int modelrow = algoListTable.convertRowIndexToModel(r);
+		AlgoListTableModel tablemodel = (AlgoListTableModel)algoListTable.getModel();
+		DbCompAlgorithm dca = (DbCompAlgorithm)tablemodel.getRowAlgorithm(modelrow);
+
 		AlgorithmDAI algorithmDao = CAPEdit.instance().theDb.makeAlgorithmDAO();
 		try
 		{

--- a/src/main/java/decodes/tsdb/compedit/ComputationsListPanel.java
+++ b/src/main/java/decodes/tsdb/compedit/ComputationsListPanel.java
@@ -231,7 +231,8 @@ public class ComputationsListPanel extends ListPanel
 				compLabels.getString("ComputationsFilterPanel.CopyError1"));
 			return;
 		}
-		ComputationInList dc = (ComputationInList)compListTableModel.getRowObject(r);
+		int rowModel = compListTable.convertRowIndexToModel(r);
+		ComputationInList dc = (ComputationInList)compListTableModel.getRowObject(rowModel);
 
 	    String newName = JOptionPane.showInputDialog(
 	    	compLabels.getString("ComputationsFilterPanel.NewInput"));
@@ -272,8 +273,8 @@ public class ComputationsListPanel extends ListPanel
 				compLabels.getString("ComputationsFilterPanel.DeleteError1"));
 			return;
 		}
-
-		ComputationInList dc = (ComputationInList)compListTableModel.getRowObject(r);
+		int rowModel = compListTable.convertRowIndexToModel(r);
+		ComputationInList dc = (ComputationInList)compListTableModel.getRowObject(rowModel);
 
 		int ok = JOptionPane.showConfirmDialog(this,
 			LoadResourceBundle.sprintf(


### PR DESCRIPTION
## Problem Description
Sorting algorithms or computations in the computation editor results in erroneous results when trying to copy or delete.

In the computation editor.  Sort the algorithms or computations by any column.  Select an algorithm or computation to be copied or deleted.  The selected item is not copied or deleted.  Since the table was sorted the wrong row gets selected.

## Solution
Used the table model to get the correct row that was selected.

## how you tested the change
Copy or delete an algorithm or computation in the computation editor.  Verified to correct algorithm or computation was copied or deleted.

## Where the following done:

- [x] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
