### PR TITLE
edit-rst-doc-files-for-cleaner-build

### DIFF
--- a/docs/source/cp-userguide.rst
+++ b/docs/source/cp-userguide.rst
@@ -6599,7 +6599,7 @@ screenings in English units to a file called “screenings.bak”::
 
    screeningExport –A –E >screenings.bak
 
-Note that the CRITERIA records are identical to DATCHK criteria files::
+Note that the CRITERIA records are identical to DATCHK criteria files
 
 SCREENING *unique-16-char-ID*
 

--- a/docs/source/dev-docs.rst
+++ b/docs/source/dev-docs.rst
@@ -295,7 +295,7 @@ Integration tests inherit from :code:AppTestBase. This simplifies access to reso
 |protected Configuration configuration;      |:code:`Configuration` that was  |
 |                                            |create for this run. Contains   |
 |                                            |reference to user.properties and|
-|                                            | other specific information.    |
+|                                            |other specific information.     |
 |                                            |This is provided by default as  |
 |                                            |almost all interactions will    |
 |                                            |require access to the           |
@@ -309,7 +309,7 @@ At the Class and method level the following annotations are available.
 |Annotation                                  |Description                     |
 +============================================+================================+
 |DecodesConfigurationRequired                |List of database import files   |
-|                                            |needed for tests to succeed.     |
+|                                            |needed for tests to succeed.    |
 |                                            |Can be set at the Class level,  |
 |                                            |Method level, or both in which  |
 |                                            |case the sets will be merged    |

--- a/docs/source/lrgs-userguide.rst
+++ b/docs/source/lrgs-userguide.rst
@@ -121,7 +121,7 @@ internet. This uses a TCP socket protocol called DDS (DCP Data Service).
 DDS allows users to specify data of interest by DCP address, channel, or
 time range. Users can retrieve historical data or a real-time stream.
 
-.. image:: ./media/install-guide/Pictures/goes-dsc-overview.png
+.. image:: ./media/lrgs-userguide/Pictures/goes-dsc-overview.png
    :alt: Image showing GOES DCS Overview
    :width: 6in
    :height: 3.2in
@@ -324,7 +324,7 @@ While the DOMSAT system is no longer supported, some of the mechanisms present f
 such as the "DOMSAT Header" still permeate the software. You may seen references to such a 
 header or various elements. These generally apply generically to various connections such as DRGS
 and HRIT in some way. Consider this while reading the documentation as we are still cleaning up the text
- and variable naming. 
+and variable naming. 
 
 LRGS Software Overview
 ======================
@@ -980,7 +980,7 @@ beginning of the line.
 |              |              |              | specify 3    |        |
 |              |              |              | DRGS         |        |
 |              |              |              | connections, |        |
-|              |              |              | HRIT, and  |        |
+|              |              |              | HRIT, and    |        |
 |              |              |              | 4 DDS        |        |
 |              |              |              | Receive      |        |
 |              |              |              | Connections, |        |
@@ -1506,31 +1506,37 @@ is shown below:
 .. code-block:: xml
 
 <?xml version="1.0"?>
-<drgsconf>
-    <validate enable="true"
-        pdturl="http://dcs.noaa.gov/ftp_daily/pdts_compressed.txt"
-        cdturl="http://dcs.noaa.gov/ftp_daily/chans_by_baud.txt"/>
-    <connection number="0" host="drgs-e.mydomain.gov">
-        <name>EAST-DRGS</name>
-        <enabled>true</enabled>
-        <msgport>17010</msgport>
-        <evtport>17011</evtport>
-        <evtenabled>false</evtenabled>
-        <startpattern>534D0D0A</startpattern>
-        <cfgfile>$LRGSHOME/EAST-DRGS.cfg</cfgfile>
-        <sourceCode>DE</sourceCode>
-    </connection>
-    <connection number="1" host="drgs-w.mydomain.gov">
-        <name>WEST-DRGS</name>
-        <enabled>false</enabled>
-        <msgport>17010</msgport>
-        <evtport>17011</evtport>
-        <evtenabled>false</evtenabled>
-        <startpattern>534D0D0A</startpattern>
-        <cfgfile>$LRGSHOME/WEST-DRGS.cfg</cfgfile>
-        <sourceCode>DW</sourceCode>
-    </connection>
-</drgsconf>
+    <drgsconf>
+        <validate enable="true"
+            pdturl="http://dcs.noaa.gov/ftp_daily/pdts_compressed.txt"
+            cdturl="http://dcs.noaa.gov/ftp_daily/chans_by_baud.txt"/>
+        <connection number="0" host="drgs-e.mydomain.gov">
+            <name>EAST-DRGS</name>
+            <enabled>true</enabled>
+            <msgport>17010</msgport>
+            <evtport>17011</evtport>
+            <evtenabled>false</evtenabled>
+            <startpattern>534D0D0A</startpattern>
+            <cfgfile>$LRGSHOME/EAST-DRGS.cfg</cfgfile>
+            <sourceCode>DE</sourceCode>
+
+        </connection>    
+
+        <connection number="1" host="drgs-w.mydomain.gov">
+            <name>WEST-DRGS</name>
+            <enabled>false</enabled>
+            <msgport>17010</msgport>
+            <evtport>17011</evtport>
+            <evtenabled>false</evtenabled>
+            <startpattern>534D0D0A</startpattern>
+            <cfgfile>$LRGSHOME/WEST-DRGS.cfg</cfgfile>
+            <sourceCode>DW</sourceCode>
+
+        </connection>
+
+    </drgsconf>
+
+
 
 Figure 5‑10: DRGS Configuration File Example.
 
@@ -2185,12 +2191,12 @@ These values can also be set on the "Misc" tab of of the RtStat configuration di
 
 The following paths are provided:
 
-+-------|--------------------------------------------------------------+
++-------+--------------------------------------------------------------+
 | path  | purpose                                                      |
 +-------+--------------------------------------------------------------+
 |/health|Returns "200 OK" if the Lrgs thinks it's in a usable state.   |
 |/status|Returns the default Lrgs Status page, same as lrgsstatus.html.|
-+-------+--------------------------------------------------------------|
++-------+--------------------------------------------------------------+
 
 Future work will include authentication, authorization, and other DDS operations
 once that protocol is designed.

--- a/docs/source/tsdb.rst
+++ b/docs/source/tsdb.rst
@@ -740,14 +740,14 @@ Example: suppose you wanted to transfer data from a group of time series
 on your CWMS database into an OpenTSDB database. Suppose the group is
 called “Stages”.
 
-1. On the CWMS Database, run::
+1. On the CWMS Database, run:
 
    outputts -S all -F tsimport group:Stage > somefile
 
 2. Transfer “somefile” from the CWMS machine to the OpenTSDB
    installation.
 
-3. On the OpenTSDB installation run::
+3. On the OpenTSDB installation run:
 
 
    importts somefile


### PR DESCRIPTION
minor edits to rst files to fix formatting for spaces, tables, and prevent lots of warning when run make html

