### PR TITLE
Fixed column sorting issues for Copy and Delete functions for Schedule Entry

### DIFF
--- a/src/main/java/decodes/dbeditor/ScheduleListPanel.java
+++ b/src/main/java/decodes/dbeditor/ScheduleListPanel.java
@@ -115,7 +115,9 @@ public class ScheduleListPanel extends JPanel implements ListOpsController
 		int idx = scheduleEntryTable.getSelectedRow();
 		if (idx == -1)
 			return null;
-		return tableModel.getObjectAt(idx);
+		//Get the correct row from the table model
+		int modelrow = scheduleEntryTable.convertRowIndexToModel(idx);
+		return tableModel.getObjectAt(modelrow);
 	}
 
 	/** @return type of entity that this panel edits. */


### PR DESCRIPTION
## Problem Description
Column sorting gives erroneous results when trying to copy or delete in schedule entry.

In Schedule Entry, sorting columns results in the wrong row being selected when trying to copy or delete a row.

## Solution
Modified the code to use the table model when selecting a row.

## how you tested the change
Open Decodes Database Editor, select the Schedule Entry tab.  Sort columns and then select a row to copy or delete.  Verify the correct row is selected for the copy or delete.

## Where the following done:

- [x] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
