### PR TITLE
Update read-the-docs yaml to force install of requirements.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,8 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "3.8"
+  install:
+    - requirements: docs/requirements.txt
 
 sphinx:
   fail_on_warning: false


### PR DESCRIPTION
## Problem Description

Realized Read the docs was throwing an error while building our online documentation.

## Solution

Describe your solution.

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
