### PR TITLE
Initial stab at all databases deriving from Database.

### DIFF
--- a/src/main/java/decodes/db/Database.java
+++ b/src/main/java/decodes/db/Database.java
@@ -276,4 +276,10 @@ public class Database extends DatabaseObject
 		}
 		return presentationGroupList;
 	}
+
+
+	public <DaoType> DaoType getDao(Class<? extends DaoType> daoClazz)
+	{
+		return null;
+	}
 }

--- a/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -465,6 +465,7 @@ import decodes.cwms.validation.dao.ScreeningDAI;
 import decodes.db.Constants;
 import decodes.db.DataType;
 import decodes.db.Database;
+import decodes.db.DatabaseIO;
 import decodes.db.EngineeringUnit;
 import decodes.db.Site;
 import decodes.db.SiteName;
@@ -482,7 +483,7 @@ Sub classes must override all the abstract methods and provide
 a mechanism to persistently store time series and computational meta
 data.
 */
-public abstract class TimeSeriesDb
+public abstract class TimeSeriesDb extends Database
     implements HasProperties, DatabaseConnectionOwner
 {
     public static String module = "tsdb";
@@ -578,8 +579,19 @@ public abstract class TimeSeriesDb
      */
     public TimeSeriesDb()
     {
-//        DecodesSettings settings = DecodesSettings.instance();
+        super(true);
 
+        DecodesSettings settings = DecodesSettings.instance();
+        try
+        {
+            DatabaseIO dbio = DatabaseIO.makeDatabaseIO(settings.editDatabaseTypeCode, settings.editDatabaseLocation);
+            this.setDbIo(dbio);
+            super.read();
+        }
+        catch (Exception ex)
+        {
+            throw new RuntimeException("Unable to create decodes database io", ex);
+        }
         writeModelRunId = Constants.undefinedIntKey;
         testMode = false;
         conn = null;


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
We technically have two database implementations within OpenDCS. One for "DECODES only" and another for Timeseries databases. It would greatly simplify the code to have a single implementation who's instance can be passed around when needed. (Like the constructors of the GUI frames).

## Solution

Taking notes from  https://github.com/opendcs/opendcs/wiki/Project-%E2%80%90-Merging-the-DECODES-Database-and-TimeseriesDb-classes this is an initial start on merging the systems into a single database implementation that has "requisite capabilities"

This starts that process. I'd like to get a few items flushed out and working before actually merging in like the getDao function
and also perhaps an improvement to how makeDatabaseIO is called.


The general goal is to turn `class Database` into `interface Database` and everything derives from that, such that the XML implementation could just be XmlDatabase.

## how you tested the change

At this point just running the tests we have to see if anything breaks.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
