### PR TITLE
Give error for non-time-series editDatabaseType

### DIFF
--- a/src/main/java/decodes/tsdb/TsdbAppTemplate.java
+++ b/src/main/java/decodes/tsdb/TsdbAppTemplate.java
@@ -261,7 +261,8 @@ public abstract class TsdbAppTemplate
 		throws ClassNotFoundException,
 		InstantiationException, IllegalAccessException
 	{
-		if (theDb != null) {
+		if (theDb != null)
+		{
 			return;
 		}
 


### PR DESCRIPTION
Avoids Null Pointer Exception when running alarmedit.bat  (AlarmEditor.java) with a xml database.  This will help other programs/batch-files give better error messages.
