### PR TITLE
Remove default text from showable password field. Additional tests.

### DIFF
--- a/src/main/java/org/opendcs/gui/PasswordWithShow.java
+++ b/src/main/java/org/opendcs/gui/PasswordWithShow.java
@@ -33,7 +33,7 @@ public class PasswordWithShow extends JPanel
     {
 
         this.setLayout(new BoxLayout(this,BoxLayout.LINE_AXIS));
-        passwordField = new JPasswordField("showablePassword",width);
+        passwordField = new JPasswordField(width);
         defaultEchoChar = passwordField.getEchoChar();
         showPasswordButton = new JToggleButton(resources.getString("Password.show"));
         showPasswordButton.setName("showToggle");

--- a/src/test-gui/java/decodes/launcher/LauncherFrameTest.java
+++ b/src/test-gui/java/decodes/launcher/LauncherFrameTest.java
@@ -42,7 +42,7 @@ public class LauncherFrameTest extends GuiTest
         lf = GuiActionRunner.execute(() -> new LauncherFrame(new String[0], Profile.getDefaultProfile()));
         lf.setExitOnClose(false);
         lf.checkForProfiles();
-        frame = new FrameFixture(lf);
+        frame = new FrameFixture(robot(), lf);
         frame.show();
         pause(new Condition("Gui visible") {
             @Override
@@ -53,7 +53,7 @@ public class LauncherFrameTest extends GuiTest
     }
 
     @AfterEach
-    public void tearDown()
+    public void tearDownEach()
     {
         frame.cleanUp();
     }

--- a/src/test-gui/java/decodes/launcher/ProfileManagerFrameTest.java
+++ b/src/test-gui/java/decodes/launcher/ProfileManagerFrameTest.java
@@ -53,7 +53,7 @@ public class ProfileManagerFrameTest extends GuiTest
         properties.set("DCSTOOL_USERDIR",resourceDir+"/decodes/launcher/profiles");
         pmf = GuiActionRunner.execute(() -> new ProfileManagerFrame());
         pmf.setExitOnClose(false);
-        frame = new FrameFixture(pmf);
+        frame = new FrameFixture(robot(), pmf);
         frame.show();
         pause(new Condition("Gui visible") {
             @Override
@@ -111,7 +111,7 @@ public class ProfileManagerFrameTest extends GuiTest
     }
 
     @AfterEach
-    public void tearDown() throws Exception
+    public void tearDownEach() throws Exception
     {
         frame.cleanUp();
         properties.teardown();

--- a/src/test-gui/java/fixtures/GuiTest.java
+++ b/src/test-gui/java/fixtures/GuiTest.java
@@ -1,14 +1,25 @@
 package fixtures;
 
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
-public class GuiTest
+public class GuiTest extends AssertJSwingJUnitTestCase
 {
-
     @BeforeAll
     public static void setup_framework()
     {
         FailOnThreadViolationRepaintManager.install();
+    }
+
+    @BeforeEach
+    public void setup_robot()
+    {
+        setUpRobot();
+    }
+    @Override
+    protected void onSetUp()
+    {
     }
 }

--- a/src/test-gui/java/org/opendcs/authentication/GuiAuthSourceTest.java
+++ b/src/test-gui/java/org/opendcs/authentication/GuiAuthSourceTest.java
@@ -38,11 +38,11 @@ public class GuiAuthSourceTest extends GuiTest
     public void setup() throws Exception
     {
         loginDialog = GuiActionRunner.execute(() -> (LoginDialog)AuthSourceService.getFromString("gui-auth-source:Login"));
-        dialog = new DialogFixture(loginDialog);
+        dialog = new DialogFixture(robot(), loginDialog);
     }
 
     @AfterEach
-    public void tearDown()
+    public void tearDownEach()
     {
         dialog.cleanUp();
     }

--- a/src/test-gui/java/org/opendcs/gui/PasswordWithShowTest.java
+++ b/src/test-gui/java/org/opendcs/gui/PasswordWithShowTest.java
@@ -1,0 +1,69 @@
+package org.opendcs.gui;
+
+import static org.assertj.swing.edt.GuiActionRunner.execute;
+import static org.assertj.swing.timing.Pause.pause;
+import static org.assertj.swing.timing.Timeout.timeout;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.FlowLayout;
+
+import javax.swing.JFrame;
+
+import org.assertj.swing.edt.GuiActionRunner;
+import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.fixture.JPanelFixture;
+import org.assertj.swing.fixture.JTextComponentFixture;
+import org.assertj.swing.timing.Condition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import fixtures.GuiTest;
+
+public class PasswordWithShowTest extends GuiTest
+{
+
+    private HoldingFrame frame;
+    private FrameFixture fixture;
+
+    @BeforeEach
+    public void setup()
+    {
+        frame  = GuiActionRunner.execute(() -> new HoldingFrame());
+        frame.setVisible(true);
+        fixture = new FrameFixture(robot(), frame);
+        assertTrue(frame.isValid(), "Our Password Panel isn't valid.");
+        pause(new Condition("Gui visible") {
+            @Override
+            public boolean test() {
+                return execute(frame::isVisible);
+            }
+        },timeout(500));
+    }
+
+    @AfterEach
+    public void teardown()
+    {
+        frame.setVisible(false);
+        fixture.cleanUp();
+    }
+
+    @Test
+    public void test_password_field() throws Exception
+    {
+        JTextComponentFixture pwFieldText = fixture.textBox("pw.showablePassword");
+        assertTrue( pwFieldText.text() == null || pwFieldText.text().isEmpty());
+    }
+
+    private static class HoldingFrame extends JFrame
+    {
+        public HoldingFrame()
+        {
+            super("Password Test");
+            setLayout(new FlowLayout());
+            PasswordWithShow pwField = new PasswordWithShow(GuiConstants.DEFAULT_PASSWORD_WITH);
+            pwField.setName("pw");
+            add(pwField);
+        }
+    }
+}


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #514. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Remove default text from JTextField Contructor

## how you tested the change

Added a GUI test to verify value defaults blank.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [x] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
