### PR TITLE
Bugfix/526 timeseries list building speed

### DIFF
--- a/src/main/java/decodes/tsdb/comprungui/CompRunGuiFrame.java
+++ b/src/main/java/decodes/tsdb/comprungui/CompRunGuiFrame.java
@@ -820,7 +820,7 @@ public class CompRunGuiFrame extends TopFrame
 					Vector<DbComputation> theComps = this.get();
 					if (theComps != null)
 					{
-						run_selected_comps(theComps, originalLogger, traceLogger, inputs);
+						runSelectedComps(theComps, originalLogger, traceLogger, inputs);
 					}
 					else
 					{
@@ -1014,7 +1014,7 @@ public class CompRunGuiFrame extends TopFrame
 	}
 
 
-	private void run_selected_comps(Collection<DbComputation> compVector, Logger originalLogger, TraceLogger traceLogger, Vector<CTimeSeries> inputs)
+	private void runSelectedComps(Collection<DbComputation> compVector, Logger originalLogger, TraceLogger traceLogger, Vector<CTimeSeries> inputs)
 	{
 		final Vector<CTimeSeries> both = new Vector<CTimeSeries>();
 		// Flush the text area inside trace dialog


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Partial Fix of #526. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Allow the system to report the current state so user at least know where a long running time series expansion is in the process.
To do this I've rearranged the the runComp handler into 3 functions.
- check if request valid
- build group comp list (if required)
- run computations

The building of computations for groups is now in a SwingerWorker that will call yet another SwingWorker when the time comes to actually run the selected computations.

Addtionally, since the reason for this issue included a group that has 14000+ timeseries assosciated to it, I've altered the timeseries transformation slightly to at least report the current progress.

There will need to be slightly more major changes to that particular loop to better increase performance.

## how you tested the change

Manually:
- Running actual computations
- Cancelling run from the start (e.g. not selecting any time series)
- Stopping in middle of run.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
