### PR TITLE
Refactor/reduce build boilerplate

### DIFF
--- a/build-macros.xml
+++ b/build-macros.xml
@@ -28,7 +28,6 @@
                 <sync todir="@{outputDir}/resources">
                     <fileset dir="@{srcDir}/resources"/>
                 </sync>
-
                 <javac debug="true" destdir="@{outputDir}/classes"
                     target="@{javaCompileTarget}" source="@{javaSrcTarget}"
                     includeantruntime="true"
@@ -55,12 +54,12 @@
         <mkdir dir="${junit.html.output.dir}"/>    
         <mkdir dir="${build.dir}/test/@{outputName}/results"/>
         <mkdir dir="${build.dir}/test/@{outputName}/tmp"/>
-        <jacoco:agent property="coverage.agent.param.test" destfile="${coverage.dir}/jacoco.@{outputName}.exec"/>
+        <jacoco:agent property="coverage.agent.param.@{outputName}" destfile="${coverage.dir}/jacoco.@{outputName}.exec"/>
         <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="@{outputName}.failed">
             <classpaths/>
             <testclasses outputdir="${build.dir}/test/@{outputName}/results">
                 <fork>
-                    <jvmarg value="${coverage.agent.param.test}"/>
+                    <jvmarg value="${coverage.agent.param.@{outputName}}"/>
                     <jvmarg value="-Dbuild.dir=${build.dir}"/>
                     <jvmarg value="-Djava.io.tmpdir=${build.dir}/test/@{outputName}/tmp"/>
                     <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>

--- a/build-macros.xml
+++ b/build-macros.xml
@@ -1,5 +1,6 @@
 <project name="macros" xmlns:ivy="antlib:org.apache.ivy.ant"
-    xmlns:if="ant:if" xmlns:unless="ant:unless">
+    xmlns:if="ant:if" xmlns:unless="ant:unless"
+    xmlns:jacoco="antlib:org.jacoco.ant">
 
 <macrodef name="compile">
     <attribute name="outputDir"/>    
@@ -42,8 +43,55 @@
         </if>
         <property name="@{outputName}.classes" value="@{outputDir}/classes"/>
         <property name="@{outputName}.resources" value="@{outputDir}/resources"/>
-        <echo>"@{outputName}.classes=${@{outputName}.classes}"</echo>
     </sequential>
 </macrodef>
-
+<macrodef name="test">
+    <attribute name="classesDir"/>
+    <attribute name="outputName"/>
+    <element name="classpaths"/>
+    <element name="testfiles" optional="true"/>
+    <element name="jvmargs" optional="true"/>
+    <sequential>
+        <mkdir dir="${junit.html.output.dir}"/>    
+        <mkdir dir="${build.dir}/test/@{outputName}/results"/>
+        <mkdir dir="${build.dir}/test/@{outputName}/tmp"/>
+        <jacoco:agent property="coverage.agent.param.test" destfile="${coverage.dir}/jacoco.@{outputName}.exec"/>
+        <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="@{outputName}.failed">
+            <classpaths/>
+            <testclasses outputdir="${build.dir}/test/@{outputName}/results">
+                <fork>
+                    <jvmarg value="${coverage.agent.param.test}"/>
+                    <jvmarg value="-Dbuild.dir=${build.dir}"/>
+                    <jvmarg value="-Djava.io.tmpdir=${build.dir}/test/@{outputName}/tmp"/>
+                    <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
+                    <jvmargs/>
+                </fork>
+                <fileset dir="@{classesDir}">
+                    <testfiles/>
+                </fileset>
+                <listener type="legacy-brief" sendSysOut="true" useLegacyReportingName="false"/>
+                <listener type="legacy-xml" sendSysErr="true" sendSysOut="true" useLegacyReportingName="false"/>
+            </testclasses>
+        </junitlauncher>
+        <mkdir dir="${junit.html.output.dir}/@{outputName}"/>
+        <junitreport todir="${junit.html.output.dir}/">
+            <fileset dir="${build.dir}/test/@{outputName}/results">
+                <include name="TEST-*.xml"/>
+                <exclude name="TEST-fixture*"/>
+                <exclude name="TEST-*$?.xml"/>
+            </fileset>
+            <report format="noframes" todir="${junit.html.output.dir}/@{outputName}"/>
+        </junitreport>
+        <if>
+            <isset property="@{outputName}.failed"/>
+            <then>
+                <delete file="${status.dir}/@{outputName}.run" quiet="true"/>
+                <fail message="Tests have failures."/>
+            </then>
+            <else>
+                <touch file="${status.dir}/@{outputName}.run"/>
+            </else>
+        </if>
+    </sequential>
+</macrodef>
 </project>

--- a/build-macros.xml
+++ b/build-macros.xml
@@ -1,0 +1,49 @@
+<project name="macros" xmlns:ivy="antlib:org.apache.ivy.ant"
+    xmlns:if="ant:if" xmlns:unless="ant:unless">
+
+<macrodef name="compile">
+    <attribute name="outputDir"/>    
+    <attribute name="srcDir"/>
+    <attribute name="outputName"/>
+    <attribute name="javaSrcTarget" default="1.8"/>
+    <attribute name="javaCompileTarget" default="1.8"/>
+    <element name="classpaths"/>
+
+    <sequential>
+        <uptodate property="@{outputName}.current" targetfile="${status.dir}/src.@{outputName}.build.date">
+            <srcfiles dir="@{srcDir}" includes="**/*"/>
+        </uptodate>
+    <!-- create build date -->
+        <mkdir dir="@{outputDir}/classes"/>
+        <mkdir dir="@{outputDir}/resources"/>
+        <tstamp>
+            <format property="buildDate" pattern="MMM dd, yyyy"/>
+        </tstamp>
+        <if>
+            <not>
+                <isset property="@{outputName.current}"/>
+            </not>
+            <then>
+                <sync todir="@{outputDir}/resources">
+                    <fileset dir="@{srcDir}/resources"/>
+                </sync>
+
+                <javac debug="true" destdir="@{outputDir}/classes"
+                    target="@{javaCompileTarget}" source="@{javaSrcTarget}"
+                    includeantruntime="true"
+                    encoding="UTF-8" includes="**">
+                    <src path="@{srcDir}/java"/>
+                    <compilerarg value="-parameters"/>
+                    <classpath>
+                        <classpaths/>
+                    </classpath>
+                </javac>
+            </then>
+        </if>
+        <property name="@{outputName}.classes" value="@{outputDir}/classes"/>
+        <property name="@{outputName}.resources" value="@{outputDir}/resources"/>
+        <echo>"@{outputName}.classes=${@{outputName}.classes}"</echo>
+    </sequential>
+</macrodef>
+
+</project>

--- a/build-macros.xml
+++ b/build-macros.xml
@@ -2,7 +2,7 @@
     xmlns:if="ant:if" xmlns:unless="ant:unless"
     xmlns:jacoco="antlib:org.jacoco.ant">
 
-<macrodef name="compile">
+<macrodef name="compile-java">
     <attribute name="outputDir"/>    
     <attribute name="srcDir"/>
     <attribute name="outputName"/>
@@ -14,6 +14,8 @@
     <sequential>
         <uptodate property="@{outputName}.compile.current" targetfile="${status.dir}/src.@{outputName}.build.date">
             <srcresources>
+                <!-- Always rebuild if baseline project files have changed -->
+                <fileset dir="${project.dir}" includes="ivy.xml,ivy-settings.xml,build.xml,build-macros.xml,common.xml"/>
                 <fileset dir="@{srcDir}" includes="**/*"/>
                 <fileset-for-update-to-date/>
             </srcresources>
@@ -62,6 +64,8 @@
         <mkdir dir="${build.dir}/test/@{outputName}/tmp"/>
         <uptodate property="@{outputName}.test.current" targetFile="${status.dir}/test.@{outputName}.run.date">
             <srcresources>
+                <!-- Always rebuild if baseline project files have changed -->
+                <fileset dir="${project.dir}" includes="ivy.xml,ivy-settings.xml,build.xml,build-macros.xml,common.xml"/>
                 <fileset dir="@{classesDir}" includes="**/*"/>
                 <fileset-for-update-to-date/>
             </srcresources>

--- a/build-macros.xml
+++ b/build-macros.xml
@@ -9,10 +9,14 @@
     <attribute name="javaSrcTarget" default="1.8"/>
     <attribute name="javaCompileTarget" default="1.8"/>
     <element name="classpaths"/>
+    <element name="fileset-for-update-to-date" optional="true"/>
 
     <sequential>
-        <uptodate property="@{outputName}.current" targetfile="${status.dir}/src.@{outputName}.build.date">
-            <srcfiles dir="@{srcDir}" includes="**/*"/>
+        <uptodate property="@{outputName}.compile.current" targetfile="${status.dir}/src.@{outputName}.build.date">
+            <srcresources>
+                <fileset dir="@{srcDir}" includes="**/*"/>
+                <fileset-for-update-to-date/>
+            </srcresources>
         </uptodate>
     <!-- create build date -->
         <mkdir dir="@{outputDir}/classes"/>
@@ -22,7 +26,7 @@
         </tstamp>
         <if>
             <not>
-                <isset property="@{outputName.current}"/>
+                <isset property="@{outputName}.compile.current}"/>
             </not>
             <then>
                 <sync todir="@{outputDir}/resources">
@@ -38,6 +42,7 @@
                         <classpaths/>
                     </classpath>
                 </javac>
+                <touch file="${status.dir}/src.@{outputName}.build.date"/>
             </then>
         </if>
         <property name="@{outputName}.classes" value="@{outputDir}/classes"/>
@@ -50,46 +55,60 @@
     <element name="classpaths"/>
     <element name="testfiles" optional="true"/>
     <element name="jvmargs" optional="true"/>
+    <element name="fileset-for-update-to-date" optional="true"/>
     <sequential>
         <mkdir dir="${junit.html.output.dir}"/>    
         <mkdir dir="${build.dir}/test/@{outputName}/results"/>
         <mkdir dir="${build.dir}/test/@{outputName}/tmp"/>
-        <jacoco:agent property="coverage.agent.param.@{outputName}" destfile="${coverage.dir}/jacoco.@{outputName}.exec"/>
-        <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="@{outputName}.failed">
-            <classpaths/>
-            <testclasses outputdir="${build.dir}/test/@{outputName}/results">
-                <fork>
-                    <jvmarg value="${coverage.agent.param.@{outputName}}"/>
-                    <jvmarg value="-Dbuild.dir=${build.dir}"/>
-                    <jvmarg value="-Djava.io.tmpdir=${build.dir}/test/@{outputName}/tmp"/>
-                    <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
-                    <jvmargs/>
-                </fork>
-                <fileset dir="@{classesDir}">
-                    <testfiles/>
-                </fileset>
-                <listener type="legacy-brief" sendSysOut="true" useLegacyReportingName="false"/>
-                <listener type="legacy-xml" sendSysErr="true" sendSysOut="true" useLegacyReportingName="false"/>
-            </testclasses>
-        </junitlauncher>
-        <mkdir dir="${junit.html.output.dir}/@{outputName}"/>
-        <junitreport todir="${junit.html.output.dir}/">
-            <fileset dir="${build.dir}/test/@{outputName}/results">
-                <include name="TEST-*.xml"/>
-                <exclude name="TEST-fixture*"/>
-                <exclude name="TEST-*$?.xml"/>
-            </fileset>
-            <report format="noframes" todir="${junit.html.output.dir}/@{outputName}"/>
-        </junitreport>
+        <uptodate property="@{outputName}.test.current" targetFile="${status.dir}/test.@{outputName}.run.date">
+            <srcresources>
+                <fileset dir="@{classesDir}" includes="**/*"/>
+                <fileset-for-update-to-date/>
+            </srcresources>
+        </uptodate>
         <if>
-            <isset property="@{outputName}.failed"/>
+            <not>
+                <isset property="@{outputName}.test.current"/>
+            </not>
             <then>
-                <delete file="${status.dir}/@{outputName}.run" quiet="true"/>
-                <fail message="Tests have failures."/>
+                <jacoco:agent property="coverage.agent.param.@{outputName}" destfile="${coverage.dir}/jacoco.@{outputName}.exec"/>
+                <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="@{outputName}.failed">
+                    <classpaths/>
+                    <testclasses outputdir="${build.dir}/test/@{outputName}/results">
+                        <fork>
+                            <jvmarg value="${coverage.agent.param.@{outputName}}"/>
+                            <jvmarg value="-Dbuild.dir=${build.dir}"/>
+                            <jvmarg value="-Djava.io.tmpdir=${build.dir}/test/@{outputName}/tmp"/>
+                            <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
+                            <jvmargs/>
+                        </fork>
+                        <fileset dir="@{classesDir}">
+                            <testfiles/>
+                        </fileset>
+                        <listener type="legacy-brief" sendSysOut="true" useLegacyReportingName="false"/>
+                        <listener type="legacy-xml" sendSysErr="true" sendSysOut="true" useLegacyReportingName="false"/>
+                    </testclasses>
+                </junitlauncher>
+                <mkdir dir="${junit.html.output.dir}/@{outputName}"/>
+                <junitreport todir="${junit.html.output.dir}/">
+                    <fileset dir="${build.dir}/test/@{outputName}/results">
+                        <include name="TEST-*.xml"/>
+                        <exclude name="TEST-fixture*"/>
+                        <exclude name="TEST-*$?.xml"/>
+                    </fileset>
+                    <report format="noframes" todir="${junit.html.output.dir}/@{outputName}"/>
+                </junitreport>
+                <if>
+                    <isset property="@{outputName}.failed"/>
+                    <then>
+                        <delete file="${status.dir}/test.@{outputName}.run.date" quiet="true"/>
+                        <fail message="Tests have failures."/>
+                    </then>
+                    <else>
+                        <touch file="${status.dir}/test.@{outputName}.run.date"/>
+                    </else>
+                </if>                
             </then>
-            <else>
-                <touch file="${status.dir}/@{outputName}.run"/>
-            </else>
         </if>
     </sequential>
 </macrodef>

--- a/build.xml
+++ b/build.xml
@@ -73,7 +73,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <echo>${opendcs.classes}</echo>
         <compile outputDir="${build.dir}/test"
                  srcDir="${src.test.dir}"
-                 outputName="test"
+                 outputName="test-compile"
                  >
             <classpaths>
                 <pathelement location="${opendcs.classes}"/>
@@ -119,53 +119,20 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         </condition>
     </target>
     <target name="test" depends="check.run-tests,compile-test,jar,common.resolve.build" unless="test.run">
-        <mkdir dir="${junit.html.output.dir}"/>
-        <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
-        <echo message="platform path: ${platform_path}"/>
-        <mkdir dir="${build.dir}/test-results"/>
-        <mkdir dir="${build.dir}/test-tmp"/>
-        <jacoco:agent property="coverage.agent.param.test" destfile="${coverage.dir}/jacoco.test.exec"/>
-        <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="test.failed">
-            <classpath refid="test.classpath"/>
-            <classpath refid="runtime.classpath"/>
-            <classpath refid="junit.platform.libs.classpath"/>
-            <classpath>
-                <pathelement location="${opendcs.resources}"/>
-                <pathelement location="${test.resources}"/>
-                <pathelement location="${test.classes}"/>
-                <pathelement location="${opendcs.classes}"/>
-            </classpath>
-            <testclasses outputdir="${build.dir}/test-results">
-                <fork>
-                    <jvmarg value="${coverage.agent.param.test}"/>
-                    <jvmarg value="-Dbuild.dir=${build.dir}"/>
-                    <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-tmp"/>
-                    <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
-                </fork>
-                <fileset dir="${test.classes}"/>
-                <listener type="legacy-brief" sendSysOut="true" useLegacyReportingName="false"/>
-                <listener type="legacy-xml" sendSysErr="true" sendSysOut="true" useLegacyReportingName="false"/>
-            </testclasses>
-        </junitlauncher>
-        <mkdir dir="${junit.html.output.dir}/test"/>
-        <junitreport todir="${junit.html.output.dir}">
-            <fileset dir="${build.dir}/test-results">
-                <include name="TEST-*.xml"/>
-                <exclude name="TEST-fixture*"/>
-                <exclude name="TEST-*$?.xml"/>
-            </fileset>
-            <report format="noframes" todir="${junit.html.output.dir}/test"/>
-        </junitreport>
-        <if>
-            <isset property="test.failed"/>
-            <then>
-                <delete file="${status.dir}/test.run" quiet="true"/>
-                <fail message="Tests have failures."/>
-            </then>
-            <else>
-                <touch file="${status.dir}/test.run"/>
-            </else>
-        </if>
+        <test outputName="test"
+              classesDir="${test-compile.classes}">
+            <classpaths>
+                <classpath refid="test.classpath"/>
+                <classpath refid="runtime.classpath"/>
+                <classpath refid="junit.platform.libs.classpath"/>
+                <classpath>
+                    <pathelement location="${opendcs.resources}"/>
+                    <pathelement location="${test-compile.resources}"/>
+                    <pathelement location="${test-compile.classes}"/>
+                    <pathelement location="${opendcs.classes}"/>
+                </classpath>
+            </classpaths>
+        </test>
     </target>
     <target name="check.it-run" depends="check.src">
         <condition property="integration.test.current">

--- a/build.xml
+++ b/build.xml
@@ -14,6 +14,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
     >
     <description>Open DCS</description>
     <include file="common.xml"/>
+    <include file="build-macros.xml"/>
     <include file="docs/build.xml"/>
 <!-- depends="clean" -->
     <target name="prepare"  description="Makes build environment.">
@@ -41,55 +42,22 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <antcall target="docs.clean"/>
     </target>
     <target name="check.src">
-        <uptodate property="src.build.current" targetfile="${status.dir}/src.build.date">
+       <!-- <uptodate property="src.build.current" targetfile="${status.dir}/src.build.date">
             <srcfiles dir="${src.main.dir}" includes="**/*"/>
-        </uptodate>
+        </uptodate>-->
     </target>
-    <target name="compile" depends="check.src,prepare,common.resolve" unless="src.build.current"
-        description="Compiles all source code.">
-        <!-- create build date -->
-        <tstamp>
-            <format property="buildDate" pattern="MMM dd, yyyy"/>
-        </tstamp>
-        <copy todir="${build.classes}/lrgs/nledit">
-            <fileset dir="${src.dir}/lrgs/nledit">
-                <include name="*.gif"/>
-            </fileset>
-        </copy>
-        <sync todir="${build.resources}">
-            <fileset dir="${resources.dir}"/>
-        </sync>
-        <delete file="${build.classes}/lrgs/gui/LrgsBuild.class"/>
-        <copy file="${src.dir}/lrgs/gui/LrgsBuild.java"
-              tofile="${build.classes}/lrgs/gui/LrgsBuild.java"
-              overwrite="true">
-            <filterset>
-                <filter token="VERSION" value="${version}"/>
-                <filter token="DATE" value="${buildDate}" />
-                <filter token="RCNUM" value="${RCNUM}" />
-            </filterset>
-        </copy>
-        <javac debug="true" destdir="${build.classes}"
-            target="1.8" source="1.8"
-            includeantruntime="true"
-            encoding="UTF-8"
-            includes="lrgs/gui/LrgsBuild.java">
-            <src path="${build.classes}"/>
-            <classpath refid="runtime.classpath"/>
-            <compilerarg value="-parameters"/>
-        </javac>
-        <javac debug="true" destdir="${build.classes}"
-            target="1.8" source="1.8"
-            includeantruntime="true"
-            encoding="UTF-8"
-            includes="**"
-            excludes="lrgs/gui/LrgsBuild.java">
-            <src path="${src.dir}"/>
-            <classpath refid="runtime.classpath"/>
-            <compilerarg value="-parameters"/>
-        </javac>
+    <target name="compile" depends="prepare,common.resolve,common.resolve.build" description="Compiles all source code.">
+        <compile outputDir="${build.dir}/main"
+                 srcDir="${src.main.dir}"
+                 outputName="opendcs"
+                 >
+            <classpaths>
+                <path refid="runtime.classpath"/>
+            </classpaths>
+        </compile>
         <touch file="${status.dir}/src.build.date"/>
     </target>
+
     <target name="check.test.src" depends="check.src">
          <uptodate property="test.src.build.current.local" targetfile="${status.dir}/test.src.build.date">
             <srcfiles dir="src/test" includes="**/*"/>
@@ -102,60 +70,44 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         </condition>
     </target>
     <target name="compile-test" depends="check.test.src,compile,common.resolve" unless="test.src.build.current">
-        <mkdir dir="${build.test.classes}"/>
-        <javac debug="true" destdir="${build.test.classes}"
-            target="1.8" source="1.8" includeantruntime="false"
-            encoding="UTF-8"
-        >
-            <src path="${src.test.dir}"/>
-            <classpath>
-                <pathelement location="${build.classes}"/>
+        <echo>${opendcs.classes}</echo>
+        <compile outputDir="${build.dir}/test"
+                 srcDir="${src.test.dir}"
+                 outputName="test"
+                 >
+            <classpaths>
+                <pathelement location="${opendcs.classes}"/>
                 <path refid="runtime.classpath"/>
                 <path refid="test.classpath"/>
-            </classpath>
-        </javac>
-        <sync todir="${build.test.resources}">
-            <fileset dir="${resources.test.dir}"/>
-        </sync>
+            </classpaths>
+        </compile>
         <touch file="${status.dir}/test.src.build.date"/>
     </target>
     <target name="compile-test-integration" depends="stage,test,common.resolve,common.resolve.build">
-        <mkdir dir="${build.test-integration.classes}"/>
-        <javac debug="true" destdir="${build.test-integration.classes}"
-            target="1.8" source="1.8" includeantruntime="false"
-            encoding="UTF-8"
-        >
-            <src path="${src.test-integration.dir}"/>
-            <classpath>
+        <compile outputDir="${build.dir}/test-integration"
+                 srcDir="${src.test-integration.main.dir}"
+                 outputName="test-integration"
+                >
+            <classpaths>
                 <pathelement location="${stage.dir}/bin/opendcs.jar"/>
                 <!--<pathelement location="${build.classes}"/>-->
                 <path refid="runtime.classpath"/>
                 <path refid="test.classpath"/>
                 <path refid="junit.platform.libs.classpath"/>
-            </classpath>
-        </javac>
-        <sync todir="${build.test-integration.resources}">
-            <fileset dir="${resources.test-integration.dir}"/>
-        </sync>
+            </classpaths>
+        </compile>
         <touch file="${status.dir}/src.integration.build.date"/>
     </target>
     <target name="compile-test-gui" depends="jar,test,common.resolve,common.resolve.build">
-        <mkdir dir="${build.test-gui.classes}"/>
-        <javac debug="true" destdir="${build.test-gui.classes}"
-            target="1.8" source="1.8" includeantruntime="false"
-            encoding="UTF-8"
-        >
-            <src path="${src.test-gui.dir}"/>
-            <classpath>
-                <pathelement location="${build.classes}"/>
-                <!--<pathelement location="${build.classes}"/>-->
+        <compile outputDir="${build.dir}/test-gui"
+                 srcDir="${src.test-gui.main.dir}"
+                 outputName="test-gui">
+            <classpaths>
+                <pathelement location="${opendcs.classes}"/>
                 <path refid="runtime.classpath"/>
                 <path refid="test.classpath"/>
-            </classpath>
-        </javac>
-       <sync todir="${build.test-gui.resources}">
-            <fileset dir="${resources.test-gui.dir}"/>
-        </sync>
+            </classpaths>
+        </compile>
         <touch file="${status.dir}/src.gui-test.build.date"/>
     </target>
     <target name="check.run-tests" depends="check.test.src">
@@ -178,10 +130,10 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
             <classpath refid="runtime.classpath"/>
             <classpath refid="junit.platform.libs.classpath"/>
             <classpath>
-                <pathelement location="${build.resources}"/>
-                <pathelement location="${build.test.resources}"/>
-                <pathelement location="${build.test.classes}"/>
-                <pathelement location="${build.classes}"/>
+                <pathelement location="${opendcs.resources}"/>
+                <pathelement location="${test.resources}"/>
+                <pathelement location="${test.classes}"/>
+                <pathelement location="${opendcs.classes}"/>
             </classpath>
             <testclasses outputdir="${build.dir}/test-results">
                 <fork>
@@ -190,7 +142,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                     <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-tmp"/>
                     <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
                 </fork>
-                <fileset dir="${build.test.classes}"/>
+                <fileset dir="${test.classes}"/>
                 <listener type="legacy-brief" sendSysOut="true" useLegacyReportingName="false"/>
                 <listener type="legacy-xml" sendSysErr="true" sendSysOut="true" useLegacyReportingName="false"/>
             </testclasses>
@@ -268,15 +220,15 @@ more information about each.
             <classpath refid="junit.platform.libs.classpath"/>
             <classpath>
                 <pathelement location="${stage.dir}/bin/opendcs.jar"/>
-                <pathelement location="${build.test-integration.resources}"/>
-                <pathelement location="${build.test-integration.classes}"/>
+                <pathelement location="${test-integration.resources}"/>
+                <pathelement location="${test-integration.classes}"/>
             </classpath>
             <testclasses outputdir="${build.dir}/test-integration/${opendcs.test.engine}/results">
                 <fork>
                     <jvmarg value="${coverage.agent.param.it}"/>
                     <jvmarg value="-Dbuild.dir=${build.dir}"/>
                     <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-integration/${opendcs.test.engine}/tmp"/>
-                    <jvmarg value="-Dresource.dir=${build.test-integration.resources}"/>
+                    <jvmarg value="-Dresource.dir=${test-integration.resources}"/>
                     <jvmarg value="-DDCSTOOL_HOME=${stage.dir}"/>
                     <jvmarg value="-Dopendcs.test.engine=${opendcs.test.engine}"/>
                     <jvmarg value="-Dopendcs.test.classpath=${opendcs.test.classpath}"/>
@@ -337,17 +289,17 @@ more information about each.
             <classpath refid="runtime.classpath"/>
             <classpath refid="junit.platform.libs.classpath"/>
             <classpath>
-                <pathelement location="${build.classes}"/>
-                <pathelement location="${build.resources}"/>
-                <pathelement location="${build.test-gui.resources}"/>
-                <pathelement location="${build.test-gui.classes}"/>
+                <pathelement location="${opendcs.classes}"/>
+                <pathelement location="${opendcs.resources}"/>
+                <pathelement location="${test-gui.resources}"/>
+                <pathelement location="${test-gui.classes}"/>
             </classpath>
             <testclasses outputdir="${build.dir}/test-gui/results">
                 <fork>
                     <jvmarg value="${coverage.agent.param.gui}"/>
                     <jvmarg value="-Dbuild.dir=${build.dir}"/>
                     <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-gui/tmp"/>
-                    <jvmarg value="-Dresource.dir=${build.test-gui.resources}"/>
+                    <jvmarg value="-Dresource.dir=${test-gui.resources}"/>
                     <jvmarg value="-DDCSTOOL_HOME=${stage.dir}"/>
                     <jvmarg value="-DDECODES_INSTALL_DIR=${stage.dir}"/>
                     <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,6 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
 <!-- depends="clean" -->
     <target name="prepare"  description="Makes build environment.">
         <mkdir dir="${build.dir}"/>
-        <mkdir dir="${build.classes}"/>
         <mkdir dir="${build.lib}"/>
         <mkdir dir="${status.dir}"/>
         <pathconvert property="junitlauncherPresent" setonempty="false" pathsep=" ">
@@ -42,21 +41,21 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <antcall target="docs.clean"/>
     </target>
     <target name="compile" depends="prepare,common.resolve,common.resolve.build" description="Compiles all source code.">
-        <compile outputDir="${build.dir}/main"
+        <compile-java outputDir="${build.dir}/main"
                  srcDir="${src.main.dir}"
                  outputName="opendcs"
                  >
             <classpaths>
                 <path refid="runtime.classpath"/>
             </classpaths>
-        </compile>
+        </compile-java>
         <touch file="${status.dir}/src.build.date"/>
     </target>
     
     <target name="compile-test" depends="compile,common.resolve">
-        <compile outputDir="${build.dir}/test"
-                 srcDir="${src.test.dir}"
-                 outputName="test-compile">
+        <compile-java outputDir="${build.dir}/test"
+                      srcDir="${src.test.dir}"
+                      outputName="test-compile">
             <classpaths>
                 <pathelement location="${opendcs.classes}"/>
                 <path refid="runtime.classpath"/>
@@ -66,16 +65,15 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 <fileset dir="${opendcs.classes}" includes="**/*"/>
                 <fileset dir="${opendcs.classes}" includes="**/*"/>
             </fileset-for-update-to-date>
-        </compile>
+        </compile-java>
         <touch file="${status.dir}/test.src.build.date"/>
     </target>
     <target name="compile-test-integration" depends="stage,test,common.resolve,common.resolve.build">
-        <compile outputDir="${build.dir}/test-integration"
-                 srcDir="${src.test-integration.main.dir}"
-                 outputName="test-integration">
+        <compile-java outputDir="${build.dir}/test-integration"
+                      srcDir="${src.test-integration.main.dir}"
+                      outputName="test-integration">
             <classpaths>
                 <pathelement location="${stage.dir}/bin/opendcs.jar"/>
-                <!--<pathelement location="${build.classes}"/>-->
                 <path refid="runtime.classpath"/>
                 <path refid="test.classpath"/>
                 <path refid="junit.platform.libs.classpath"/>
@@ -84,13 +82,13 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 <fileset dir="${opendcs.classes}" includes="**/*"/>
                 <fileset dir="${opendcs.classes}" includes="**/*"/>
             </fileset-for-update-to-date>
-        </compile>
+        </compile-java>
         <touch file="${status.dir}/src.integration.build.date"/>
     </target>
     <target name="compile-test-gui" depends="jar,test,common.resolve,common.resolve.build">
-        <compile outputDir="${build.dir}/test-gui"
-                 srcDir="${src.test-gui.main.dir}"
-                 outputName="test-gui">
+        <compile-java outputDir="${build.dir}/test-gui"
+                      srcDir="${src.test-gui.main.dir}"
+                      outputName="test-gui">
             <classpaths>
                 <pathelement location="${opendcs.classes}"/>
                 <path refid="runtime.classpath"/>
@@ -100,7 +98,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 <fileset dir="${opendcs.classes}" includes="**/*"/>
                 <fileset dir="${opendcs.classes}" includes="**/*"/>
             </fileset-for-update-to-date>
-        </compile>
+        </compile-java>
         <touch file="${status.dir}/src.gui-test.build.date"/>
     </target>
     <target name="test" depends="compile-test,jar,common.resolve.build">
@@ -669,7 +667,7 @@ more information about each.
     <target name="code-anaylsis" depends="spotbugs,cpd" description="Run all available code anaylsis"/>
     <!-- Still debating on if this should depend on all the tests, but it's perfectly valid to only want to see
          coverage for what's actually been generated. -->
-    <target name="coverage.report" depends="common.resolve.build">
+    <target name="coverage.report" depends="compile,common.resolve.build">
         <jacoco:merge destfile="${reports.dir}/coverage.exec">
             <fileset dir="${coverage.dir}" includes="*.exec"/>
         </jacoco:merge>
@@ -679,11 +677,11 @@ more information about each.
             </executiondata>
             <structure name="OpenDCS">
                 <classfiles>
-                    <fileset dir="${build.classes}"
+                    <fileset dir="${opendcs.classes}"
                              excludes="**/easy_install/**,**/python_packages,**/certifi/**,**/chardet/**,**/urllib3/**,**/requests/**,**/chardet/**,**/urllib3/**,**/idna/**,**/pkg_resources/**"/>
                 </classfiles>
                 <sourcefiles encoding="UTF-8">
-                    <fileset dir="${src.dir}"/>
+                    <fileset dir="${src.main.dir}/java"/>
                 </sourcefiles>
             </structure>
             <html destdir="${reports.dir}/coverage.html"/>

--- a/build.xml
+++ b/build.xml
@@ -86,8 +86,7 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
     <target name="compile-test-integration" depends="stage,test,common.resolve,common.resolve.build">
         <compile outputDir="${build.dir}/test-integration"
                  srcDir="${src.test-integration.main.dir}"
-                 outputName="test-integration"
-                >
+                 outputName="test-integration">
             <classpaths>
                 <pathelement location="${stage.dir}/bin/opendcs.jar"/>
                 <!--<pathelement location="${build.classes}"/>-->
@@ -169,69 +168,39 @@ more information about each.
                 <fail message="See above message and set correct settings."/>
             </then>
         </if>
-        <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
-        <mkdir dir="${build.dir}/test-integration/${opendcs.test.engine}/results"/>
-        <mkdir dir="${build.dir}/test-integration/${opendcs.test.engine}/tmp"/>
-        <jacoco:agent property="coverage.agent.param.it"
-                      destfile="${coverage.dir}/jacoco.test-it-${opendcs.test.engine}.exec"/>
         <!-- This path is used by the integration test extension when
             creating independent OpenDCS application processes-->
         <path id="opendcs.runtime">
             <pathelement location="${stage.dir}/bin/opendcs.jar"/>
             <fileset dir="${stage.dir}/dep"/>
         </path>
-        <pathconvert property="opendcs.test.classpath" refid="opendcs.runtime"/>
-        <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="integration.failed">
+        <test outputName="test-integration"
+              classesDir="${test-integration.classes}">
+              <classpaths>
             <classpath refid="test.classpath"/>
-            <classpath refid="runtime.classpath"/>
-            <classpath refid="junit.platform.libs.classpath"/>
-            <classpath>
-                <pathelement location="${stage.dir}/bin/opendcs.jar"/>
-                <pathelement location="${test-integration.resources}"/>
-                <pathelement location="${test-integration.classes}"/>
-            </classpath>
-            <testclasses outputdir="${build.dir}/test-integration/${opendcs.test.engine}/results">
-                <fork>
-                    <jvmarg value="${coverage.agent.param.it}"/>
-                    <jvmarg value="-Dbuild.dir=${build.dir}"/>
-                    <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-integration/${opendcs.test.engine}/tmp"/>
-                    <jvmarg value="-Dresource.dir=${test-integration.resources}"/>
-                    <jvmarg value="-DDCSTOOL_HOME=${stage.dir}"/>
-                    <jvmarg value="-Dopendcs.test.engine=${opendcs.test.engine}"/>
-                    <jvmarg value="-Dopendcs.test.classpath=${opendcs.test.classpath}"/>
-                    <jvmarg value="-Djava.util.logging.config.file=${build.dir}/../src/test-integration/test-config/logging.properties"/>
-                    <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
-                    <syspropertyset>
-                        <propertyref prefix="opendcs"/>
-                    </syspropertyset>
-                    <syspropertyset>
-                        <propertyref prefix="testcontainer"/>
-                    </syspropertyset>
-                </fork>
-                <fileset dir="${build.test-integration.classes}"/>
-                <listener type="legacy-brief" sendSysOut="true" useLegacyReportingName="false"/>
-                <listener type="legacy-xml" sendSysErr="true" sendSysOut="true" useLegacyReportingName="false"/>
-            </testclasses>
-        </junitlauncher>
-        <mkdir dir="${junit.html.output.dir}/test-integration/${opendcs.test.engine}"/>
-        <junitreport todir="${junit.html.output.dir}">
-            <fileset dir="${build.dir}/test-integration/${opendcs.test.engine}/results">
-                <include name="TEST-*.xml"/>
-                <exclude name="TEST-org.opendcs.spi.configuration*"/>
-                <exclude name="TEST-org.opendcs.fixture*"/>
-            </fileset>
-            <report format="noframes" todir="${junit.html.output.dir}/test-integration/${opendcs.test.engine}"/>
-        </junitreport>
-        <if>
-            <isset property="integration.failed"/>
-            <then>
-                <delete file="${status.dir}/src.integration.run.${opendcs.test.engine}" quiet="true"/>
-                <fail message="Integration tests have failures."/>
-            </then>
-            <else>
-                <touch file="${status.dir}/src.integration.run.${opendcs.test.engine}"/>
-            </else>
-        </if>
+                <classpath refid="runtime.classpath"/>
+                <classpath refid="junit.platform.libs.classpath"/>
+                <classpath>
+                    <pathelement location="${stage.dir}/bin/opendcs.jar"/>
+                    <pathelement location="${test-integration.resources}"/>
+                    <pathelement location="${test-integration.classes}"/>
+                </classpath>
+            </classpaths>
+            <jvmargs>
+                <jvmarg value="-Dresource.dir=${test-integration.resources}"/>
+                <jvmarg value="-DDCSTOOL_HOME=${stage.dir}"/>
+                <jvmarg value="-Dopendcs.test.engine=${opendcs.test.engine}"/>
+                <jvmarg value="-Dopendcs.test.classpath=${opendcs.test.classpath}"/>
+                <jvmarg value="-Djava.util.logging.config.file=${build.dir}/../src/test-integration/test-config/logging.properties"/>
+                <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
+                <syspropertyset>
+                    <propertyref prefix="opendcs"/>
+                </syspropertyset>
+                <syspropertyset>
+                    <propertyref prefix="testcontainer"/>
+                </syspropertyset>
+            </jvmargs>
+        </test>
     </target>
     <target name="check.gui-test" depends="check.src">
         <condition property="gui.test.current">
@@ -247,52 +216,25 @@ more information about each.
     <target name="gui-test" depends="check.gui-test,compile-test-gui,stage,common.resolve"
             description="Run available GUI element tests"
             unless="gui.test.current">
-        <pathconvert property="platform_path" refid="junit.platform.libs.classpath"/>
-        <mkdir dir="${build.dir}/test-gui/results"/>
-        <mkdir dir="${build.dir}/test-gui/tmp"/>
-        <jacoco:agent property="coverage.agent.param.gui" destfile="${coverage.dir}/jacoco.test-gui.exec"/>
-        <junitlauncher haltOnFailure="false" printSummary="true" failureProperty="gui.failed">
-            <classpath refid="test.classpath"/>
-            <classpath refid="runtime.classpath"/>
-            <classpath refid="junit.platform.libs.classpath"/>
-            <classpath>
-                <pathelement location="${opendcs.classes}"/>
-                <pathelement location="${opendcs.resources}"/>
-                <pathelement location="${test-gui.resources}"/>
-                <pathelement location="${test-gui.classes}"/>
-            </classpath>
-            <testclasses outputdir="${build.dir}/test-gui/results">
-                <fork>
-                    <jvmarg value="${coverage.agent.param.gui}"/>
-                    <jvmarg value="-Dbuild.dir=${build.dir}"/>
-                    <jvmarg value="-Djava.io.tmpdir=${build.dir}/test-gui/tmp"/>
-                    <jvmarg value="-Dresource.dir=${test-gui.resources}"/>
-                    <jvmarg value="-DDCSTOOL_HOME=${stage.dir}"/>
-                    <jvmarg value="-DDECODES_INSTALL_DIR=${stage.dir}"/>
-                    <jvmarg if:set="debugPort" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
-                </fork>
-                <fileset dir="${build.test-gui.classes}"/>
-                <listener type="legacy-brief" sendSysOut="true" useLegacyReportingName="false"/>
-                <listener type="legacy-xml" sendSysErr="true" sendSysOut="true" useLegacyReportingName="false"/>
-            </testclasses>
-        </junitlauncher>
-        <mkdir dir="${junit.html.output.dir}/test-gui"/>
-        <junitreport todir="${junit.html.output.dir}">
-            <fileset dir="${build.dir}/test-gui/results">
-                <include name="TEST-*.xml"/>
-            </fileset>
-            <report format="noframes" todir="${junit.html.output.dir}/test-gui"/>
-        </junitreport>
-        <if>
-            <isset property="gui.failed"/>
-            <then>
-                <delete file="${status.dir}/src.gui-test.run" quiet="true"/>
-                <fail message="Gui tests have failures."/>
-            </then>
-            <else>
-                <touch file="${status.dir}/src.gui-test.run"/>
-            </else>
-        </if>
+        <test outputName="gui-test"
+              classesDir="${test-gui.classes}">
+            <classpaths>
+                <classpath refid="test.classpath"/>
+                <classpath refid="runtime.classpath"/>
+                <classpath refid="junit.platform.libs.classpath"/>
+                <classpath>
+                    <pathelement location="${opendcs.classes}"/>
+                    <pathelement location="${opendcs.resources}"/>
+                    <pathelement location="${test-gui.resources}"/>
+                    <pathelement location="${test-gui.classes}"/>
+                </classpath>
+            </classpaths>
+            <jvmargs>
+                <jvmarg value="-Dresource.dir=${test-gui.resources}"/>
+                <jvmarg value="-DDCSTOOL_HOME=${stage.dir}"/>
+                <jvmarg value="-DDECODES_INSTALL_DIR=${stage.dir}"/>
+            </jvmargs>
+        </test>
     </target>
     <target name="check.jar" depends="check.src">
         <uptodate property="jar.current" targetFile="${dist.jar}">
@@ -300,19 +242,15 @@ more information about each.
         </uptodate>
     </target>
     <target name="jar" depends="check.jar,compile" description="Generates opendcs.jar." unless="jar.current">
-        <!-- copy the resource files to the build directory. -->
-        <copy todir="${build.classes}">
-            <fileset dir="${resources.dir}"/>
-        </copy>
-        <!-- AW_AlgorithmTemplate.java needed by Algorithm Editor. -->
-        <copy todir="${build.classes}/decodes/tsdb/algo">
+        <jar jarfile="${dist.jar}"
+             update="true">
+            <fileset dir="${opendcs.resources}"/>
+            <fileset dir="${opendcs.classes}"/>
+            <!-- AW_AlgorithmTemplate.java needed by Algorithm Editor. -->
             <fileset dir="${src.dir}/decodes/tsdb/algo">
                 <include name="AW_AlgorithmTemplate.java"/>
             </fileset>
-        </copy>
-        <jar jarfile="${dist.jar}"
-             basedir="${build.classes}"
-             update="true"/>
+        </jar>
     </target>
     <target name="publish" depends="jar,common.init-ivy,common.resolve.build" description="--> publish ivy artifacts">
         <publish/>

--- a/build.xml
+++ b/build.xml
@@ -41,11 +41,6 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         <delete dir="combined-src"/>
         <antcall target="docs.clean"/>
     </target>
-    <target name="check.src">
-       <!-- <uptodate property="src.build.current" targetfile="${status.dir}/src.build.date">
-            <srcfiles dir="${src.main.dir}" includes="**/*"/>
-        </uptodate>-->
-    </target>
     <target name="compile" depends="prepare,common.resolve,common.resolve.build" description="Compiles all source code.">
         <compile outputDir="${build.dir}/main"
                  srcDir="${src.main.dir}"
@@ -57,29 +52,20 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
         </compile>
         <touch file="${status.dir}/src.build.date"/>
     </target>
-
-    <target name="check.test.src" depends="check.src">
-         <uptodate property="test.src.build.current.local" targetfile="${status.dir}/test.src.build.date">
-            <srcfiles dir="src/test" includes="**/*"/>
-        </uptodate>
-        <condition property="test.src.build.current">
-            <and>
-                <isset property="src.build.current"/>
-                <isset property="test.src.build.current.local"/>
-            </and>
-        </condition>
-    </target>
-    <target name="compile-test" depends="check.test.src,compile,common.resolve" unless="test.src.build.current">
-        <echo>${opendcs.classes}</echo>
+    
+    <target name="compile-test" depends="compile,common.resolve">
         <compile outputDir="${build.dir}/test"
                  srcDir="${src.test.dir}"
-                 outputName="test-compile"
-                 >
+                 outputName="test-compile">
             <classpaths>
                 <pathelement location="${opendcs.classes}"/>
                 <path refid="runtime.classpath"/>
                 <path refid="test.classpath"/>
             </classpaths>
+            <fileset-for-update-to-date>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+            </fileset-for-update-to-date>
         </compile>
         <touch file="${status.dir}/test.src.build.date"/>
     </target>
@@ -94,6 +80,10 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 <path refid="test.classpath"/>
                 <path refid="junit.platform.libs.classpath"/>
             </classpaths>
+            <fileset-for-update-to-date>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+            </fileset-for-update-to-date>
         </compile>
         <touch file="${status.dir}/src.integration.build.date"/>
     </target>
@@ -106,18 +96,14 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                 <path refid="runtime.classpath"/>
                 <path refid="test.classpath"/>
             </classpaths>
+            <fileset-for-update-to-date>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+            </fileset-for-update-to-date>
         </compile>
         <touch file="${status.dir}/src.gui-test.build.date"/>
     </target>
-    <target name="check.run-tests" depends="check.test.src">
-        <condition property="test.run">
-            <and>
-                <available file="${status.dir}/test.run"/>
-                <isset property="test.src.build.current"/>
-            </and>
-        </condition>
-    </target>
-    <target name="test" depends="check.run-tests,compile-test,jar,common.resolve.build" unless="test.run">
+    <target name="test" depends="compile-test,jar,common.resolve.build">
         <test outputName="test"
               classesDir="${test-compile.classes}">
             <classpaths>
@@ -131,26 +117,14 @@ NOTE at this time jdk8 must be used as there is still a dependency on tools.jar
                     <pathelement location="${opendcs.classes}"/>
                 </classpath>
             </classpaths>
+            <fileset-for-update-to-date>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+            </fileset-for-update-to-date>
         </test>
     </target>
-    <target name="check.it-run" depends="check.src">
-        <condition property="integration.test.current">
-            <and>
-                <available file="${status.dir}/src.integration.run.${opendcs.test.engine}"/>
-                <isset property="src.build.current"/>
-                <uptodate property="integration.src.current" targetFile="${status.dir}/src.integration.build.date">
-                    <srcFiles dir="${src.test-integration.main.dir}" includes="**/*"/>
-                </uptodate>
-            </and>
-        </condition>
-        <condition property="test.engine.set">
-            <isset property="opendcs.test.engine"/>
-        </condition>
-    </target>
-    <target name="integration-test" depends="check.it-run,compile-test-integration,stage,common.resolve"
-            description="Run the integration test suite with available implementations."
-            unless="integration.test.current"
-            >
+    <target name="integration-test" depends="compile-test-integration,stage,common.resolve"
+            description="Run the integration test suite with available implementations.">
         <if>
             <not>
                 <isset property="opendcs.test.engine"/>
@@ -200,22 +174,14 @@ more information about each.
                     <propertyref prefix="testcontainer"/>
                 </syspropertyset>
             </jvmargs>
+            <fileset-for-update-to-date>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+            </fileset-for-update-to-date>
         </test>
     </target>
-    <target name="check.gui-test" depends="check.src">
-        <condition property="gui.test.current">
-            <and>
-                <available file="${status.dir}/src.gui-test.run"/>
-                <isset property="src.build.current"/>
-                <uptodate property="gui-test.src.current" targetFile="${status.dir}/src.gui-test.build.date">
-                    <srcFiles dir="${src.test-gui.main.dir}" includes="**/*"/>
-                </uptodate>
-            </and>
-        </condition>
-    </target>
-    <target name="gui-test" depends="check.gui-test,compile-test-gui,stage,common.resolve"
-            description="Run available GUI element tests"
-            unless="gui.test.current">
+    <target name="gui-test" depends="compile-test-gui,stage,common.resolve"
+            description="Run available GUI element tests">
         <test outputName="gui-test"
               classesDir="${test-gui.classes}">
             <classpaths>
@@ -234,9 +200,13 @@ more information about each.
                 <jvmarg value="-DDCSTOOL_HOME=${stage.dir}"/>
                 <jvmarg value="-DDECODES_INSTALL_DIR=${stage.dir}"/>
             </jvmargs>
+            <fileset-for-update-to-date>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+                <fileset dir="${opendcs.classes}" includes="**/*"/>
+            </fileset-for-update-to-date>
         </test>
     </target>
-    <target name="check.jar" depends="check.src">
+    <target name="check.jar">
         <uptodate property="jar.current" targetFile="${dist.jar}">
             <srcfiles dir="${src.main.dir}" includes="**/*"/>
         </uptodate>

--- a/common.xml
+++ b/common.xml
@@ -23,8 +23,7 @@
     <property name="src.main.dir" value="src/main"/>
     <property name="src.dir" value="src/main/java"/>
     <property name="resources.dir" value="src/main/resources"/>
-    <property name="src.test.dir" value="src/test/java"/>
-    <property name="resources.test.dir" value="src/test/resources"/>
+    <property name="src.test.dir" value="src/test"/>
     <property name="src.test-integration.dir" value="src/test-integration/java"/>
     <property name="src.test-integration.main.dir" value="src/test-integration"/>
     <property name="resources.test-integration.dir" value="src/test-integration/resources"/>
@@ -44,7 +43,7 @@
     <property name="build.test.lib" value="${build.dir}/test-libs"/>
     <property name="build.test-integration.classes" value="${build.dir}/test-integration/classes"/>
     <property name="build.test-integration.resources" value="${build.dir}/test-integration/resources"/>
-    <property name="build.test-gui.classes" value="${build.dir}/test-gui/classes"/>
+    <property name="build.test-gui.classes" value="${build.dir}/test-gui"/>
     <property name="build.test-gui.resources" value="${build.dir}/test-gui/resources"/>
     <property name="build.test.lib" value="${build.dir}/test-integration/libs"/>
     <property name="dist.jar" value="${build.lib}/opendcs.jar"/>

--- a/common.xml
+++ b/common.xml
@@ -22,30 +22,14 @@
     <property name="project.dir" value="${basedir}"/>
     <property name="src.main.dir" value="src/main"/>
     <property name="src.dir" value="src/main/java"/>
-    <property name="resources.dir" value="src/main/resources"/>
     <property name="src.test.dir" value="src/test"/>
-    <property name="src.test-integration.dir" value="src/test-integration/java"/>
     <property name="src.test-integration.main.dir" value="src/test-integration"/>
-    <property name="resources.test-integration.dir" value="src/test-integration/resources"/>
-    <property name="src.test-gui.dir" value="src/test-gui/java"/>
-    <property name="resources.test-gui.dir" value="src/test-gui/resources"/>
     <property name="src.test-gui.main.dir" value="src/test-gui"/>
-
     <property name="build.dir" value="build"/>
     <property name="reports.dir" value="${build.dir}/reports"/>
-    <property name="build.classes" value="${build.dir}/classes"/>
-    <property name="build.resources" value="${build.dir}/resources"/>
     <property name="build.lib" value="${build.dir}/lib"/>
     <property name="status.dir" value="${build.dir}/.status"/>
     <property name="stage.dir" value="stage"/>
-    <property name="build.test.classes" value="${build.dir}/test-classes"/>
-    <property name="build.test.resources" value="${build.dir}/test-resources"/>
-    <property name="build.test.lib" value="${build.dir}/test-libs"/>
-    <property name="build.test-integration.classes" value="${build.dir}/test-integration/classes"/>
-    <property name="build.test-integration.resources" value="${build.dir}/test-integration/resources"/>
-    <property name="build.test-gui.classes" value="${build.dir}/test-gui"/>
-    <property name="build.test-gui.resources" value="${build.dir}/test-gui/resources"/>
-    <property name="build.test.lib" value="${build.dir}/test-integration/libs"/>
     <property name="dist.jar" value="${build.lib}/opendcs.jar"/>
     <property name="build.release.dir" value="${build.dir}/release"/>
     <property name="spotbugs.output.dir" value="${reports.dir}/spotbugs"/>

--- a/src/main/java/lrgs/gui/LrgsBuild.java
+++ b/src/main/java/lrgs/gui/LrgsBuild.java
@@ -19,8 +19,8 @@ package is built.
 */
 public class LrgsBuild
 {
-	public static final String buildDate = "@DATE@";
-	public static final String rcNum = "@RCNUM@";
-	public static final String version = "@VERSION@";
+	public static final String buildDate = "7.0.13";
+	public static final String rcNum = "13";
+	public static final String version = "7.0";
 }
 


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
After getting #525 working I realized we'd be running the LRGS multiple times in the automated build (as it's part of the current integration test suite but doesn't depend on any of that infrastructure.)

After deciding it would be best to create yet-another-test-target the amount of duplicate XML that would be required bothered me. Thus I've reduced the boilerplate to make it easier to add new compile and test targets.

## Solution

- Created a `compile-java` macrodef to handle compiling java and dealing with when things are up-to-date
- Created a `test` macrodef to handle running tests.

Callers of the task are required to set the src files for compile, classes for test, and the classpath for both.
Additional jvmargs may be provided for the test tests.
Additional filessets to determine if the output is up-to-date may also be provided.


## how you tested the change

Since the tests pass, the build works. (NOTE: at least for those things under test, but that's now varied enough I feel confident things are in a good state.)

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
