### PR TITLE
Refactor/update compile dialog

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -254,8 +254,8 @@ more information about each.
             <fileset dir="${opendcs.resources}"/>
             <fileset dir="${opendcs.classes}"/>
             <!-- AW_AlgorithmTemplate.java needed by Algorithm Editor. -->
-            <fileset dir="${src.dir}/decodes/tsdb/algo">
-                <include name="AW_AlgorithmTemplate.java"/>
+            <fileset dir="${src.dir}" >
+                <include name="**/AW_AlgorithmTemplate.java"/>
             </fileset>
         </jar>
     </target>

--- a/build.xml
+++ b/build.xml
@@ -143,7 +143,7 @@ more information about each.
             <fileset dir="${stage.dir}/dep"/>
         </path>
         <pathconvert property="opendcs.test.classpath" refid="opendcs.runtime"/>
-        <test outputName="test-integration"
+        <test outputName="test-integration-${opendcs.test.engine}"
               classesDir="${test-integration.classes}">
               <classpaths>
             <classpath refid="test.classpath"/>

--- a/src/main/java/decodes/tsdb/algoedit/CompileDialog.java
+++ b/src/main/java/decodes/tsdb/algoedit/CompileDialog.java
@@ -3,10 +3,8 @@
 */
 package decodes.tsdb.algoedit;
 
-import java.awt.event.*;
 import java.awt.*;
 import java.io.*;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -28,9 +26,6 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import javax.tools.Diagnostic.Kind;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.nio.charset.Charset;
 
 import ilex.util.FileUtil;
@@ -42,504 +37,480 @@ import ilex.util.EnvExpander;
 
 public class CompileDialog extends GuiDialog
 {
-	private ResourceBundle labels = null;
-	private ResourceBundle genericLabels = null;
-	
-	private JPanel northPanel = new JPanel();
-	private JPanel centerPanel = new JPanel();
-	private JPanel buttonPanel = new JPanel();
+    private ResourceBundle labels = null;
+    private ResourceBundle genericLabels = null;
 
-	private JLabel compOptionsLabel;
-	static private JTextField compOptionsField = new JTextField();
-	private JLabel classPathLabel;
-	static private JTextField classPathField = new JTextField();
-	static
-	{
-		compOptionsField.setText(
-			DecodesSettings.instance().algoEditCompileOptions);
-		classPathField.setText(System.getProperty("java.class.path"));
-	}
+    private JPanel northPanel = new JPanel();
+    private JPanel centerPanel = new JPanel();
+    private JPanel buttonPanel = new JPanel();
 
-	private JPanel northButtonPanel = new JPanel();
-	private JButton clearButton;
-	private JButton writeJavaButton;
-	private JButton compileButton;
+    private JLabel compOptionsLabel;
+    static private JTextField compOptionsField = new JTextField();
+    private JLabel classPathLabel;
+    static private JTextField classPathField = new JTextField();
+    static
+    {
+        compOptionsField.setText(
+            DecodesSettings.instance().algoEditCompileOptions);
+        classPathField.setText(System.getProperty("java.class.path"));
+    }
 
-	private JScrollPane javaCodePane = new JScrollPane();
-	private JTextArea javaCodeArea = new JTextArea();
-	private JScrollPane resultsPane = new JScrollPane();
-	private JTextArea resultsArea = new JTextArea();
+    private JPanel northButtonPanel = new JPanel();
+    private JButton clearButton;
+    private JButton writeJavaButton;
+    private JButton compileButton;
 
-	private JButton addToJarButton;
-	private JButton saveClassButton;
-	private JButton doneButton;
-	private static JFileChooser fileChooser = new JFileChooser();
+    private JScrollPane javaCodePane = new JScrollPane();
+    private JTextArea javaCodeArea = new JTextArea();
+    private JScrollPane resultsPane = new JScrollPane();
+    private JTextArea resultsArea = new JTextArea();
 
-	private AlgoData algoData;
-	private AlgoWriter algoWriter;
-	private File algotmpdir = null;
-	private File pkgdir = null;
-	private File tmpFile = null;
+    private JButton addToJarButton;
+    private JButton saveClassButton;
+    private JButton doneButton;
+    private static JFileChooser fileChooser = new JFileChooser();
 
-	public CompileDialog(AlgoData algoData, AlgoWriter algoWriter)
-	{
-		super(AlgorithmWizard.instance().getFrame(), "", false);
+    private AlgoData algoData;
+    private AlgoWriter algoWriter;
+    private File algoTmpDir = null;
+    private File pkgDir = null;
+    private File tmpFile = null;
 
-		this.algoData = algoData;
-		this.algoWriter = algoWriter;
-		
-		labels = AlgorithmWizard.getLabels();
-		genericLabels = AlgorithmWizard.getGenericLabels();
+    public CompileDialog(AlgoData algoData, AlgoWriter algoWriter)
+    {
+        super(AlgorithmWizard.instance().getFrame(), "", false);
 
-		this.setTitle(labels.getString("CompileDialog.title"));
-		compOptionsLabel = 
-			new JLabel(labels.getString("CompileDialog.compilerOptions"));
-		classPathLabel = 
-			new JLabel(labels.getString("CompileDialog.classPath"));
-		clearButton = new JButton(labels.getString("CompileDialog.clear"));
-		writeJavaButton = 
-			new JButton(labels.getString("CompileDialog.writeJavaCode"));
-		compileButton = new JButton(labels.getString("CompileDialog.compile"));
-		addToJarButton = 
-			new JButton(labels.getString("CompileDialog.addToJarFile"));
-		saveClassButton = 
-			new JButton(labels.getString("CompileDialog.saveClassFile"));
-		doneButton = new JButton(labels.getString("CompileDialog.done"));
-		
-		guiInit();
-		pack();
-		getRootPane().setDefaultButton(doneButton);
-	}
-	
-	public void clear()
-	{
-		javaCodeArea.setText("");
-		resultsArea.setText("");
-		compileButton.setEnabled(false);
-		addToJarButton.setEnabled(false);
-		saveClassButton.setEnabled(false);
-	}
+        this.algoData = algoData;
+        this.algoWriter = algoWriter;
 
-	private void fill()
-	{
-	}
+        labels = AlgorithmWizard.getLabels();
+        genericLabels = AlgorithmWizard.getGenericLabels();
 
-	private void guiInit()
-	{
-		getContentPane().setLayout(new BorderLayout());
-		getContentPane().setPreferredSize(new Dimension(500, 600));
-		getContentPane().add(northPanel, BorderLayout.NORTH);
-		getContentPane().add(centerPanel, BorderLayout.CENTER);
-		getContentPane().add(buttonPanel, BorderLayout.SOUTH);
+        this.setTitle(labels.getString("CompileDialog.title"));
+        compOptionsLabel =
+            new JLabel(labels.getString("CompileDialog.compilerOptions"));
+        classPathLabel =
+            new JLabel(labels.getString("CompileDialog.classPath"));
+        clearButton = new JButton(labels.getString("CompileDialog.clear"));
+        writeJavaButton =
+            new JButton(labels.getString("CompileDialog.writeJavaCode"));
+        compileButton = new JButton(labels.getString("CompileDialog.compile"));
+        addToJarButton =
+            new JButton(labels.getString("CompileDialog.addToJarFile"));
+        saveClassButton =
+            new JButton(labels.getString("CompileDialog.saveClassFile"));
+        doneButton = new JButton(labels.getString("CompileDialog.done"));
 
-		northPanel.setLayout(new GridBagLayout());
-		northPanel.add(compOptionsLabel,
-			new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
-				GridBagConstraints.EAST, GridBagConstraints.NONE,
-				new Insets(15, 10, 5, 2), 0, 0));
-		northPanel.add(compOptionsField,
-			new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0,
-				GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-				new Insets(15, 0, 5, 10), 0, 0));
-		northPanel.add(classPathLabel,
-			new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0,
-				GridBagConstraints.EAST, GridBagConstraints.NONE,
-				new Insets(5, 10, 5, 2), 0, 0));
-		northPanel.add(classPathField,
-			new GridBagConstraints(1, 1, 1, 1, 1.0, 0.0,
-				GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-				new Insets(5, 0, 5, 10), 0, 0));
+        guiInit();
+        pack();
+        getRootPane().setDefaultButton(doneButton);
+    }
 
-		northButtonPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 20, 10));
-		northPanel.add(northButtonPanel,
-			new GridBagConstraints(0, 2, 2, 1, 1.0, 0.0,
-				GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
-				new Insets(8, 20, 8, 20), 0, 0));
-		Dimension buttonDim = writeJavaButton.getSize();
-		buttonDim.setSize(120, (int)buttonDim.getHeight());
-		//writeJavaButton.setPreferredSize(buttonDim);
-		northButtonPanel.add(clearButton);
-		northButtonPanel.add(writeJavaButton);
-		//compileButton.setPreferredSize(buttonDim);
-		northButtonPanel.add(compileButton);
+    public void clear()
+    {
+        javaCodeArea.setText("");
+        resultsArea.setText("");
+        compileButton.setEnabled(false);
+        addToJarButton.setEnabled(false);
+        saveClassButton.setEnabled(false);
+    }
 
-		clearButton.addActionListener(
-			new ActionListener() 
-			{
-				public void actionPerformed(ActionEvent e) { clear(); }
-			});
-		clearButton.setEnabled(true);
-		writeJavaButton.addActionListener(
-			new ActionListener() 
-			{
-				public void actionPerformed(ActionEvent e) { doWriteJava(); }
-			});
-		writeJavaButton.setEnabled(true);
-		compileButton.addActionListener(
-			new ActionListener() 
-			{
-				public void actionPerformed(ActionEvent e) { doCompile(); }
-			});
-		compileButton.setEnabled(false);
+    private void guiInit()
+    {
+        getContentPane().setLayout(new BorderLayout());
+        getContentPane().setPreferredSize(new Dimension(500, 600));
+        getContentPane().add(northPanel, BorderLayout.NORTH);
+        getContentPane().add(centerPanel, BorderLayout.CENTER);
+        getContentPane().add(buttonPanel, BorderLayout.SOUTH);
 
-		centerPanel.setLayout(new GridBagLayout());
+        northPanel.setLayout(new GridBagLayout());
+        northPanel.add(compOptionsLabel,
+            new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(15, 10, 5, 2), 0, 0));
+        northPanel.add(compOptionsField,
+            new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(15, 0, 5, 10), 0, 0));
+        northPanel.add(classPathLabel,
+            new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(5, 10, 5, 2), 0, 0));
+        northPanel.add(classPathField,
+            new GridBagConstraints(1, 1, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(5, 0, 5, 10), 0, 0));
 
-		javaCodePane.setBorder(
-			BorderFactory.createTitledBorder(
-				BorderFactory.createLineBorder(Color.gray, 2),
-				labels.getString("CompileDialog.javaCode")));
-		javaCodePane.setViewportView(javaCodeArea);
-		javaCodeArea.setTabSize(4);
-		Font oldfont = javaCodeArea.getFont();
-		Font newfont = new Font("Monospaced",Font.PLAIN,oldfont.getSize());
-		javaCodeArea.setFont(newfont);
-		javaCodeArea.setBorder(
-			BorderFactory.createEtchedBorder(EtchedBorder.LOWERED));
-		centerPanel.add(javaCodePane,
-			new GridBagConstraints(0, 0, 1, 1, 1.0, 0.6,
-				GridBagConstraints.CENTER, GridBagConstraints.BOTH,
-				new Insets(8, 5, 8, 5), 0, 0));
+        northButtonPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 20, 10));
+        northPanel.add(northButtonPanel,
+            new GridBagConstraints(0, 2, 2, 1, 1.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                new Insets(8, 20, 8, 20), 0, 0));
+        Dimension buttonDim = writeJavaButton.getSize();
+        buttonDim.setSize(120, (int)buttonDim.getHeight());
+        //writeJavaButton.setPreferredSize(buttonDim);
+        northButtonPanel.add(clearButton);
+        northButtonPanel.add(writeJavaButton);
+        //compileButton.setPreferredSize(buttonDim);
+        northButtonPanel.add(compileButton);
 
-		resultsPane.setBorder(
-			BorderFactory.createTitledBorder(
-				BorderFactory.createLineBorder(Color.gray, 2), 
-				labels.getString("CompileDialog.compileResults")));
-		resultsPane.setViewportView(resultsArea);
-		resultsArea.setBorder(
-			BorderFactory.createEtchedBorder(EtchedBorder.LOWERED));
-		centerPanel.add(resultsPane,
-			new GridBagConstraints(0, 1, 1, 1, 1.0, 0.6,
-				GridBagConstraints.CENTER, GridBagConstraints.BOTH,
-				new Insets(8, 5, 8, 5), 0, 0));
+        clearButton.addActionListener(e -> clear());
+        clearButton.setEnabled(true);
+        writeJavaButton.addActionListener(e -> doWriteJava());
+        writeJavaButton.setEnabled(true);
+        compileButton.addActionListener(e -> doCompile());
+        compileButton.setEnabled(false);
 
-		buttonPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 20, 10));
-		addToJarButton.setEnabled(false);
-		//addToJarButton.setPreferredSize(buttonDim);
-		buttonPanel.add(addToJarButton);
-		saveClassButton.setEnabled(false);
-		//saveClassButton.setPreferredSize(buttonDim);
-		buttonPanel.add(saveClassButton);
-		//doneButton.setPreferredSize(buttonDim);
-		buttonPanel.add(doneButton);
-		addToJarButton.addActionListener(
-			new ActionListener() 
-			{
-				public void actionPerformed(ActionEvent e) { doAddToJar(); }
-			});
-		saveClassButton.addActionListener(
-			new ActionListener() 
-			{
-				public void actionPerformed(ActionEvent e) { doSaveClass(); }
-			});
-		doneButton.addActionListener(
-			new ActionListener() 
-			{
-				public void actionPerformed(ActionEvent e) { doDone(); }
-			});
-	}
+        centerPanel.setLayout(new GridBagLayout());
 
-	private void doWriteJava()
-	{
-		algotmpdir = new File(
-			EnvExpander.expand("$DCSTOOL_USERDIR/tmp/algo"));
-		if (!algotmpdir.isDirectory())
-			algotmpdir.mkdirs();
-		StringBuilder pkgnm = new StringBuilder(algoData.getJavaPackage());
-		for(int i = 0; i < pkgnm.length(); i++)
-			if (pkgnm.charAt(i) == '.')
-				pkgnm.setCharAt(i, '/');
-		if (pkgnm.length() > 0)
-		{
-			pkgdir = new File(algotmpdir, pkgnm.toString());
-			if (!pkgdir.isDirectory())
-				pkgdir.mkdirs();
-		}
-		else
-			pkgdir = algotmpdir;
-		tmpFile = new File(pkgdir, algoData.getJavaClassName() + ".java");
-		javaCodeArea.setText("");
-		resultsArea.setText(
-				LoadResourceBundle.sprintf(
-				labels.getString("CompileDialog.saveToTempFileMsg"),
-				tmpFile.getPath()) + "\n");
-		try { algoWriter.saveToTheFile(tmpFile, algoData); }
-		catch(AlgoIOException ex)
-		{
-			resultsArea.append(
-				labels.getString("CompileDialog.cannotWriteJavaFileErr") + 
-				ex.getMessage() + '\n');
-			return;
-		}
-		LineNumberReader lnr = null;
-		try
-		{
-			lnr = new LineNumberReader(new FileReader(tmpFile));
-			String line = null;
-			while((line = lnr.readLine()) != null)
-				javaCodeArea.append("" + lnr.getLineNumber() + ": " + line + 
-					"\n");
-		}
-		catch(IOException ex)
-		{
-			resultsArea.append(
-				labels.getString("CompileDialog.cannotReadJavaFileErr")
-				+ ex.getMessage() + '\n');
-			return;
-		}
-		finally
-		{
-			if (lnr != null)
-				try { lnr.close(); } catch(Exception ex) {}
-		}
-		resultsArea.setText(labels.getString("CompileDialog.savedJavaFileInfo"));
-		resultsArea.append(
-				labels.getString("CompileDialog.pressingCompileInfo"));
-		compileButton.setEnabled(true);
-	}
+        javaCodePane.setBorder(
+            BorderFactory.createTitledBorder(
+                BorderFactory.createLineBorder(Color.gray, 2),
+                labels.getString("CompileDialog.javaCode")));
+        javaCodePane.setViewportView(javaCodeArea);
+        javaCodeArea.setTabSize(4);
+        Font oldfont = javaCodeArea.getFont();
+        Font newfont = new Font("Monospaced",Font.PLAIN,oldfont.getSize());
+        javaCodeArea.setFont(newfont);
+        javaCodeArea.setBorder(
+            BorderFactory.createEtchedBorder(EtchedBorder.LOWERED));
+        centerPanel.add(javaCodePane,
+            new GridBagConstraints(0, 0, 1, 1, 1.0, 0.6,
+                GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                new Insets(8, 5, 8, 5), 0, 0));
 
-	/**
-	 *
-	 */
-	public void doCompile()
-	{
-		File logFile = new File(algotmpdir, "compile.log");
-		saveClassButton.setEnabled(false);
-		addToJarButton.setEnabled(false);
-		try (PrintWriter logWriter = new PrintWriter(logFile))
-		{
-			final List<String> args = new ArrayList<String>();
-			StringTokenizer st = new StringTokenizer(
-				compOptionsField.getText().trim());
-			while(st.hasMoreTokens())
-			{
-				args.add(st.nextToken());
-			}
-			String x = classPathField.getText().trim();
-			if (x.length() > 0)
-			{
-				args.add("-classpath");
-				args.add(x);
-			}
-			args.add("-source"); args.add("1.8");
-			args.add("-target"); args.add("1.8");
-			//args.add(tmpFile.getPath());
-			args.add("-d");
-			args.add(algotmpdir.getPath());
-			JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-			if (compiler == null)
-			{
-				resultsArea.append(
-					labels.getString("CompileDialog.cannotLoadCompilerErr"));
-				return;
-			}
-			StandardJavaFileManager fm = compiler.getStandardFileManager(null, getLocale(), Charset.forName("UTF-8"));
-			Iterable<? extends JavaFileObject> javaFileObjects = fm.getJavaFileObjects(tmpFile);
-			final DiagnosticListener<javax.tools.JavaFileObject> listener = new DiagnosticListener<javax.tools.JavaFileObject>()
-			{
-				@Override
-				public void report(Diagnostic<? extends JavaFileObject> diagnostic)
-				{
-					String msg = diagnostic.getMessage(getLocale());
-					long line = diagnostic.getLineNumber();
-					long column = diagnostic.getColumnNumber();
-					Kind kind = diagnostic.getKind();
-					JavaFileObject jfo = diagnostic.getSource();
-					String fileName = "textarea";
-					if (jfo != null)
-					{
-						fileName = diagnostic.getSource().toUri().toString();
-					}
-					String userMsg = (jfo == null )
-								   ? String.format("%s %s%s", kind.toString(), msg, System.lineSeparator())
-								   : String.format("%s %s:%d%d: %s%s", kind.toString(), fileName, line, column, msg, System.lineSeparator());
-					resultsArea.append(userMsg);
-				}
-			};
-			JavaCompiler.CompilationTask task = compiler.getTask(logWriter, fm, listener, args, null, javaFileObjects);
-			if (!task.call())
-			{
-				resultsArea.append("Compilation failed.");
-			}
-			else
-			{
-				resultsArea.append("Compilation succeeded.");
-				saveClassButton.setEnabled(true);
-				addToJarButton.setEnabled(true);
-			}
-		}
-		catch(Exception ex)
-		{
-			resultsArea.append(
-				labels.getString("CompileDialog.failedToCompileErr")
-				+ ex.getMessage());
-			StringWriter sw = new StringWriter();
-			PrintWriter pw = new PrintWriter(sw);
-			ex.printStackTrace(pw);
-			resultsArea.append(sw.toString());
-			return;
-		}
-	}
+        resultsPane.setBorder(
+            BorderFactory.createTitledBorder(
+                BorderFactory.createLineBorder(Color.gray, 2),
+                labels.getString("CompileDialog.compileResults")));
+        resultsPane.setViewportView(resultsArea);
+        resultsArea.setBorder(
+            BorderFactory.createEtchedBorder(EtchedBorder.LOWERED));
+        centerPanel.add(resultsPane,
+            new GridBagConstraints(0, 1, 1, 1, 1.0, 0.6,
+                GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                new Insets(8, 5, 8, 5), 0, 0));
 
-	public void doSaveClass()
-	{
-		if (fileChooser.showSaveDialog(this) == JFileChooser.APPROVE_OPTION)
-		{
-			File file = fileChooser.getSelectedFile();
-			if (file != null)
-			{
-				String classFileName = tmpFile.getPath();
-				int idx = classFileName.lastIndexOf(".java");
-				if (idx > 0)
-					classFileName = classFileName.substring(0, idx);
-				classFileName = classFileName + ".class";
-				try { FileUtil.copyFile(new File(classFileName), file); }
-				catch(IOException ex)
-				{
-					showError(
-							LoadResourceBundle.sprintf(
-							labels.getString("CompileDialog.cannotSaveErr"),
-							file.getPath()) + ex);
-				}
-			}
-		}
-	}
-	
-	public void doAddToJar()
-	{
-		File jarFile = null;
-		if (fileChooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION
-		 || (jarFile = fileChooser.getSelectedFile()) == null)
-		{
-			resultsArea.append(
-					labels.getString("CompileDialog.noJarSelectedInfo"));
-			return;
-		}
+        buttonPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 20, 10));
+        addToJarButton.setEnabled(false);
+        //addToJarButton.setPreferredSize(buttonDim);
+        buttonPanel.add(addToJarButton);
+        saveClassButton.setEnabled(false);
+        //saveClassButton.setPreferredSize(buttonDim);
+        buttonPanel.add(saveClassButton);
+        //doneButton.setPreferredSize(buttonDim);
+        buttonPanel.add(doneButton);
+        addToJarButton.addActionListener(e -> doAddToJar());
+        saveClassButton.addActionListener(e -> doSaveClass());
+        doneButton.addActionListener(e -> doDone());
+    }
 
-		List<JarEntryWithData> existingEntries = new ArrayList<>();
-		Manifest manifest = null;
-		if (jarFile.exists())
-		{
-			try (JarFile jf = new JarFile(jarFile))
-			{
-				manifest = jf.getManifest();
-				Enumeration<JarEntry> entries = jf.entries();
-				while(entries.hasMoreElements())
-				{
-					JarEntry entry = entries.nextElement();
-					if (!entry.getName().equals("META-INF/MANIFEST.MF"))
-					{
-						InputStream is = jf.getInputStream(entry);
-						byte[] data = new byte[(int)entry.getSize()];
-						is.read(data, 0, (int)entry.getSize());
-						existingEntries.add(new JarEntryWithData(entry, data));
-					}
-				}
-			}
-			catch (IOException ex)
-			{
-				resultsArea.append("Unable to Read in existing Jar File contents: " + ex.getLocalizedMessage());
-				StringWriter sw = new StringWriter();
-				PrintWriter pw = new PrintWriter(sw);
-				ex.printStackTrace(pw);
-				resultsArea.append(sw.toString());
-				return;
-			}
-		}
-		if (manifest == null)
-		{
-			manifest = new Manifest();
-			Attributes attr = manifest.getMainAttributes();
-			attr.put(Attributes.Name.MANIFEST_VERSION, "1.0");
-			String createdBy = String.format("AlgoEdit with %s",ToolProvider.getSystemJavaCompiler().getClass().getName());
-			attr.putValue("Created-By", createdBy);
-		}
+    private void doWriteJava()
+    {
+        algoTmpDir = new File(
+            EnvExpander.expand("$DCSTOOL_USERDIR/tmp/algo"));
+        if (!algoTmpDir.isDirectory())
+        {
+            algoTmpDir.mkdirs();
+        }
+        StringBuilder packageName = new StringBuilder(algoData.getJavaPackage());
+        for(int i = 0; i < packageName.length(); i++)
+        {
+            if (packageName.charAt(i) == '.')
+            {
+                packageName.setCharAt(i, '/');
+            }
+        }
+        if (packageName.length() > 0)
+        {
+            pkgDir = new File(algoTmpDir, packageName.toString());
+            if (!pkgDir.isDirectory())
+            {
+                pkgDir.mkdirs();
+            }
+        }
+        else
+        {
+            pkgDir = algoTmpDir;
+        }
+        tmpFile = new File(pkgDir, algoData.getJavaClassName() + ".java");
+        javaCodeArea.setText("");
+        resultsArea.setText(
+                LoadResourceBundle.sprintf(
+                labels.getString("CompileDialog.saveToTempFileMsg"),
+                tmpFile.getPath()) + "\n");
+        try
+        {
+            algoWriter.saveToTheFile(tmpFile, algoData);
+        }
+        catch(AlgoIOException ex)
+        {
+            resultsArea.append(
+                labels.getString("CompileDialog.cannotWriteJavaFileErr") +
+                ex.getMessage() + '\n');
+            return;
+        }
+        LineNumberReader lnr = null;
+        try
+        {
+            lnr = new LineNumberReader(new FileReader(tmpFile));
+            String line = null;
+            while((line = lnr.readLine()) != null)
+            {
+                javaCodeArea.append("" + lnr.getLineNumber() + ": " + line + "\n");
+            }
+        }
+        catch(IOException ex)
+        {
+            resultsArea.append(
+                labels.getString("CompileDialog.cannotReadJavaFileErr")
+                + ex.getMessage() + '\n');
+            return;
+        }
+        finally
+        {
+            if (lnr != null)
+            {
+                try { lnr.close(); } catch(Exception ex) {}
+            }
+        }
+        resultsArea.setText(labels.getString("CompileDialog.savedJavaFileInfo"));
+        resultsArea.append(
+                labels.getString("CompileDialog.pressingCompileInfo"));
+        compileButton.setEnabled(true);
+    }
 
-		String classFileName;
-		if (algotmpdir != pkgdir)
-		{
-			StringBuilder sb = new StringBuilder(
-				algoData.getJavaPackage() + "." + algoData.getJavaClassName());
-			for(int i=0; i<sb.length(); i++)
-				if (sb.charAt(i) == '.')
-					sb.setCharAt(i, '/');
-			sb.append(".class");
-			classFileName = sb.toString();
-		}
-		else
-		{
-			classFileName = algoData.getJavaClassName() + ".class";
-		}
-		
-		try
-		{
-			File tmpJarFile = File.createTempFile(jarFile.getName(), ".jar");
-			tmpJarFile.deleteOnExit();
-			try(
-				OutputStream os = new FileOutputStream(tmpJarFile);
-				JarOutputStream jos = new JarOutputStream(os, manifest);)
-			{
-				for (JarEntryWithData entry: existingEntries)
-				{
-					if (!entry.entry.getName().equals(classFileName))
-					{
-						jos.putNextEntry(entry.entry);
-						jos.write(entry.data); // write bytes here.
-						jos.closeEntry();
-					}
-				}
-				File classFile = new File(algotmpdir, classFileName);
-				JarEntry algoEntry = new JarEntry(classFileName);
-				jos.putNextEntry(algoEntry);
-				byte data[] = FileUtil.getfileBytes(classFile);
-				jos.write(data);
-				jos.closeEntry();
-			}
-			FileUtil.copyFile(tmpJarFile, jarFile);
-		}
-		catch (IOException ex)
-		{
-			resultsArea.append("Unable to add class file to jar:" + ex.getLocalizedMessage());
-			StringWriter sw = new StringWriter();
-			PrintWriter pw = new PrintWriter(sw);
-			ex.printStackTrace(pw);
-			resultsArea.append(sw.toString());
-		}
-	}
+    /**
+     *
+     */
+    public void doCompile()
+    {
+        File logFile = new File(algoTmpDir, "compile.log");
+        saveClassButton.setEnabled(false);
+        addToJarButton.setEnabled(false);
+        try (PrintWriter logWriter = new PrintWriter(logFile))
+        {
+            final List<String> args = new ArrayList<String>();
+            StringTokenizer st = new StringTokenizer(
+                compOptionsField.getText().trim());
+            while(st.hasMoreTokens())
+            {
+                args.add(st.nextToken());
+            }
+            String x = classPathField.getText().trim();
+            if (x.length() > 0)
+            {
+                args.add("-classpath");
+                args.add(x);
+            }
+            args.add("-source"); args.add("1.8");
+            args.add("-target"); args.add("1.8");
+            //args.add(tmpFile.getPath());
+            args.add("-d");
+            args.add(algoTmpDir.getPath());
+            JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+            if (compiler == null)
+            {
+                resultsArea.append(
+                    labels.getString("CompileDialog.cannotLoadCompilerErr"));
+                return;
+            }
+            StandardJavaFileManager fm = compiler.getStandardFileManager(null, getLocale(), Charset.forName("UTF-8"));
+            Iterable<? extends JavaFileObject> javaFileObjects = fm.getJavaFileObjects(tmpFile);
+            final DiagnosticListener<javax.tools.JavaFileObject> listener = new DiagnosticListener<javax.tools.JavaFileObject>()
+            {
+                @Override
+                public void report(Diagnostic<? extends JavaFileObject> diagnostic)
+                {
+                    String msg = diagnostic.getMessage(getLocale());
+                    long line = diagnostic.getLineNumber();
+                    long column = diagnostic.getColumnNumber();
+                    Kind kind = diagnostic.getKind();
+                    JavaFileObject jfo = diagnostic.getSource();
+                    String fileName = "textarea";
+                    if (jfo != null)
+                    {
+                        fileName = diagnostic.getSource().toUri().toString();
+                    }
+                    String userMsg = (jfo == null )
+                                   ? String.format("%s %s%s", kind.toString(), msg, System.lineSeparator())
+                                   : String.format("%s %s:%d%d: %s%s", kind.toString(), fileName, line, column, msg, System.lineSeparator());
+                    resultsArea.append(userMsg);
+                }
+            };
+            JavaCompiler.CompilationTask task = compiler.getTask(logWriter, fm, listener, args, null, javaFileObjects);
+            if (!task.call())
+            {
+                resultsArea.append("Compilation failed.");
+            }
+            else
+            {
+                resultsArea.append("Compilation succeeded.");
+                saveClassButton.setEnabled(true);
+                addToJarButton.setEnabled(true);
+            }
+        }
+        catch(Exception ex)
+        {
+            resultsArea.append(
+                labels.getString("CompileDialog.failedToCompileErr")
+                + ex.getMessage());
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            ex.printStackTrace(pw);
+            resultsArea.append(sw.toString());
+        }
+    }
 
-	public void doDone()
-	{
-		setVisible(false);
-	}
+    public void doSaveClass()
+    {
+        if (fileChooser.showSaveDialog(this) == JFileChooser.APPROVE_OPTION)
+        {
+            File file = fileChooser.getSelectedFile();
+            if (file != null)
+            {
+                String classFileName = tmpFile.getPath();
+                int idx = classFileName.lastIndexOf(".java");
+                if (idx > 0)
+                {
+                    classFileName = classFileName.substring(0, idx);
+                }
+                classFileName = classFileName + ".class";
+                try
+                {
+                    FileUtil.copyFile(new File(classFileName), file);
+                }
+                catch(IOException ex)
+                {
+                    showError(
+                            LoadResourceBundle.sprintf(
+                            labels.getString("CompileDialog.cannotSaveErr"),
+                            file.getPath()) + ex);
+                }
+            }
+        }
+    }
 
-	public static String path2url(String path)
-	{
-		StringBuilder sb = new StringBuilder(path);
-		for(int i=0; i < sb.length(); i++)
-		{
-			if (sb.charAt(i) == '\\')
-				sb.setCharAt(i, '/');
-			else if (sb.charAt(i) == ' ')
-			{
-				sb.setCharAt(i, '%');
-				sb.insert(++i, "20");
-			}
-		}
-		if (sb.charAt(0) != '/')
-			sb.insert(0, "file:///");
-		else 
-			sb.insert(0, "file://");
-		return sb.toString();
-	}
+    public void doAddToJar()
+    {
+        File jarFile = null;
+        if (fileChooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION
+         || (jarFile = fileChooser.getSelectedFile()) == null)
+        {
+            resultsArea.append(
+                    labels.getString("CompileDialog.noJarSelectedInfo"));
+            return;
+        }
 
-	private static class JarEntryWithData
-	{
-		public final JarEntry entry;
-		public final byte[] data;
+        List<JarEntryWithData> existingEntries = new ArrayList<>();
+        Manifest manifest = null;
+        if (jarFile.exists())
+        {
+            try (JarFile jf = new JarFile(jarFile))
+            {
+                manifest = jf.getManifest();
+                Enumeration<JarEntry> entries = jf.entries();
+                while(entries.hasMoreElements())
+                {
+                    JarEntry entry = entries.nextElement();
+                    if (!entry.getName().equals("META-INF/MANIFEST.MF"))
+                    {
+                        InputStream is = jf.getInputStream(entry);
+                        byte[] data = new byte[(int)entry.getSize()];
+                        is.read(data, 0, (int)entry.getSize());
+                        existingEntries.add(new JarEntryWithData(entry, data));
+                    }
+                }
+            }
+            catch (IOException ex)
+            {
+                resultsArea.append("Unable to Read in existing Jar File contents: " + ex.getLocalizedMessage());
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                ex.printStackTrace(pw);
+                resultsArea.append(sw.toString());
+                return;
+            }
+        }
+        if (manifest == null)
+        {
+            manifest = new Manifest();
+            Attributes attr = manifest.getMainAttributes();
+            attr.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+            String createdBy = String.format("AlgoEdit with %s",ToolProvider.getSystemJavaCompiler().getClass().getName());
+            attr.putValue("Created-By", createdBy);
+        }
 
-		public JarEntryWithData(JarEntry entry, byte[] data)
-		{
-			this.entry = entry;
-			this.data = data;
-		}
-	}
+        String classFileName;
+        if (algoTmpDir != pkgDir)
+        {
+            StringBuilder sb = new StringBuilder(
+                algoData.getJavaPackage() + "." + algoData.getJavaClassName());
+            for(int i=0; i<sb.length(); i++)
+            {
+                if (sb.charAt(i) == '.')
+                {
+                    sb.setCharAt(i, '/');
+                }
+            }
+            sb.append(".class");
+            classFileName = sb.toString();
+        }
+        else
+        {
+            classFileName = algoData.getJavaClassName() + ".class";
+        }
+
+        try
+        {
+            File tmpJarFile = File.createTempFile(jarFile.getName(), ".jar");
+            tmpJarFile.deleteOnExit();
+            try(
+                OutputStream os = new FileOutputStream(tmpJarFile);
+                JarOutputStream jos = new JarOutputStream(os, manifest);)
+            {
+                for (JarEntryWithData entry: existingEntries)
+                {
+                    if (!entry.entry.getName().equals(classFileName))
+                    {
+                        jos.putNextEntry(entry.entry);
+                        jos.write(entry.data); // write bytes here.
+                        jos.closeEntry();
+                    }
+                }
+                File classFile = new File(algoTmpDir, classFileName);
+                JarEntry algoEntry = new JarEntry(classFileName);
+                jos.putNextEntry(algoEntry);
+                byte data[] = FileUtil.getfileBytes(classFile);
+                jos.write(data);
+                jos.closeEntry();
+            }
+            FileUtil.copyFile(tmpJarFile, jarFile);
+        }
+        catch (IOException ex)
+        {
+            resultsArea.append("Unable to add class file to jar:" + ex.getLocalizedMessage());
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            ex.printStackTrace(pw);
+            resultsArea.append(sw.toString());
+        }
+    }
+
+    public void doDone()
+    {
+        setVisible(false);
+    }
+
+    private static class JarEntryWithData
+    {
+        public final JarEntry entry;
+        public final byte[] data;
+
+        public JarEntryWithData(JarEntry entry, byte[] data)
+        {
+            this.entry = entry;
+            this.data = data;
+        }
+    }
 }


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #. 

<!-- if you are referencing a specific issue a problem description is not required -->
Developers will often get a warning about the direct use of the `com.sun.tools.javac.Main` package. It's also deprecated in 9+ up (at least as accessible that way.)

The logic in the doCompile step tried to do too much on behalf of the user.

## Solution

Use the javax.tools.ToolProvider.getSystemJavaCompiler() to get an instance of `JavaCompiler`. This is the standard interface to get the compiler.

Additionally modified addToJar tasks to use JarFile and JarOutputStream to handle creating and updating the Jar; thus removing another direct `com.sun...` dependency.

On a JRE an error is returned and nothing else is done. As the `.getSystemJavaCompiler` will return null.

For the curious, the returned compiler *is* `com.sun.tools.javac.api.JavacTool` with OpenJDK 17. But this avoids that direct dependency that causes the compiler warning message and would also allow for alternate implementations (e.g. in other JDKs)

NOTE: this also means our build is now compatible with up-to java 17. The tests pass using that JDK. The output is still targeted at 1.8. I know a JDK 21 won't work, there's runtime issues due some APIs being deprecated but I'll add another PR after this one to expand the build and test actions to include LTS JDKs up to 17 for runtime verification.

## how you tested the change

- Open algoedit
- Create algorithm (file -> new) doesn't need to do much
- Compile & and Jar
- Verify class file in correct location in and jar is valid (used the JD-GUI java decompiler)
- Create new algorithm with different name and slightly altered contents
- Compile
- Add to existing jar
- Using JD-GUI again verify that both files are in the jar and JD-GUI is able to decompile them.


NOTE: tested with Java JDK 17, set to generate source/target 1.8 files.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
