### PR TITLE
Refactor/launcher stream usage

### DIFF
--- a/src/main/java/decodes/dbeditor/TraceLogger.java
+++ b/src/main/java/decodes/dbeditor/TraceLogger.java
@@ -1,6 +1,11 @@
 
 package decodes.dbeditor;
 
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import ilex.util.Logger;
 
 /**
@@ -11,6 +16,10 @@ public class TraceLogger extends Logger
 	/** The trace dialog. */
 	TraceDialog dlg;
 
+	private BlockingQueue<String> queue = new ArrayBlockingQueue<>(5000);
+	private Thread writerThread;
+	private AtomicBoolean closeOperations = new AtomicBoolean(false);
+
 	/**
 	 Constructor.
 	*/
@@ -18,6 +27,28 @@ public class TraceLogger extends Logger
 	{
 		super(procName);
 		this.dlg = null;
+		writerThread = new Thread(() ->
+		{
+			while (closeOperations.get() == false)
+			{
+				try
+				{
+					String line = queue.poll(1, TimeUnit.SECONDS);
+					if (dlg != null)
+					{
+						dlg.addText(line);
+					}
+				}
+				catch (InterruptedException ex)
+				{
+					// go back to operation, in this scenario most likely closeOperations is true and
+					// and we're ditching the logging
+				}
+			}
+		},
+		"TraceDialog-Writer");
+		writerThread.setDaemon(true);
+		writerThread.start();
 	}
 
 	/**
@@ -32,11 +63,11 @@ public class TraceLogger extends Logger
 	/** Does nothing. */
 	public void close()
 	{
+		closeOperations.set(true);
 	}
 
 	public synchronized void doLog(int priority, String text)
 	{
-		if (dlg != null)
-			dlg.addText(text + "\n");
+		queue.add(text + "\n");
 	}
 }

--- a/src/main/java/decodes/dbeditor/TraceLogger.java
+++ b/src/main/java/decodes/dbeditor/TraceLogger.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import ilex.util.Logger;
 
 /**
-TraceLogger captures and display 'trace' log messages in a dialog, during interactive operation like decoding.
+TraceLogger captures and displays  'trace' log messages in a dialog, during interactive operation like decoding.
 */
 public class TraceLogger extends Logger
 {

--- a/src/main/java/decodes/dbeditor/TraceLogger.java
+++ b/src/main/java/decodes/dbeditor/TraceLogger.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import ilex.util.Logger;
 
 /**
-Used to grabe 'trace' log messages when Decode button is pressed.
+TraceLogger captures and display 'trace' log messages in a dialog, during interactive operation like decoding.
 */
 public class TraceLogger extends Logger
 {

--- a/src/main/java/ilex/util/FileLogger.java
+++ b/src/main/java/ilex/util/FileLogger.java
@@ -3,8 +3,6 @@
 */
 package ilex.util;
 
-import java.util.Date;
-import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -94,11 +92,7 @@ public class FileLogger extends Logger
 		super(procName);
 		this.filename = EnvExpander.expand(filename);
 		this.maxLength = maxLength;
-//		outputFile = new File(EnvExpander.expand(filename));
 		openNewLog();
-		
-//		FileOutputStream fos = new FileOutputStream(outputFile, appendFlag);
-//		output = new PrintStream(fos, true);
 	}
 
 	/**

--- a/src/main/java/ilex/util/ProcWaiterCallback.java
+++ b/src/main/java/ilex/util/ProcWaiterCallback.java
@@ -5,6 +5,7 @@ package ilex.util;
 The ProcWaiterThread can issue a callback when the process has died.
 Implement this interface if you want a callback.
 */
+@FunctionalInterface
 public interface ProcWaiterCallback
 {
 	public void procFinished(String procName, Object obj, int exitStatus);


### PR DESCRIPTION
## Problem Description


<!-- if you are referencing a specific issue a problem description is not required -->
With recent logging changes and tweaks to the launcher profile system users have been reporting certain interfaces are slower than usual.

## Solution

Modify the profile threads that wait on application data to use BufferedReaders so that there are more waits.
Lowered the priority to not hang up other operations.

As an extra measure, implemented simple async logging within FileLogger and TraceLogger to improve application speed.
GUI apps do appear to load faster/more consistently but, for example, the NWP comp that uses a coup with near 14000 time series continues to be slow processing only 7 timeseries/second. See #526 for more details on that.

If, after additional measurement, the async logging proves valuable I'll reorganize the code to avoid so much duplication.

## how you tested the change

Running applications directly and from the launcher to gauge the speed of when thing first rendered.
It did feel faster to me.

I suspect the local test on my VM is not a fair test. The VM itself is hosted on an independant SSD from the OS and writers are generally very fast. The async logger change *should* help in situations of NFS, HDDs, or SD cards (e.g. a raspberry pi, which I'll test later when I have access.)

I plan to also test this change on the HEC T7 (SPARC/Solaris, uses NFS for just about everything) but likely no earlier than Monday.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
