### PR TITLE
Switch to macos-13 to allow JDK 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-13, windows-latest]
         jdk: [8, 11, 17]
     runs-on: ${{matrix.platform}}
     steps:


### PR DESCRIPTION
Macos-latest is now using M1 hardware which doesn't have a JDK 8 distribution available. At least not the Temurin JDK.

## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
macos jdk 8 build action is not passing.

## Solution

switch to previous mac version.

## how you tested the change

tested when actions run.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
