### PR TITLE
Fixed column sorting issues

### DIFF
--- a/src/main/java/decodes/dbeditor/ConfigSelectPanel.java
+++ b/src/main/java/decodes/dbeditor/ConfigSelectPanel.java
@@ -102,7 +102,10 @@ public class ConfigSelectPanel extends JPanel
 		int r = configTable.getSelectedRow();
 		if (r == -1)
 			return null;
-		return (PlatformConfig)model.getRowObject(r);
+		//Get the correct row from the table model
+		int modelrow = configTable.convertRowIndexToModel(r);
+		ConfigSelectTableModel tablemodel = (ConfigSelectTableModel)configTable.getModel();
+		return (PlatformConfig)tablemodel.getRowObject(modelrow);
 	}
 
 	/** Tells the panel to refresh itself from the database config list. */
@@ -132,7 +135,10 @@ public class ConfigSelectPanel extends JPanel
 		int r = configTable.getSelectedRow();
 		if (r == -1)
 			return;
-		model.deleteAt(r);
+		//Get the correct row from the table model
+		int modelrow = configTable.convertRowIndexToModel(r);
+		ConfigSelectTableModel tablemodel = (ConfigSelectTableModel)configTable.getModel();
+		tablemodel.deleteAt(modelrow);
 	}
 
 	/**

--- a/src/main/java/decodes/dbeditor/NetlistEditPanel.java
+++ b/src/main/java/decodes/dbeditor/NetlistEditPanel.java
@@ -302,11 +302,14 @@ public class NetlistEditPanel extends DbEditorTab implements ChangeTracker, Enti
 			TopFrame.instance().showError(dbeditLabels.getString("NetlistEditPanel.EditError"));
 			return;
 		}
-		NetworkListEntry nle = tableModel.getObjectAt(row);
+		//Get the correct row from the table model
+		int modelrow = netlistContentsTable.convertRowIndexToModel(row);
+		NetlistContentsTableModel tablemodel = (NetlistContentsTableModel)netlistContentsTable.getModel();
+		NetworkListEntry nle = tableModel.getObjectAt(modelrow);
 		NetlistEntryDialog dlg = new NetlistEntryDialog(nle);
 		launchDialog(dlg);
 		if (dlg.wasOkPressed())
-			tableModel.replace(nle, row);
+			tableModel.replace(nle, modelrow);
 	}
 
 	protected void mediumTypeSelected()


### PR DESCRIPTION
## Problem Description
In the Decodes Database Editor the Network List selects the wrong site after sorting the columns when doing a manual edit.  The Platforms also selects the wrong config when editing a platform.

## Solution
I modified the code to use the table model so the correct row is selected.

## how you tested the change
In the Decodes Database Editor go into the Network List, select a site and open it.  Sort the columns, select a site, select the Manual Edit button.  The correct site is selected.
On the Platforms tab select a platform and open it.  Then choose a different config.  Sort the columns, select a different config.  The correct config is selected.

## Where the following done:

- [x] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
