### PR TITLE
Set daemon thread true , only start one thread.

### DIFF
--- a/src/main/java/ilex/util/FileLogger.java
+++ b/src/main/java/ilex/util/FileLogger.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.io.*;
 import java.nio.channels.FileChannel;
 
@@ -27,7 +28,7 @@ public class FileLogger extends Logger
 	/**
 	* The current output PrintStream
 	*/
-	private PrintStream output = null;
+	private final AtomicReference<PrintStream> output = new AtomicReference<>();
 
 	/**
 	* The filename supplied to the constructor.
@@ -93,6 +94,28 @@ public class FileLogger extends Logger
 		this.filename = EnvExpander.expand(filename);
 		this.maxLength = maxLength;
 		openNewLog();
+		writerThread = new Thread(() ->
+			{
+				while(closeOperations.get() == false)
+				{
+					try
+					{
+						String msg = queue.poll(1, TimeUnit.SECONDS);
+						PrintStream ps = output.get();
+						if (msg != null && ps != null && !ps.checkError())
+						{
+							ps.println(msg);
+						}
+					}
+					catch (InterruptedException ex)
+					{
+
+					}
+				}
+			},
+			"FileLogger-Writer");
+		writerThread.setDaemon(true);
+		writerThread.start();
 	}
 
 	/**
@@ -100,14 +123,12 @@ public class FileLogger extends Logger
 	*/
 	public void close( )
 	{
-		closeOperations.set(true);
-		if (output != null)
+		PrintStream ps = output.getAndSet(null);
+		if (ps != null)
 		{
-			output.close();
+			ps.close();
 		}
 		fileChan = null;
-		output = null;
-		
 	}
 
 	/**
@@ -162,27 +183,7 @@ public class FileLogger extends Logger
 			} else {
 				os = new FileOutputStream(outputFile, appendFlag);
 			}
-			output = new PrintStream(os, true);
-			writerThread = new Thread(() ->
-			{
-				while(closeOperations.get() == false)
-				{
-					try
-					{
-						String msg = queue.poll(1, TimeUnit.SECONDS);
-						if (msg != null && output != null && !output.checkError())
-						{
-							output.println(msg);
-						}
-					}
-					catch (InterruptedException ex)
-					{
-
-					}
-				}
-			},
-			"FileLogger-Writer");
-			writerThread.start();
+			output.set(new PrintStream(os, true));
 		}
 		catch(IOException ex)
 		{
@@ -210,7 +211,7 @@ public class FileLogger extends Logger
 	*/
 	public PrintStream getLogOutput( )
 	{
-		return output;
+		return output.get();
 	}
 
 	/**


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #. 

<!-- if you are referencing a specific issue a problem description is not required -->
@baoyuyin reported rs finishing but never cloising, FileLogger thread was not set to Daemon thread and most likely holding it open (will test a command line rs tomorrow, don't use it in the home lab.)
## Solution

Set the thread to a daemon thread. Additionally made it so FileLogger only opens one thread, not constantly making new ones.

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
