### PR TITLE
Bugfix/540 msgaccess display next

### DIFF
--- a/src/main/java/lrgs/gui/MessageBrowser.java
+++ b/src/main/java/lrgs/gui/MessageBrowser.java
@@ -909,17 +909,18 @@ public class MessageBrowser extends MenuFrame
         // anything has been changed in it.
         if (scedit != null)
         {
-            if (firstAfterConnect || scedit.isChanged())
+            if (firstAfterConnect)
             {
                 // They are different!
-                searchcrit = new SearchCriteria();
-                scedit.fillSearchCrit(searchcrit);
+                searchcrit = scedit.getCurrenCriteria();
                 needToSendSC = true;
             }
             // Else no changes have been made in the editor.
             else
             {
-                needToSendSC = false;
+                SearchCriteria fromEditor = scedit.getCurrenCriteria();
+                needToSendSC = !fromEditor.equals(searchcrit);
+                searchcrit = fromEditor;
             }
         }
         // Else no editor active, just go by the filename specified.
@@ -929,7 +930,7 @@ public class MessageBrowser extends MenuFrame
             File f = new File(curSCName);
             try
             {
-                searchcrit.parseFile(f);
+                searchcrit = new SearchCriteria(f);
             }
             catch(Exception ioe)
             {
@@ -941,7 +942,7 @@ public class MessageBrowser extends MenuFrame
                         f.createNewFile(); 
                         try 
                         {
-                            searchcrit.parseFile(f);
+                            searchcrit = new SearchCriteria(f);
                         }
                         catch(Exception ex) {}
                     }

--- a/src/main/java/lrgs/gui/SearchCriteriaEditFrame.java
+++ b/src/main/java/lrgs/gui/SearchCriteriaEditFrame.java
@@ -16,6 +16,7 @@ import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 import java.io.File;
 import java.io.IOException;
 
@@ -44,6 +45,7 @@ public class SearchCriteriaEditFrame
 	private File scFile = null;
 	private boolean autoSave = false;
 	private SearchCritEditorParent parent = null;
+	private SearchCriteria searchCriteria = null;
 
 	
 	public SearchCriteriaEditFrame()
@@ -64,7 +66,8 @@ public class SearchCriteriaEditFrame
 			return;
 		try
 		{
-			scePanel.setSearchCrit(new SearchCriteria(scFile));
+			searchCriteria = new SearchCriteria(scFile);
+			scePanel.setSearchCrit(searchCriteria);
 		}
 		catch(Exception ex)
 		{
@@ -139,12 +142,20 @@ public class SearchCriteriaEditFrame
 
 		filechooser.setCurrentDirectory(
 			new File(System.getProperty("user.dir")));
+
+		this.addWindowListener(new WindowAdapter() {
+			@Override
+			public void windowClosed(WindowEvent e) {
+				exitPressed();
+				super.windowClosed(e);
+			}
+		});
 	}
 	
 	
 	protected void exitPressed()
 	{
-		if (scePanel.hasChanged())
+		if (this.isChanged())
 		{
 			if (autoSave && scFile != null)
 				savePressed();
@@ -178,11 +189,11 @@ public class SearchCriteriaEditFrame
 			saveAsPressed();
 			return;
 		}
-		SearchCriteria sc = new SearchCriteria();
-		scePanel.fillSearchCrit(sc);
+		SearchCriteria sc = scePanel.getCurrentCriteria();
 		try
 		{
 			sc.saveFile(scFile);
+			searchCriteria = sc;
 		}
 		catch (IOException ex)
 		{
@@ -230,7 +241,7 @@ public class SearchCriteriaEditFrame
 	 */
 	private boolean checkDiscard()
 	{
-		if (!scePanel.hasChanged())
+		if (!this.isChanged())
 			return true;
 		return showConfirm("Confirm Search Criteria", 
 			"Search criteria have been modified. Discard changes?", 
@@ -299,7 +310,9 @@ public class SearchCriteriaEditFrame
 	@Override
 	public boolean isChanged()
 	{
-		return scePanel.hasChanged();
+		SearchCriteria fromEdit = scePanel.getCurrentCriteria();
+
+		return !searchCriteria.equals(fromEdit);
 	}
 
 	public void launch( int x, int y, int w, int h )
@@ -338,6 +351,12 @@ public class SearchCriteriaEditFrame
 //				}
 //			});
 
+	}
+
+	@Override
+	public SearchCriteria getCurrenCriteria()
+	{
+		return scePanel.getCurrentCriteria();
 	}
 
 }

--- a/src/main/java/lrgs/gui/SearchCriteriaEditPanel.java
+++ b/src/main/java/lrgs/gui/SearchCriteriaEditPanel.java
@@ -63,6 +63,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.EtchedBorder;
 import javax.swing.table.AbstractTableModel;
 
+import decodes.cwms.validation.ScreeningCriteria;
 import decodes.db.Database;
 import decodes.db.NetworkList;
 import decodes.db.Platform;
@@ -176,9 +177,23 @@ public class SearchCriteriaEditPanel
 	{
 		if (origSearchCrit == null)
 			return false;
-		SearchCriteria test = new SearchCriteria();
-		fillSearchCrit(test);
-		return !test.equals(origSearchCrit);
+		SearchCriteria test = getCurrentCriteria();
+		if (!test.equals(origSearchCrit))
+		{
+			origSearchCrit = test;
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	public SearchCriteria getCurrentCriteria()
+	{
+		SearchCriteria ret = new SearchCriteria();
+		fillSearchCrit(ret);
+		return ret;
 	}
 	
 	/**

--- a/src/main/java/lrgs/gui/SearchCriteriaEditPanel.java
+++ b/src/main/java/lrgs/gui/SearchCriteriaEditPanel.java
@@ -178,15 +178,7 @@ public class SearchCriteriaEditPanel
 		if (origSearchCrit == null)
 			return false;
 		SearchCriteria test = getCurrentCriteria();
-		if (!test.equals(origSearchCrit))
-		{
-			origSearchCrit = test;
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return !test.equals(origSearchCrit);
 	}
 
 	public SearchCriteria getCurrentCriteria()

--- a/src/main/java/lrgs/gui/SearchCriteriaEditor.java
+++ b/src/main/java/lrgs/gui/SearchCriteriaEditor.java
@@ -816,4 +816,10 @@ public class SearchCriteriaEditor extends MenuFrame
 		me.startup(100, 100);
 	}
 
+	@Override
+	public SearchCriteria getCurrenCriteria()
+	{
+		return searchcrit;
+	}
+
 }

--- a/src/main/java/lrgs/gui/SearchCriteriaEditorIF.java
+++ b/src/main/java/lrgs/gui/SearchCriteriaEditorIF.java
@@ -34,6 +34,8 @@ public interface SearchCriteriaEditorIF
 	/** Fills the search crit with the contents of the GUI controls */
 	public void fillSearchCrit(SearchCriteria searchcrit);
 
+	public SearchCriteria getCurrenCriteria();
+
 	public boolean isChanged();
 
 	public void toFront();


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #540 . 

When the Search Criteria edit panel was open the hasChange check would always return true as it wasn't tracking that
the newested critieria was already sent.

## Solution

Modified tracking of current Search Criteria to an appropriate place to determine change. MessageBrowser itself, and the SearchCriteriaFrame (to handle if it should save) were modified to be responsible for tracking their respective states.
SearchCriteriaEditPanel just provides the current SearchCriteria for comparisons elsewhere.

## how you tested the change

Manually.
- Open MessageBrowser (msgaccess)
- Open SearchCriteriaEdit
- Connect to LRGS
- Click display next several times, see correct result
- Make edit in criteria editor
- Click display next several times, see correct result.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
