### PR TITLE
Implement code to correctly determine active flags when saving criteria.

### DIFF
--- a/src/main/java/decodes/cwms/validation/Screening.java
+++ b/src/main/java/decodes/cwms/validation/Screening.java
@@ -36,8 +36,8 @@ import ilex.util.Logger;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.TimeZone;
+import java.util.function.Function;
 
 import opendcs.dao.CachableDbObject;
 import decodes.db.EngineeringUnit;
@@ -105,6 +105,46 @@ public class Screening
 		this.checkUnitsAbbr = checkUnitsAbbr;
 	}
 
+	/**
+	 * Updates the screening flags based on List of ScreeningCriteria
+	 * @param season List of ScreeningCriteria to apply
+	 */
+	public void updateActiveFlags(ArrayList<ScreeningCriteria> season)
+	{
+		boolean rangeActive = false;
+		boolean constActive = false;
+		boolean rocActive = false;
+		boolean durMagActive = false;
+		for (ScreeningCriteria crit: season)
+		{
+			if (crit.hasAbs())
+			{
+				rangeActive = true;
+			}
+			if (crit.hasConst())
+			{
+				constActive = true;
+			}
+			if (crit.hasRoc())
+			{
+				rocActive = true;
+			}
+			if (crit.hasDurMag())
+			{
+				durMagActive = true;
+			}
+		}
+
+		setRangeActive(rangeActive);
+		setConstActive(constActive);
+		setRocActive(rocActive);
+		setDurMagActive(durMagActive);
+	}
+
+
+
+
+
 	public DbKey getScreeningCode()
 	{
 		return screeningCode;
@@ -127,7 +167,7 @@ public class Screening
 	
 	/**
 	 * Adds a screening criteria and keeps the set in order.
-	 * @param screeningCriteria
+	 * @param screeningCriteria to be added
 	 */
 	public void add(ScreeningCriteria screeningCriteria)
 	{

--- a/src/main/java/decodes/cwms/validation/ScreeningCriteria.java
+++ b/src/main/java/decodes/cwms/validation/ScreeningCriteria.java
@@ -30,6 +30,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.TreeSet;
+import java.util.function.Function;
 
 import decodes.cwms.CwmsFlags;
 import decodes.db.UnitConverter;
@@ -786,4 +787,64 @@ public class ScreeningCriteria
 		rocPerHourChecks.clear();
 		durCheckPeriods.clear();
 	}
+
+	protected boolean hasAbs()
+	{
+		Function<AbsCheck,Boolean> check = (AbsCheck c) ->
+		{
+			return c != null
+					&& (c.getHigh() != Double.NEGATIVE_INFINITY
+					|| c.getLow() != Double.NEGATIVE_INFINITY);
+		};
+		AbsCheck rejected = getAbsCheckFor('R');
+		AbsCheck question = getAbsCheckFor('Q');
+		return (check.apply(rejected) || check.apply(question));
+	}
+	protected boolean hasConst()
+	{
+		Function<ConstCheck,Boolean> check = (ConstCheck c) ->
+		{
+			return c != null
+					&& (c.getTolerance() != Double.NEGATIVE_INFINITY
+					|| c.getAllowedMissing() != Integer.MIN_VALUE
+					|| c.getMinToCheck() != Double.NEGATIVE_INFINITY);
+		};
+		ConstCheck reject = getConstCheckFor('R');
+		ConstCheck question = getConstCheckFor('Q');
+		return check.apply(reject) || check.apply(question);
+	}
+
+	protected boolean hasRoc()
+	{
+		Function<RocPerHourCheck,Boolean> check = (RocPerHourCheck c) ->
+		{
+			return c != null
+					&& (c.getFall() != Double.NEGATIVE_INFINITY
+					|| c.getRise() != Double.NEGATIVE_INFINITY);
+		};
+		RocPerHourCheck reject = getRocCheckFor('R');
+		RocPerHourCheck question = getRocCheckFor('Q');
+		return check.apply(reject) || check.apply(question);
+	}
+
+	protected boolean hasDurMag()
+	{
+		Function<DurCheckPeriod,Boolean> check = (DurCheckPeriod c) ->
+		{
+			return c != null
+					&& (c.getHigh() != Double.NEGATIVE_INFINITY
+					|| c.getLow() != Double.NEGATIVE_INFINITY);
+
+		};
+		boolean ret = false;
+		for	(DurCheckPeriod c: getDurCheckPeriods())
+		{
+			if (check.apply(c))
+			{
+				ret = true;
+			}
+		}
+		return ret;
+	}
+
 }

--- a/src/main/java/decodes/cwms/validation/dao/ScreeningDAO.java
+++ b/src/main/java/decodes/cwms/validation/dao/ScreeningDAO.java
@@ -259,8 +259,8 @@ public class ScreeningDAO
             List<ScreenCritType> oracleScreenCritArray = Arrays.asList(oracleScreenCrit);
 
             ScreeningControlT screenControlType = new ScreeningControlT(
-                screening.isRangeActive() ? "T" : "F",
                 screening.isRocActive() ? "T" : "F",
+                screening.isRangeActive() ? "T" : "F",
                 screening.isConstActive() ? "T" : "F",
                 screening.isDurMagActive() ? "T" : "F");
 

--- a/src/main/java/decodes/cwms/validation/gui/ScreeningEditTab.java
+++ b/src/main/java/decodes/cwms/validation/gui/ScreeningEditTab.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -42,9 +44,14 @@ import javax.swing.JTabbedPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
+import javax.swing.SwingWorker;
 
 import opendcs.dai.IntervalDAI;
 import decodes.cwms.CwmsTimeSeriesDb;
+import decodes.cwms.validation.AbsCheck;
+import decodes.cwms.validation.ConstCheck;
+import decodes.cwms.validation.DurCheckPeriod;
+import decodes.cwms.validation.RocPerHourCheck;
 import decodes.cwms.validation.Screening;
 import decodes.cwms.validation.ScreeningCriteria;
 import decodes.cwms.validation.dao.ScreeningDAI;
@@ -74,7 +81,7 @@ public class ScreeningEditTab extends JPanel
 	private JLabel unitsLabel = new JLabel("(undefined)");
 	private int currentUnitsSystem = 0;
 	private SimpleDateFormat sdf = new SimpleDateFormat("MMM dd");
-	private boolean committed = false;
+	private AtomicBoolean committed = new AtomicBoolean(false);
 	private JButton paramButton = null;
 
 	
@@ -479,7 +486,7 @@ public class ScreeningEditTab extends JPanel
 
 	protected void closePressed()
 	{
-		if (!committed)
+		if (!committed.get())
 		{
 			int r = JOptionPane.showConfirmDialog(frame, "Save Changes?", "Save Changes?", 
 				JOptionPane.YES_NO_CANCEL_OPTION);
@@ -496,9 +503,15 @@ public class ScreeningEditTab extends JPanel
 		for(int idx = 0; idx < seasonsPane.getComponentCount(); idx++)
 			if (!((SeasonCheckPanel)seasonsPane.getComponentAt(idx)).validateFields())
 				return;
-		
+		ArrayList<ScreeningCriteria> seasons = new ArrayList<>();
 		for(int idx = 0; idx < seasonsPane.getComponentCount(); idx++)
-			((SeasonCheckPanel)seasonsPane.getComponentAt(idx)).saveFields();
+		{
+			SeasonCheckPanel scp = (SeasonCheckPanel)seasonsPane.getComponentAt(idx);
+			scp.saveFields();
+			seasons.add(scp.getSeason());
+			
+		}
+		correctActiveFlags(screening, seasons);
 		
 		screening.setParamId(paramField.getText().trim());
 		screening.setDurationId((String)durationCombo.getSelectedItem());
@@ -507,33 +520,127 @@ public class ScreeningEditTab extends JPanel
 		screening.setCheckUnitsAbbr(s.substring(1, s.length()-1));
 		screening.setScreeningDesc(descArea.getText());
 
-		ScreeningDAI screeningDAO = null;
-		try
+		final SwingWorker<Void,Void> w = new SwingWorker<Void,Void>()
 		{
-			screeningDAO = frame.getTheDb().makeScreeningDAO();
-			
-			// If screening ID was changed. Need to rename it in the DB before making updates.
-			if (!screening.getScreeningName().equals(screeningIdField.getText()))
+			@Override
+			protected Void doInBackground() throws Exception
 			{
-				screeningDAO.renameScreening(screening.getScreeningName(), screeningIdField.getText());
-				screening.setScreeningName(screeningIdField.getText());
-			}
+				try (ScreeningDAI screeningDAO = frame.getTheDb().makeScreeningDAO())
+				{
+					// If screening ID was changed. Need to rename it in the DB before making updates.
+					if (!screening.getScreeningName().equals(screeningIdField.getText()))
+					{
+						screeningDAO.renameScreening(screening.getScreeningName(), screeningIdField.getText());
+						screening.setScreeningName(screeningIdField.getText());
+					}
 
-			screeningDAO.writeScreening(screening);
-		}
-		catch(Exception ex)
-		{
-			frame.showError("Error writing screening '" + screening.getScreeningName()
-				+ "': " + ex);
-		}
-		finally
-		{
-			if (screeningDAO != null)
-				screeningDAO.close();
-		}
-		committed = true;
+					screeningDAO.writeScreening(screening);
+					committed.set(true);
+				}
+				catch(Exception ex)
+				{
+					frame.showError("Error writing screening '" + screening.getScreeningName()
+						+ "': " + ex);
+				}
+				return null;
+			}
+		};
+		w.execute();
+
 	}
 
+
+	private static void correctActiveFlags(Screening screening, ArrayList<ScreeningCriteria> season)
+	{
+		boolean rangeActive = false;
+		boolean constActive = false;
+		boolean rocActive = false;
+		boolean durMagActive = false;
+		for (ScreeningCriteria crit: season)
+		{
+			if (hasAbs(crit))
+			{
+				rangeActive = true;
+			}
+			if (hasConst(crit))
+			{
+				constActive = true;
+			}
+			if (hasRoc(crit))
+			{
+				rocActive = true;
+			}
+			if (hasDurMag(crit))
+			{
+				durMagActive = true;
+			}
+		}
+
+		screening.setRangeActive(rangeActive);
+		screening.setConstActive(constActive);
+		screening.setRocActive(rocActive);
+		screening.setDurMagActive(durMagActive);
+	}
+
+	private static boolean hasAbs(ScreeningCriteria crit)
+	{
+		Function<AbsCheck,Boolean> check = (AbsCheck c) ->
+		{
+			return c != null
+				&& (c.getHigh() != Double.NEGATIVE_INFINITY 
+				|| c.getLow() != Double.NEGATIVE_INFINITY);
+		};
+		AbsCheck rejected = crit.getAbsCheckFor('R');
+		AbsCheck question = crit.getAbsCheckFor('Q');
+		return (check.apply(rejected) || check.apply(question));
+	}
+
+	private static boolean hasConst(ScreeningCriteria crit)
+	{
+		Function<ConstCheck,Boolean> check = (ConstCheck c) ->
+		{
+			return c != null
+				&& (c.getTolerance() != Double.NEGATIVE_INFINITY
+				|| c.getAllowedMissing() != Integer.MIN_VALUE
+				|| c.getMinToCheck() != Double.NEGATIVE_INFINITY);
+		};
+		ConstCheck reject = crit.getConstCheckFor('R');
+		ConstCheck question = crit.getConstCheckFor('Q');
+		return check.apply(reject) || check.apply(question);
+	}
+
+	private static boolean hasRoc(ScreeningCriteria crit)
+	{
+		Function<RocPerHourCheck,Boolean> check = (RocPerHourCheck c) ->
+		{
+			return c != null
+				&& (c.getFall() != Double.NEGATIVE_INFINITY
+				|| c.getRise() != Double.NEGATIVE_INFINITY);
+		};
+		RocPerHourCheck reject = crit.getRocCheckFor('R');
+		RocPerHourCheck question = crit.getRocCheckFor('Q');
+		return check.apply(reject) || check.apply(question);
+	}
+
+	private static boolean hasDurMag(ScreeningCriteria crit)
+	{
+		Function<DurCheckPeriod,Boolean> check = (DurCheckPeriod c) ->
+		{
+			return c != null
+				&& (c.getHigh() != Double.NEGATIVE_INFINITY
+				|| c.getLow() != Double.NEGATIVE_INFINITY);
+
+		};
+		boolean ret = false;
+		for	(DurCheckPeriod c: crit.getDurCheckPeriods())
+		{
+			if (check.apply(c))
+			{
+				ret = true;
+			}
+		}
+		return ret;
+	}
 
 	protected void paramPressed()
 	{

--- a/src/main/java/decodes/cwms/validation/gui/ScreeningEditTab.java
+++ b/src/main/java/decodes/cwms/validation/gui/ScreeningEditTab.java
@@ -32,7 +32,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -48,10 +47,6 @@ import javax.swing.SwingWorker;
 
 import opendcs.dai.IntervalDAI;
 import decodes.cwms.CwmsTimeSeriesDb;
-import decodes.cwms.validation.AbsCheck;
-import decodes.cwms.validation.ConstCheck;
-import decodes.cwms.validation.DurCheckPeriod;
-import decodes.cwms.validation.RocPerHourCheck;
 import decodes.cwms.validation.Screening;
 import decodes.cwms.validation.ScreeningCriteria;
 import decodes.cwms.validation.dao.ScreeningDAI;
@@ -511,8 +506,8 @@ public class ScreeningEditTab extends JPanel
 			seasons.add(scp.getSeason());
 			
 		}
-		correctActiveFlags(screening, seasons);
-		
+		screening.updateActiveFlags(seasons);
+
 		screening.setParamId(paramField.getText().trim());
 		screening.setDurationId((String)durationCombo.getSelectedItem());
 		screening.setParamTypeId((String)paramTypeCombo.getSelectedItem());
@@ -549,98 +544,6 @@ public class ScreeningEditTab extends JPanel
 
 	}
 
-
-	private static void correctActiveFlags(Screening screening, ArrayList<ScreeningCriteria> season)
-	{
-		boolean rangeActive = false;
-		boolean constActive = false;
-		boolean rocActive = false;
-		boolean durMagActive = false;
-		for (ScreeningCriteria crit: season)
-		{
-			if (hasAbs(crit))
-			{
-				rangeActive = true;
-			}
-			if (hasConst(crit))
-			{
-				constActive = true;
-			}
-			if (hasRoc(crit))
-			{
-				rocActive = true;
-			}
-			if (hasDurMag(crit))
-			{
-				durMagActive = true;
-			}
-		}
-
-		screening.setRangeActive(rangeActive);
-		screening.setConstActive(constActive);
-		screening.setRocActive(rocActive);
-		screening.setDurMagActive(durMagActive);
-	}
-
-	private static boolean hasAbs(ScreeningCriteria crit)
-	{
-		Function<AbsCheck,Boolean> check = (AbsCheck c) ->
-		{
-			return c != null
-				&& (c.getHigh() != Double.NEGATIVE_INFINITY 
-				|| c.getLow() != Double.NEGATIVE_INFINITY);
-		};
-		AbsCheck rejected = crit.getAbsCheckFor('R');
-		AbsCheck question = crit.getAbsCheckFor('Q');
-		return (check.apply(rejected) || check.apply(question));
-	}
-
-	private static boolean hasConst(ScreeningCriteria crit)
-	{
-		Function<ConstCheck,Boolean> check = (ConstCheck c) ->
-		{
-			return c != null
-				&& (c.getTolerance() != Double.NEGATIVE_INFINITY
-				|| c.getAllowedMissing() != Integer.MIN_VALUE
-				|| c.getMinToCheck() != Double.NEGATIVE_INFINITY);
-		};
-		ConstCheck reject = crit.getConstCheckFor('R');
-		ConstCheck question = crit.getConstCheckFor('Q');
-		return check.apply(reject) || check.apply(question);
-	}
-
-	private static boolean hasRoc(ScreeningCriteria crit)
-	{
-		Function<RocPerHourCheck,Boolean> check = (RocPerHourCheck c) ->
-		{
-			return c != null
-				&& (c.getFall() != Double.NEGATIVE_INFINITY
-				|| c.getRise() != Double.NEGATIVE_INFINITY);
-		};
-		RocPerHourCheck reject = crit.getRocCheckFor('R');
-		RocPerHourCheck question = crit.getRocCheckFor('Q');
-		return check.apply(reject) || check.apply(question);
-	}
-
-	private static boolean hasDurMag(ScreeningCriteria crit)
-	{
-		Function<DurCheckPeriod,Boolean> check = (DurCheckPeriod c) ->
-		{
-			return c != null
-				&& (c.getHigh() != Double.NEGATIVE_INFINITY
-				|| c.getLow() != Double.NEGATIVE_INFINITY);
-
-		};
-		boolean ret = false;
-		for	(DurCheckPeriod c: crit.getDurCheckPeriods())
-		{
-			if (check.apply(c))
-			{
-				ret = true;
-			}
-		}
-		return ret;
-	}
 
 	protected void paramPressed()
 	{

--- a/src/main/java/decodes/cwms/validation/gui/ScreeningEditor.java
+++ b/src/main/java/decodes/cwms/validation/gui/ScreeningEditor.java
@@ -57,7 +57,7 @@ public class ScreeningEditor extends TsdbAppTemplate
 	{
 		if (DecodesInterface.isInitialized())
 			return;
-		DecodesInterface.initDecodesMinimal(cmdLineArgs.getPropertiesFile());
+		DecodesInterface.initDecodesMinimal(cmdLineArgs.getProfile().getFile().getAbsolutePath());
 		DecodesInterface.readSiteList();
 		Database.getDb().dataTypeSet.read();
 	}


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #507. 

<!-- if you are referencing a specific issue a problem description is not required -->


## Solution

Determined that the following was happening:
- CWMS Office Code was never getting set, so nothing was getting saved correctly.
- Active Flags were only set on either initial creation, or retrieval (whatever they were) and would never change.
- This caused the screeningalgorithm to skip doing the checks, even though all the data was there.

I corrected the Correct office code situation and implemented code that would determine, based on configured data, what the active flags should be.

Also corrected order of parameters for the ScreeningControlType constructor.

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

I'm going to try and create some tests later. There's a few in the old regression tests already but I'd also like to test the save/load case.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
