### PR TITLE
Bugfix/sensor config property list sorting

### DIFF
--- a/src/main/java/decodes/cwms/CwmsConstants.java
+++ b/src/main/java/decodes/cwms/CwmsConstants.java
@@ -51,6 +51,7 @@ public class CwmsConstants
 	public static final String CWMS_PARAM_TYPE = "CwmsParamType";
 	/** The Constant to get Cwms duration from properties */
 	public static final String CWMS_DURATION = "CwmsDuration";
+	public static final String CWMS_INTERVAL = "cwmsInterval";
 	public static final String CWMS_VERSION = "CwmsVersion";
 	public static final String CWMS_STORE_RULE = "storerule";
 	public static final String CWMS_OVERRIDE_PROT = "overrideprot";

--- a/src/main/java/decodes/db/ConfigSensor.java
+++ b/src/main/java/decodes/db/ConfigSensor.java
@@ -126,6 +126,9 @@ public class ConfigSensor
 			"Duration to use in Time Series ID in CWMS Consumer"),
 		new PropertySpec(CwmsConstants.CWMS_VERSION, PropertySpec.STRING,
 			"Version to use in Time Series ID in CWMS Consumer"),
+		new PropertySpec(CwmsConstants.CWMS_INTERVAL, PropertySpec.STRING,
+			"Interval to use instead of using the set interval. For example if you need ~15Minutes."
+			),
 		new PropertySpec("interval", PropertySpec.STRING,
 			"In HDB Consumer, use this for the INTERVAL part of Time Series ID."),
 		new PropertySpec("modeled", PropertySpec.BOOLEAN,
@@ -416,4 +419,3 @@ public class ConfigSensor
 		PropertiesUtil.rmIgnoreCase(getProperties(), name);
 	}
 }
-

--- a/src/main/java/decodes/gui/PropertiesEditPanel.java
+++ b/src/main/java/decodes/gui/PropertiesEditPanel.java
@@ -140,7 +140,8 @@ public class PropertiesEditPanel extends JPanel
 			if (propHash != null)
 			{
 				// property name is in column 0
-				String pn = ((String) ptm.getValueAt(row, 0)).toUpperCase();
+				int modelRow = table.convertRowIndexToModel(row);
+				String pn = ((String) ptm.getValueAt(modelRow, 0)).toUpperCase();
 				PropertySpec ps = propHash.get(pn);
 				cr.setToolTipText(ps != null ? ps.getDescription() : "");
 //if (ps == null) System.out.println("No propHash entry for '" + pn + "'");


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Discovered the tool tips wouldn't render correctly if you sorted the properties while reviewing adding a decodes script sensor.
Additional a property was "hidden" from the user so it was added.

## Solution

Cell renderer properly converts to the table row to the model row before lookup.
Added property to ConfigSensor so users are aware they can't manually specify the interval if needed.

## how you tested the change

Manually, creating a sensor and looking at the tool tips. User who reported the issue verify data would save to the CWMS database if the property was set. This change just fixes the properties sorting and adds the property to the list by default so users can be aware of it.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
