### PR TITLE
User color chooser for color setting properties.

### DIFF
--- a/src/main/java/decodes/gui/PropertiesEditPanel.java
+++ b/src/main/java/decodes/gui/PropertiesEditPanel.java
@@ -9,7 +9,6 @@ import java.awt.*;
 import javax.swing.*;
 import javax.swing.table.*;
 
-import org.cobraparser.html.style.TableCellRenderState;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;

--- a/src/main/java/decodes/gui/PropertyEditDialog.java
+++ b/src/main/java/decodes/gui/PropertyEditDialog.java
@@ -244,6 +244,11 @@ public class PropertyEditDialog
 				ta.setWrapStyleWord(true);
 				valueField = ta;
 			}
+			else if (propSpec.getType().equals(PropertySpec.COLOR))
+			{
+				JColorChooser jc = new JColorChooser();
+				valueField = jc;
+			}
 		}
 
 		if (valueField instanceof JTextArea)
@@ -437,6 +442,12 @@ System.out.println("PropertyEditDialog.okPressed: set prop '" + propSpec.getName
 		{
 			return ((JComboBox)valueField).getSelectedItem().toString();
 		}
+		else if (valueField instanceof JColorChooser)
+		{
+			final JColorChooser jc = (JColorChooser)this.valueField;
+			Color c = jc.getColor();
+			return "0x" + Integer.toHexString(c.getRGB()).substring(2) ;
+		}
 		else
 		{
 			return "";
@@ -476,6 +487,15 @@ System.out.println("PropertyEditDialog.okPressed: set prop '" + propSpec.getName
 		else if (valueField instanceof JComboBox)
 		{
 			((JComboBox)valueField).setSelectedItem(value);
+		}
+		else if (valueField instanceof JColorChooser)
+		{
+			final JColorChooser jc = (JColorChooser)valueField;
+			if (value.toLowerCase().startsWith("0x"))
+			{
+				int colorValue = Integer.parseInt(value.substring(2), 16);
+				jc.setColor(Color.getColor("",colorValue));
+			}
 		}
 	}
 	

--- a/src/main/java/decodes/util/DecodesSettings.java
+++ b/src/main/java/decodes/util/DecodesSettings.java
@@ -508,52 +508,52 @@ public class DecodesSettings
             "Name of the routing spec that PollGUI uses for TCP Platforms"),
         new PropertySpec("rememberScreenPosition", PropertySpec.BOOLEAN,
             "Remember position and size of GUI screens when they are moved."),
-        new PropertySpec("decodeScriptColor1", PropertySpec.STRING,
+        new PropertySpec("decodeScriptColor1", PropertySpec.COLOR,
             "Hex color representation for decoded-data color 1. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values. Default=0000FF "),
-        new PropertySpec("decodeScriptColor2", PropertySpec.STRING,
+        new PropertySpec("decodeScriptColor2", PropertySpec.COLOR,
             "Hex color representation for decoded-data color 2. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values. Default=00FFFF "),
-        new PropertySpec("decodeScriptColor3", PropertySpec.STRING,
+        new PropertySpec("decodeScriptColor3", PropertySpec.COLOR,
             "Hex color representation for decoded-data color 3. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values. Default=D2691E "),
-        new PropertySpec("decodeScriptColor4", PropertySpec.STRING,
+        new PropertySpec("decodeScriptColor4", PropertySpec.COLOR,
             "Hex color representation for decoded-data color 4. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values. Default=00D000 "),
-        new PropertySpec("decodeScriptColor5", PropertySpec.STRING,
+        new PropertySpec("decodeScriptColor5", PropertySpec.COLOR,
             "Hex color representation for decoded-data color 5. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values. Default=8B0000 "),
-        new PropertySpec("decodeScriptColor6", PropertySpec.STRING,
+        new PropertySpec("decodeScriptColor6", PropertySpec.COLOR,
             "Hex color representation for decoded-data color 6. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values. Default=4B0082 "),
-        new PropertySpec("decodeScriptColor7", PropertySpec.STRING,
+        new PropertySpec("decodeScriptColor7", PropertySpec.COLOR,
             "Hex color representation for decoded-data color 7. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values. Default=808000 "),
-        new PropertySpec("decodeScriptColor8", PropertySpec.STRING,
+        new PropertySpec("decodeScriptColor8", PropertySpec.COLOR,
             "Hex color representation for decoded-data color 8. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values. Default=8B4513 "),
-        new PropertySpec("pyNormalColor", PropertySpec.STRING,
+        new PropertySpec("pyNormalColor", PropertySpec.COLOR,
             "Hex color representation for normal text in a python script. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values."),
-        new PropertySpec("pyKeywordColor", PropertySpec.STRING,
+        new PropertySpec("pyKeywordColor", PropertySpec.COLOR,
             "Hex color representation for keywords in a python script. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values."),
-        new PropertySpec("pyBuiltinColor", PropertySpec.STRING,
+        new PropertySpec("pyBuiltinColor", PropertySpec.COLOR,
             "Hex color representation for built-in functions in a python script. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values."),
-        new PropertySpec("pyQuotedColor", PropertySpec.STRING,
+        new PropertySpec("pyQuotedColor", PropertySpec.COLOR,
             "Hex color representation for quoted strings in a python script. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values."),
-        new PropertySpec("pyTsRoleColor", PropertySpec.STRING,
+        new PropertySpec("pyTsRoleColor", PropertySpec.COLOR,
             "Hex color representation for time series roles in a python script. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values."),
-        new PropertySpec("pyPropColor", PropertySpec.STRING,
+        new PropertySpec("pyPropColor", PropertySpec.COLOR,
             "Hex color representation for comp-property names in a python script. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values."),
-        new PropertySpec("pyCommentColor", PropertySpec.STRING,
+        new PropertySpec("pyCommentColor", PropertySpec.COLOR,
             "Hex color representation for comments in a python script. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values."),
-        new PropertySpec("pyCpFuncColor", PropertySpec.STRING,
+        new PropertySpec("pyCpFuncColor", PropertySpec.COLOR,
             "Hex color representation for CP Function Names in a python script. Should be 6 digits."
             + " That is, 2 hex digits each for the RGB values."),
         new PropertySpec("screeningUnitSystem",

--- a/src/main/java/decodes/util/PropertySpec.java
+++ b/src/main/java/decodes/util/PropertySpec.java
@@ -54,6 +54,8 @@ public class PropertySpec
 	
 	/** A long string property that should be displayed in a multi-line TextArea */
 	public static final String LONGSTRING = "l";
+
+	public static final String COLOR = "color";
 	
 	private boolean dynamic = false;
 	


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #548. 

<!-- if you are referencing a specific issue a problem description is not required -->

## Solution

Implement a new PropertySpec type and Change all instances of Color (in the user.properties) to use it.
The properties file still uses the standard 0x prefixed HEX value, but I'm not opposed to the work of allow additional formats)

## how you tested the change

Manually. Open the properties editor for the database, see the colors selected in the properties list, on clicking edit a JColorChooser pops up and allows selection by method of users choosing.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [x] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
