### PR TITLE
Refactor/tsdb caches

### DIFF
--- a/src/main/java/decodes/cwms/CwmsSiteDAO.java
+++ b/src/main/java/decodes/cwms/CwmsSiteDAO.java
@@ -71,6 +71,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.opendcs.database.DbObjectCache;
+
 import decodes.db.Constants;
 import decodes.db.Database;
 import decodes.db.Platform;
@@ -83,7 +85,7 @@ import decodes.tsdb.NoSuchObjectException;
 import decodes.tsdb.TsdbDatabaseVersion;
 import decodes.util.DecodesSettings;
 import opendcs.dao.DatabaseConnectionOwner;
-import opendcs.dao.DbObjectCache;
+import opendcs.dao.ScheduledReloadDbObjectCache;
 import opendcs.dao.SiteDAO;
 import usace.cwms.db.dao.ifc.loc.CwmsDbLoc;
 import usace.cwms.db.dao.util.services.CwmsDbServiceLookup;
@@ -444,7 +446,7 @@ public class CwmsSiteDAO extends SiteDAO
 	}
 	
 	@Override
-	public void fillCache()
+	public void fillCache(DbObjectCache<Site> cache)
 		throws DbIoException
 	{
 		debug3("CwmsSiteDAO.fillCache()");
@@ -515,7 +517,7 @@ public class CwmsSiteDAO extends SiteDAO
 			int nProps = 0;
 			if (db.getDecodesDatabaseVersion() >= DecodesDatabaseVersion.DECODES_DB_8)
 			{
-				nProps = propsDao.readPropertiesIntoCache("site_property", (DbObjectCache<?>) cache);
+				nProps = propsDao.readPropertiesIntoCache("site_property", cache);
 			}
 
 			debug1("Site Cache Filled: " + cache.size() + " sites, " + nNames[0]

--- a/src/main/java/decodes/cwms/CwmsSiteDAO.java
+++ b/src/main/java/decodes/cwms/CwmsSiteDAO.java
@@ -83,6 +83,7 @@ import decodes.tsdb.NoSuchObjectException;
 import decodes.tsdb.TsdbDatabaseVersion;
 import decodes.util.DecodesSettings;
 import opendcs.dao.DatabaseConnectionOwner;
+import opendcs.dao.DbObjectCache;
 import opendcs.dao.SiteDAO;
 import usace.cwms.db.dao.ifc.loc.CwmsDbLoc;
 import usace.cwms.db.dao.util.services.CwmsDbServiceLookup;
@@ -514,7 +515,7 @@ public class CwmsSiteDAO extends SiteDAO
 			int nProps = 0;
 			if (db.getDecodesDatabaseVersion() >= DecodesDatabaseVersion.DECODES_DB_8)
 			{
-				nProps = propsDao.readPropertiesIntoCache("site_property", cache);
+				nProps = propsDao.readPropertiesIntoCache("site_property", (DbObjectCache<?>) cache);
 			}
 
 			debug1("Site Cache Filled: " + cache.size() + " sites, " + nNames[0]

--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
@@ -698,8 +698,10 @@ import opendcs.dai.LoadingAppDAI;
 import opendcs.dai.ScheduleEntryDAI;
 import opendcs.dai.SiteDAI;
 import opendcs.dai.TimeSeriesDAI;
+import opendcs.dao.CachableDbObject;
 import opendcs.dao.DaoBase;
 import opendcs.dao.DaoHelper;
+import opendcs.dao.DbObjectCache;
 import opendcs.dao.LoadingAppDao;
 import opendcs.opentsdb.OpenTsdbSettings;
 import opendcs.util.sql.WrappedConnection;
@@ -1683,6 +1685,4 @@ public class CwmsTimeSeriesDb
 			Logger.instance().warning("Unable to close returned connection: " + ex.getLocalizedMessage());
 		}
 	}
-	
-	
 }

--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDb.java
@@ -786,7 +786,8 @@ public class CwmsTimeSeriesDb
 		curTimeName = "sysdate";
 		maxCompRetryTimeFrmt = "%d*1/24";
 		module = "CwmsTimeSeriesDb";
-		cacheMap.put(Screening.class,
+                // add Cwms specific cache
+		cacheMap.put(Screening.class,     
         new ScheduledReloadDbObjectCache<Screening>(SiteDAO.CACHE_MAX_AGE, false, (cache) ->
         {
         try (ScreeningDAI dao = this.makeScreeningDAO())
@@ -797,7 +798,7 @@ public class CwmsTimeSeriesDb
         {
             log.atError()
             .setCause(ex)
-            .log("Unable to refresh Site Cache.");
+            .log("Unable to refresh Screening Cache.");
         }
         }, cacheExecutor));
 	}

--- a/src/main/java/decodes/cwms/validation/dao/ScreeningDAI.java
+++ b/src/main/java/decodes/cwms/validation/dao/ScreeningDAI.java
@@ -9,6 +9,8 @@ package decodes.cwms.validation.dao;
 
 import java.util.List;
 
+import org.opendcs.database.DbObjectCache;
+
 import decodes.cwms.validation.Screening;
 import decodes.sql.DbKey;
 import decodes.tsdb.DbIoException;
@@ -59,6 +61,8 @@ public interface ScreeningDAI extends AutoCloseable
 	 * Clear any cached screenings. Used by GUI when Refresh is pressed.
 	 */
 	public void clearCache();
+
+	public void reloadCache(DbObjectCache<Screening> cache) throws DbIoException;
 	
 	/**
 	 * Used by GUI to populate the list tab.

--- a/src/main/java/decodes/hdb/Convert2Group.java
+++ b/src/main/java/decodes/hdb/Convert2Group.java
@@ -315,7 +315,7 @@ public class Convert2Group
 			while(rs != null && rs.next())
 				grpIds.add(DbKey.createDbKey(rs, 1));
 				
-			tsGroupDAO.fillCache();
+			tsGroupDAO.fillCache(theDb.getCache(TsGroup.class));
 
 			info("Expanding Groups in Cache...");
 			groupHelper.evalAll();

--- a/src/main/java/decodes/hdb/HdbSiteDAO.java
+++ b/src/main/java/decodes/hdb/HdbSiteDAO.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 
+import org.opendcs.database.DbObjectCache;
+
 import decodes.db.Constants;
 import decodes.db.Site;
 import decodes.db.SiteName;
@@ -17,7 +19,6 @@ import decodes.sql.DecodesDatabaseVersion;
 import decodes.tsdb.DbIoException;
 import decodes.tsdb.NoSuchObjectException;
 import opendcs.dao.DatabaseConnectionOwner;
-import opendcs.dao.DbObjectCache;
 import opendcs.dao.SiteDAO;
 
 public class HdbSiteDAO extends SiteDAO
@@ -554,13 +555,11 @@ debug3("HdbSiteDAO.lookupSiteID -- no match to any site name in cache.");
 	}
 
 	@Override
-	public void fillCache()
-		throws DbIoException
+	public void fillCache(DbObjectCache<Site> cache) throws DbIoException
 	{
 		debug3("(Generic)SiteDAO.fillCache()");
 
 		HashMap<DbKey, Site> siteHash = new HashMap<DbKey, Site>();
-//		ArrayList<Site> siteList = new ArrayList<Site>();
 		int nNames = 0;
 		String q = buildSiteQuery(Constants.undefinedId);
 		try
@@ -622,10 +621,12 @@ debug3("HdbSiteDAO.lookupSiteID -- no match to any site name in cache.");
 			throw new DbIoException(msg);
 		}
 		for(Site site : siteHash.values())
+		{
 			cache.put(site);
+		}
 		int nProps = 0;
 		if (db.getDecodesDatabaseVersion() >= DecodesDatabaseVersion.DECODES_DB_8)
-			nProps = propsDao.readPropertiesIntoCache("site_property", (DbObjectCache<?>)cache);
+			nProps = propsDao.readPropertiesIntoCache("site_property", cache);
 		debug1("Site Cache Filled: " + cache.size() + " sites, " + nNames
 			+ " names, " + nProps + " properties.");
 		lastCacheFillMsec = System.currentTimeMillis();

--- a/src/main/java/decodes/hdb/HdbSiteDAO.java
+++ b/src/main/java/decodes/hdb/HdbSiteDAO.java
@@ -17,6 +17,7 @@ import decodes.sql.DecodesDatabaseVersion;
 import decodes.tsdb.DbIoException;
 import decodes.tsdb.NoSuchObjectException;
 import opendcs.dao.DatabaseConnectionOwner;
+import opendcs.dao.DbObjectCache;
 import opendcs.dao.SiteDAO;
 
 public class HdbSiteDAO extends SiteDAO
@@ -624,7 +625,7 @@ debug3("HdbSiteDAO.lookupSiteID -- no match to any site name in cache.");
 			cache.put(site);
 		int nProps = 0;
 		if (db.getDecodesDatabaseVersion() >= DecodesDatabaseVersion.DECODES_DB_8)
-			nProps = propsDao.readPropertiesIntoCache("site_property", cache);
+			nProps = propsDao.readPropertiesIntoCache("site_property", (DbObjectCache<?>)cache);
 		debug1("Site Cache Filled: " + cache.size() + " sites, " + nNames
 			+ " names, " + nProps + " properties.");
 		lastCacheFillMsec = System.currentTimeMillis();

--- a/src/main/java/decodes/hdb/HdbTimeSeriesDb.java
+++ b/src/main/java/decodes/hdb/HdbTimeSeriesDb.java
@@ -127,7 +127,7 @@ import opendcs.dai.SiteDAI;
 import opendcs.dai.TimeSeriesDAI;
 import opendcs.dao.CachableDbObject;
 import opendcs.dao.DaoBase;
-import opendcs.dao.DbObjectCache;
+import opendcs.dao.ScheduledReloadDbObjectCache;
 import oracle.jdbc.OraclePreparedStatement;
 import ilex.util.Logger;
 import ilex.util.TextUtil;

--- a/src/main/java/decodes/hdb/HdbTimeSeriesDb.java
+++ b/src/main/java/decodes/hdb/HdbTimeSeriesDb.java
@@ -125,7 +125,9 @@ import opendcs.dai.IntervalDAI;
 import opendcs.dai.ScheduleEntryDAI;
 import opendcs.dai.SiteDAI;
 import opendcs.dai.TimeSeriesDAI;
+import opendcs.dao.CachableDbObject;
 import opendcs.dao.DaoBase;
+import opendcs.dao.DbObjectCache;
 import oracle.jdbc.OraclePreparedStatement;
 import ilex.util.Logger;
 import ilex.util.TextUtil;
@@ -1341,5 +1343,4 @@ public class HdbTimeSeriesDb
 	{
 		return HdbFlags.flag2HdbDerivation(flags);
 	}
-
 }

--- a/src/main/java/decodes/sql/SqlDatabaseIO.java
+++ b/src/main/java/decodes/sql/SqlDatabaseIO.java
@@ -316,7 +316,7 @@ public class SqlDatabaseIO
                         {
                             log.atError()
                             .setCause(ex)
-                            .log("Unable to refresh Site Cache.");
+                            .log("Unable to refresh TimeSeriesIdentifier Cache.");
                         }
                      }, cacheExecutor));
 
@@ -331,7 +331,7 @@ public class SqlDatabaseIO
                 {
                     log.atError()
                     .setCause(ex)
-                    .log("Unable to refresh Site Cache.");
+                    .log("Unable to refresh AlarmScreening Cache.");
                 }
             }, cacheExecutor));
         cacheMap.put(DbEnum.class,

--- a/src/main/java/decodes/tsdb/ComputationApp.java
+++ b/src/main/java/decodes/tsdb/ComputationApp.java
@@ -119,14 +119,15 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.TimeZone;
+
+import org.opendcs.database.DbObjectCache;
+
 import java.net.InetAddress;
 
 import opendcs.dai.ComputationDAI;
 import opendcs.dai.LoadingAppDAI;
-import opendcs.dai.SiteDAI;
 import opendcs.dai.TimeSeriesDAI;
 import opendcs.dai.TsGroupDAI;
-import opendcs.dao.DbObjectCache;
 import opendcs.opentsdb.Interval;
 import lrgs.gui.DecodesInterface;
 import ilex.cmdline.BooleanToken;

--- a/src/main/java/decodes/tsdb/CpCompDependsUpdater.java
+++ b/src/main/java/decodes/tsdb/CpCompDependsUpdater.java
@@ -432,7 +432,7 @@ public class CpCompDependsUpdater
                 + " computations in cache.");
 
             info("Refreshing Group Cache...");
-            tsGroupDAO.fillCache();
+            tsGroupDAO.fillCache(theDb.getCache(TsGroup.class));
 
             info("Expanding Groups in Cache...");
             groupHelper.evalAll();

--- a/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -650,7 +650,7 @@ public abstract class TimeSeriesDb
                         {
                             log.atError()
                             .setCause(ex)
-                            .log("Unable to refresh Site Cache.");
+                            .log("Unable to refresh TimeSeriesIdentifier Cache.");
                         }
                      }, cacheExecutor));
         cacheMap.put(DbComputation.class,
@@ -664,7 +664,7 @@ public abstract class TimeSeriesDb
                         {
                             log.atError()
                             .setCause(ex)
-                            .log("Unable to refresh Site Cache.");
+                            .log("Unable to refresh DbComputation Cache.");
                         }
                     }, cacheExecutor));
         cacheMap.put(AlarmScreening.class,
@@ -678,7 +678,7 @@ public abstract class TimeSeriesDb
                 {
                     log.atError()
                     .setCause(ex)
-                    .log("Unable to refresh Site Cache.");
+                    .log("Unable to refresh AlarmScreening Cache.");
                 }
             }, cacheExecutor));
         cacheMap.put(DbEnum.class,
@@ -699,7 +699,7 @@ public abstract class TimeSeriesDb
                         {
                             log.atError()
                             .setCause(ex)
-                            .log("Unable to refresh Site Cache.");
+                            .log("Unable to refresh TsGroup Cache.");
                         }
                     }, cacheExecutor));
     }

--- a/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -422,6 +422,8 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -444,6 +446,7 @@ import opendcs.dai.TimeSeriesDAI;
 import opendcs.dai.TsGroupDAI;
 import opendcs.dao.AlarmDAO;
 import opendcs.dao.AlgorithmDAO;
+import opendcs.dao.CachableDbObject;
 import opendcs.dao.CompDependsDAO;
 import opendcs.dao.CompDependsNotifyDAO;
 import opendcs.dao.ComputationDAO;
@@ -489,6 +492,8 @@ public abstract class TimeSeriesDb
 
     /** The application ID of the connected program */
     protected DbKey appId = Constants.undefinedId;
+
+    private final Map<Class<? extends CachableDbObject>, org.opendcs.database.DbObjectCache<?>> cacheMap = new HashMap<>();
 
     /** The model run ID currently in use for writing data. */
     protected int writeModelRunId;
@@ -593,6 +598,7 @@ public abstract class TimeSeriesDb
 
         cpCompDepends_col1 = isHdb() ? "TS_ID" : "SITE_DATATYPE_ID";
         getLogDateFormat().setTimeZone(TimeZone.getTimeZone("UTC"));
+        cacheMap.put(Site.class, new opendcs.dao.DbObjectCache<Site>(SiteDAO.CACHE_MAX_AGE, false));
     }
 
     /** @return the JDBC connection in use by this object. */
@@ -2208,4 +2214,10 @@ public abstract class TimeSeriesDb
 
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public <Type extends CachableDbObject> org.opendcs.database.DbObjectCache<Type> getCache(Class<? extends CachableDbObject> dataType)
+    {
+        return (org.opendcs.database.DbObjectCache<Type>)cacheMap.get(dataType);
+    }
 }

--- a/src/main/java/opendcs/dai/AlarmDAI.java
+++ b/src/main/java/opendcs/dai/AlarmDAI.java
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 
+import org.opendcs.database.DbObjectCache;
+
 import decodes.sql.DbKey;
 import decodes.tsdb.BadScreeningException;
 import decodes.tsdb.DbIoException;
@@ -199,4 +201,6 @@ public interface AlarmDAI extends DaiBase
 	 */
 	public Date lastHistoryAlarmTime(TimeSeriesIdentifier tsid)
 		throws DbIoException;
+
+	public void reloadCache(DbObjectCache<AlarmScreening> cache) throws DbIoException;
 }

--- a/src/main/java/opendcs/dai/ComputationDAI.java
+++ b/src/main/java/opendcs/dai/ComputationDAI.java
@@ -10,6 +10,8 @@ package opendcs.dai;
 
 import java.util.ArrayList;
 
+import org.opendcs.database.DbObjectCache;
+
 import decodes.db.Site;
 import decodes.db.SiteList;
 import decodes.db.SiteName;
@@ -99,4 +101,6 @@ public interface ComputationDAI
 	 * @throws DbIoException
 	 */
 	public ArrayList<ComputationInList> compEditList(CompFilter filter) throws DbIoException;
+
+	public void fillCache(DbObjectCache<DbComputation> cache) throws DbIoException;
 }

--- a/src/main/java/opendcs/dai/PropertiesDAI.java
+++ b/src/main/java/opendcs/dai/PropertiesDAI.java
@@ -3,8 +3,9 @@ package opendcs.dai;
 import java.util.List;
 import java.util.Properties;
 
+import org.opendcs.database.DbObjectCache;
+
 import opendcs.dao.CachableHasProperties;
-import opendcs.dao.DbObjectCache;
 
 import decodes.sql.DbKey;
 import decodes.tsdb.DbIoException;

--- a/src/main/java/opendcs/dai/SiteDAI.java
+++ b/src/main/java/opendcs/dai/SiteDAI.java
@@ -1,11 +1,14 @@
 package opendcs.dai;
 
+import org.python.bouncycastle.util.BigIntegers.Cache;
+
 import decodes.db.Site;
 import decodes.db.SiteList;
 import decodes.db.SiteName;
 import decodes.sql.DbKey;
 import decodes.tsdb.DbIoException;
 import decodes.tsdb.NoSuchObjectException;
+import opendcs.dao.CachableDbObject;
 
 /**
  * Defines public interface for reading/writing site (i.e. location) objects.
@@ -92,8 +95,12 @@ public interface SiteDAI
 	 * Fills the cache of all known sites in an efficient manner.
 	 * @throws DbIoException
 	 */
-	public void fillCache()
-		throws DbIoException;
+	public void fillCache() throws DbIoException;
+
+	default void fillCache(org.opendcs.database.DbObjectCache<Site> cache) throws DbIoException
+	{
+		// default do nothing.
+	}
 	
 	/**
 	 * @return the msec time that the cache was last filled, or 0 if never.

--- a/src/main/java/opendcs/dai/TimeSeriesDAI.java
+++ b/src/main/java/opendcs/dai/TimeSeriesDAI.java
@@ -6,7 +6,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
-import opendcs.dao.DbObjectCache;
+import org.h2.engine.DbObject;
+import org.opendcs.database.DbObjectCache;
 
 import decodes.sql.DbKey;
 import decodes.tsdb.BadTimeSeriesException;
@@ -195,8 +196,9 @@ public interface TimeSeriesDAI
 	 * Flush and reload the internal Time Series ID cache inside the DAO
 	 * @throws DbIoException on error.
 	 */
-	public void reloadTsIdCache()
-		throws DbIoException;
+	public void reloadTsIdCache() throws DbIoException;
+
+	public void reloadTsIdCache(DbObjectCache<TimeSeriesIdentifier> cache) throws DbIoException;
 
 	/**
 	 * Some applications need direct access to the internal cache to adjust

--- a/src/main/java/opendcs/dai/TsGroupDAI.java
+++ b/src/main/java/opendcs/dai/TsGroupDAI.java
@@ -16,6 +16,8 @@ package opendcs.dai;
 
 import java.util.ArrayList;
 
+import org.opendcs.database.DbObjectCache;
+
 import decodes.sql.DbKey;
 import decodes.tsdb.DbIoException;
 import decodes.tsdb.TsGroup;
@@ -25,8 +27,7 @@ import decodes.tsdb.TsGroup;
  * Defines public interface for reading/writing Time Series Group objects.
  * @author mmaloney - Mike Maloney, Cove Software, LLC
  */
-public interface TsGroupDAI
-	extends DaiBase
+public interface TsGroupDAI extends DaiBase
 {
 	
 	/**
@@ -90,8 +91,7 @@ public interface TsGroupDAI
 	/**
 	 * Fill cache with all groups.
 	 */
-	public void fillCache()
-		throws DbIoException;
+	public void fillCache(DbObjectCache<TsGroup> cache) throws DbIoException;
 
 	/**
 	 * Removes any computation dependencies for the group. That is computations

--- a/src/main/java/opendcs/dao/DatabaseConnectionOwner.java
+++ b/src/main/java/opendcs/dao/DatabaseConnectionOwner.java
@@ -50,6 +50,7 @@ import opendcs.dai.CompDependsDAI;
 import opendcs.dai.CompDependsNotifyDAI;
 import opendcs.dai.ComputationDAI;
 import opendcs.dai.DacqEventDAI;
+import opendcs.dai.DaiBase;
 import opendcs.dai.DataTypeDAI;
 import opendcs.dai.DeviceStatusDAI;
 import opendcs.dai.EnumDAI;
@@ -63,6 +64,7 @@ import opendcs.dai.TimeSeriesDAI;
 import opendcs.dai.TsGroupDAI;
 import opendcs.dai.XmitRecordDAI;
 import decodes.cwms.validation.dao.ScreeningDAI;
+import decodes.db.Site;
 import decodes.db.UnitConverter;
 import decodes.sql.DbKey;
 import decodes.sql.KeyGenerator;
@@ -349,5 +351,13 @@ public interface DatabaseConnectionOwner
 		throws DbIoException;
 	
 	public AlarmDAI makeAlarmDAO();
+
+	/**
+	 * Get appropriate object case from the connection owner.
+	 * @param <Type> datatype we need a cache for
+	 * @param dataType Specific data type needed
+	 * @return cache used by a given DAO
+	 */
+    public <Type extends CachableDbObject> org.opendcs.database.DbObjectCache<Type> getCache(Class<? extends CachableDbObject> dataType);
 
 }

--- a/src/main/java/opendcs/dao/DatabaseConnectionOwner.java
+++ b/src/main/java/opendcs/dao/DatabaseConnectionOwner.java
@@ -353,7 +353,7 @@ public interface DatabaseConnectionOwner
 	public AlarmDAI makeAlarmDAO();
 
 	/**
-	 * Get appropriate object case from the connection owner.
+	 * Get appropriate object cache from the connection owner.
 	 * @param <Type> datatype we need a cache for
 	 * @param dataType Specific data type needed
 	 * @return cache used by a given DAO

--- a/src/main/java/opendcs/dao/DbObjectCache.java
+++ b/src/main/java/opendcs/dao/DbObjectCache.java
@@ -33,7 +33,7 @@ import decodes.sql.DbKey;
  * @author mmaloney Mike Maloney, Cove Software LLC
  *
  */
-public class DbObjectCache<DBT extends CachableDbObject>
+public class DbObjectCache<DBT extends CachableDbObject> implements org.opendcs.database.DbObjectCache<DBT>
 {
 	private long maxAge = 3600000L; // # ms. If older than this, object is removed from cache.
 	private boolean nameIsCaseSensitive = false;
@@ -69,6 +69,7 @@ public class DbObjectCache<DBT extends CachableDbObject>
 	 * Place an object in the cache.
 	 * @param dbObj the object to cache
 	 */
+	@Override
 	public synchronized void put(DBT dbObj)
 	{
 		String un = dbObj.getUniqueName();
@@ -86,6 +87,7 @@ public class DbObjectCache<DBT extends CachableDbObject>
 	 *
 	 * @param key DbKey of the object to be removed.
 	 */
+	@Override
 	public synchronized void remove(DbKey key)
 	{
 		ObjWrapper ow = keyObjMap.get(key);
@@ -115,6 +117,7 @@ public class DbObjectCache<DBT extends CachableDbObject>
 	 * @param key the surrogate database key
 	 * @return the object
 	 */
+	@Override
 	public DBT getByKey(DbKey key)
 	{
 		ObjWrapper ow = keyObjMap.get(key);
@@ -140,6 +143,7 @@ public class DbObjectCache<DBT extends CachableDbObject>
 	 * @param daoBase the DAO
 	 * @return the object or null if cached object doesn't exist or is not OK.
 	 */
+	@Override
 	public DBT getByKey(DbKey key, DaoBase daoBase)
 	{
 		DBT ret = getByKey(key);
@@ -156,6 +160,7 @@ public class DbObjectCache<DBT extends CachableDbObject>
 	 * @param uniqueName the unique name
 	 * @return the object
 	 */
+	@Override
 	public DBT getByUniqueName(String uniqueName)
 	{
 		ObjWrapper ow = nameObjMap.get(
@@ -178,6 +183,7 @@ public class DbObjectCache<DBT extends CachableDbObject>
 	 * @param daoBase the DAO
 	 * @return the object or null if cached object doesn't exist or is not OK.
 	 */
+	@Override
 	public DBT getByUniqueName(String uniqueName, DaoBase daoBase)
 	{
 		DBT ret = getByUniqueName(uniqueName);
@@ -189,6 +195,7 @@ public class DbObjectCache<DBT extends CachableDbObject>
 		return ret;
 	}
 
+	@Override
 	public int size()
 	{
 		return keyObjMap.size();
@@ -201,6 +208,7 @@ public class DbObjectCache<DBT extends CachableDbObject>
 	 * @param cmp The comparator
 	 * @return a matching object, or null if non is found.
 	 */
+	@Override
 	public DBT search(Comparable<DBT> cmp)
 	{
 		for(ObjWrapper ow : keyObjMap.values())
@@ -236,10 +244,11 @@ public class DbObjectCache<DBT extends CachableDbObject>
 			wrapperIterator.remove();
 		}
 	}
-	
+
 	/**
 	 * @return iterator into the list of cached values.
 	 */
+	@Override
 	public CacheIterator iterator()
 	{
 		return new CacheIterator(keyObjMap.values().iterator());
@@ -248,12 +257,14 @@ public class DbObjectCache<DBT extends CachableDbObject>
 	/**
 	 * Completely clear the cache.
 	 */
+	@Override
 	public void clear()
 	{
 		keyObjMap.clear();
 		nameObjMap.clear();
 	}
 
+	@Override
 	public void setMaxAge(long maxAge)
 	{
 		this.maxAge = maxAge;

--- a/src/main/java/opendcs/dao/DbObjectCache.java
+++ b/src/main/java/opendcs/dao/DbObjectCache.java
@@ -21,6 +21,9 @@
  */
 package opendcs.dao;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;

--- a/src/main/java/opendcs/dao/EnumSqlDao.java
+++ b/src/main/java/opendcs/dao/EnumSqlDao.java
@@ -25,6 +25,8 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Iterator;
 
+import org.opendcs.database.DbObjectCache;
+
 import opendcs.dai.EnumDAI;
 
 import decodes.db.DbEnum;
@@ -38,15 +40,15 @@ import decodes.tsdb.DbIoException;
  * Data Access Object for writing/reading DbEnum objects to/from a SQL database
  * @author mmaloney Mike Maloney, Cove Software, LLC
  */
-public class EnumSqlDao 
-	extends DaoBase 
-	implements EnumDAI
+public class EnumSqlDao extends DaoBase implements EnumDAI
 {
-	private static DbObjectCache<DbEnum> cache = new DbObjectCache<DbEnum>(3600000, false);
+	public static Long ENUM_MAX_LIFE = 60*60*1000L; // 1 Hour, in milliseconds
+	private final DbObjectCache<DbEnum> cache;
 	
 	public EnumSqlDao(DatabaseConnectionOwner tsdb)
 	{
 		super(tsdb, "EnumSqlDao");
+		this.cache = tsdb.getCache(DbEnum.class);
 	}
 	
 	private String getEnumColumns(int dbVer)

--- a/src/main/java/opendcs/dao/PropertiesSqlDao.java
+++ b/src/main/java/opendcs/dao/PropertiesSqlDao.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 
+import org.opendcs.database.DbObjectCache;
 import org.opendcs.utils.Property;
 
 import opendcs.dai.PropertiesDAI;
@@ -182,8 +183,7 @@ public class PropertiesSqlDao
     }
 
     @Override
-    public int readPropertiesIntoCache(String tableName, DbObjectCache<?> cache)
-        throws DbIoException
+    public int readPropertiesIntoCache(String tableName, DbObjectCache<?> cache) throws DbIoException
     {
         String q = "select * from " + tableName;
         Integer n[] = new Integer[1];

--- a/src/main/java/opendcs/dao/SiteDAO.java
+++ b/src/main/java/opendcs/dao/SiteDAO.java
@@ -292,8 +292,13 @@ public class SiteDAO
     }
 
     @Override
-    public void fillCache()
-        throws DbIoException
+    public void fillCache() throws DbIoException
+    {
+        this.fillCache(cache);
+    }
+
+    @Override
+    public void fillCache(org.opendcs.database.DbObjectCache<Site> cache) throws DbIoException
     {
         debug3("(Generic)SiteDAO.fillCache()");
 
@@ -363,7 +368,7 @@ public class SiteDAO
             cache.put(site);
         int nProps = 0;
         if (db.getDecodesDatabaseVersion() >= DecodesDatabaseVersion.DECODES_DB_8)
-            nProps = propsDao.readPropertiesIntoCache("site_property", (opendcs.dao.DbObjectCache<?>) cache);
+            nProps = propsDao.readPropertiesIntoCache("site_property", cache);
         debug1("Site Cache Filled: " + cache.size() + " sites, " + nNames[0]
             + " names, " + nProps + " properties.");
         lastCacheFillMsec = System.currentTimeMillis();

--- a/src/main/java/opendcs/dao/SiteDAO.java
+++ b/src/main/java/opendcs/dao/SiteDAO.java
@@ -91,7 +91,7 @@ public class SiteDAO
 {
     // MJM Increased from 30 min to 3 hours for 6.4 RC08
     public static final long CACHE_MAX_AGE = 3 * 60 * 60 * 1000L;
-    protected static DbObjectCache<Site> cache = new DbObjectCache<Site>(CACHE_MAX_AGE, false);
+    protected final org.opendcs.database.DbObjectCache<Site> cache;
 
     public String siteAttributes =
         "id, latitude, longitude, nearestCity, state, "
@@ -106,6 +106,7 @@ public class SiteDAO
     public SiteDAO(DatabaseConnectionOwner tsdb)
     {
         super(tsdb, "SiteDao");
+        cache = tsdb.getCache(Site.class);
         propsDao = new PropertiesSqlDao(tsdb);
         siteNameAttributes =
             (tsdb.getDecodesDatabaseVersion() >= DecodesDatabaseVersion.DECODES_DB_7) ?
@@ -362,7 +363,7 @@ public class SiteDAO
             cache.put(site);
         int nProps = 0;
         if (db.getDecodesDatabaseVersion() >= DecodesDatabaseVersion.DECODES_DB_8)
-            nProps = propsDao.readPropertiesIntoCache("site_property", cache);
+            nProps = propsDao.readPropertiesIntoCache("site_property", (opendcs.dao.DbObjectCache<?>) cache);
         debug1("Site Cache Filled: " + cache.size() + " sites, " + nNames[0]
             + " names, " + nProps + " properties.");
         lastCacheFillMsec = System.currentTimeMillis();
@@ -373,7 +374,7 @@ public class SiteDAO
     {
         if (cache.size() == 0)
             fillCache();
-        for(DbObjectCache<Site>.CacheIterator cit = cache.iterator(); cit.hasNext(); )
+        for(Iterator<Site> cit = cache.iterator(); cit.hasNext(); )
             siteList.addSite(cit.next());
     }
 

--- a/src/main/java/opendcs/opentsdb/OpenTsdb.java
+++ b/src/main/java/opendcs/opentsdb/OpenTsdb.java
@@ -11,7 +11,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import opendcs.dai.DaiBase;
@@ -19,8 +21,11 @@ import opendcs.dai.IntervalDAI;
 import opendcs.dai.ScheduleEntryDAI;
 import opendcs.dai.SiteDAI;
 import opendcs.dai.TimeSeriesDAI;
+import opendcs.dao.CachableDbObject;
 import opendcs.dao.DaoBase;
+import opendcs.dao.DbObjectCache;
 import opendcs.dao.ScheduleEntryDAO;
+import opendcs.dao.SiteDAO;
 import opendcs.dao.XmitRecordDAO;
 import decodes.cwms.CwmsGroupHelper;
 import decodes.cwms.CwmsTsId;
@@ -30,6 +35,7 @@ import decodes.db.DataPresentation;
 import decodes.db.DataType;
 import decodes.db.Database;
 import decodes.db.PresentationGroup;
+import decodes.db.Site;
 import decodes.db.SiteName;
 import decodes.sql.DbKey;
 import decodes.tsdb.BadConnectException;
@@ -58,7 +64,6 @@ public class OpenTsdb extends TimeSeriesDb
 	public static final char TABLE_TYPE_STRING = 'S';
 
 	String getMinStmtQuery = null, getTaskListStmtQuery = null;
-
 
 	public OpenTsdb()
 	{
@@ -578,6 +583,4 @@ public class OpenTsdb extends TimeSeriesDb
 
 		return ret;
 	}
-
-
 }

--- a/src/main/java/opendcs/opentsdb/OpenTsdb.java
+++ b/src/main/java/opendcs/opentsdb/OpenTsdb.java
@@ -23,7 +23,7 @@ import opendcs.dai.SiteDAI;
 import opendcs.dai.TimeSeriesDAI;
 import opendcs.dao.CachableDbObject;
 import opendcs.dao.DaoBase;
-import opendcs.dao.DbObjectCache;
+import opendcs.dao.ScheduledReloadDbObjectCache;
 import opendcs.dao.ScheduleEntryDAO;
 import opendcs.dao.SiteDAO;
 import opendcs.dao.XmitRecordDAO;

--- a/src/main/java/opendcs/opentsdb/OpenTsdb.java
+++ b/src/main/java/opendcs/opentsdb/OpenTsdb.java
@@ -35,7 +35,6 @@ import decodes.db.DataPresentation;
 import decodes.db.DataType;
 import decodes.db.Database;
 import decodes.db.PresentationGroup;
-import decodes.db.Site;
 import decodes.db.SiteName;
 import decodes.sql.DbKey;
 import decodes.tsdb.BadConnectException;

--- a/src/main/java/org/opendcs/database/CacheKey.java
+++ b/src/main/java/org/opendcs/database/CacheKey.java
@@ -1,0 +1,50 @@
+package org.opendcs.database;
+
+import decodes.sql.DbKey;
+import java.util.Objects;
+
+public class CacheKey<DBT>
+{
+    final private DbKey key;
+    final private String uniqueName;
+
+    public CacheKey(DbKey key, String uniqueName)
+    {
+        if (key == null)
+        {
+            this.key = DbKey.NullKey;
+        }
+        else
+        {
+            this.key = key;
+        }
+        this.uniqueName = uniqueName;
+    }
+
+    @Override
+    public boolean equals(Object rhs)
+    {
+        if (rhs instanceof CacheKey<?>)
+        {
+            CacheKey<?> other = (CacheKey<?>)rhs;
+            if (this.key.equals(other.key))
+            {
+                return true;
+            }
+            else
+            {
+                return this.uniqueName.equals(other.uniqueName);
+            }
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(key, uniqueName);
+    }
+}

--- a/src/main/java/org/opendcs/database/CacheKey.java
+++ b/src/main/java/org/opendcs/database/CacheKey.java
@@ -3,7 +3,7 @@ package org.opendcs.database;
 import decodes.sql.DbKey;
 import java.util.Objects;
 
-public class CacheKey<DBT>
+public class CacheKey<DBT> implements Comparable<CacheKey<DBT>>
 {
     final private DbKey key;
     final private String uniqueName;
@@ -45,6 +45,23 @@ public class CacheKey<DBT>
     @Override
     public int hashCode()
     {
-        return Objects.hash(key, uniqueName);
+        return key.hashCode();
+    }
+
+    @Override
+    public int compareTo(CacheKey<DBT> o)
+    {
+        if (!DbKey.isNull(key))
+        {
+            return key.compareTo(o.key);
+        }
+        else if (uniqueName != null)
+        {
+            return uniqueName.compareTo(o.uniqueName);
+        }
+        else
+        {
+            return -1;
+        }
     }
 }

--- a/src/main/java/org/opendcs/database/CacheKey.java
+++ b/src/main/java/org/opendcs/database/CacheKey.java
@@ -1,8 +1,31 @@
+/**
+ * Copyright 2024 The OpenDCS Consortium and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.opendcs.database;
 
-import decodes.sql.DbKey;
 import java.util.Objects;
 
+import decodes.sql.DbKey;
+
+/**
+ * A composite key type that can be used by some cache implementations
+ * to allow storing by the full key,uniqueName set but searching by either.
+ * 
+ * NOTE: This does not work for HashMap as the hash function could never
+ * output the correctly value in both cases. (Well, not without some work anyways.)
+ */
 public class CacheKey<DBT> implements Comparable<CacheKey<DBT>>
 {
     final private DbKey key;
@@ -21,6 +44,9 @@ public class CacheKey<DBT> implements Comparable<CacheKey<DBT>>
         this.uniqueName = uniqueName;
     }
 
+    /**
+     * Loose equality. If only one set needs to match of the other set has a null value.
+     */
     @Override
     public boolean equals(Object rhs)
     {
@@ -42,10 +68,17 @@ public class CacheKey<DBT> implements Comparable<CacheKey<DBT>>
         }
     }
 
+    /**
+     * Get the hashCode of the complete data set.
+     * A CacheKey that contains only one of key or uniqueName
+     * will not map to the same hash.
+     * 
+     * ... Unless someone figures that out.
+     */
     @Override
     public int hashCode()
     {
-        return key.hashCode();
+        return Objects.hash(key, uniqueName);
     }
 
     @Override

--- a/src/main/java/org/opendcs/database/CacheKey.java
+++ b/src/main/java/org/opendcs/database/CacheKey.java
@@ -45,7 +45,7 @@ public class CacheKey<DBT> implements Comparable<CacheKey<DBT>>
     }
 
     /**
-     * Loose equality. If only one set needs to match of the other set has a null value.
+     * Loose equality. If only one set needs to match or the other set has a null value.
      */
     @Override
     public boolean equals(Object rhs)

--- a/src/main/java/org/opendcs/database/DbObjectCache.java
+++ b/src/main/java/org/opendcs/database/DbObjectCache.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2024 The OpenDCS Consortium and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.opendcs.database;
 
 import java.util.Iterator;
@@ -6,6 +21,12 @@ import decodes.sql.DbKey;
 import opendcs.dao.CachableDbObject;
 import opendcs.dao.DaoBase;
 
+/**
+ * Definition of a Cache Databases or DAOs can use to store objects.
+ * Provides common operations.
+ * 
+ * Cache invalidation and thread safety are determined by the implementations.
+ */
 public interface DbObjectCache<DBT extends CachableDbObject> {
 
     /**
@@ -44,22 +65,7 @@ public interface DbObjectCache<DBT extends CachableDbObject> {
      * @return the object
      */
     DBT getByUniqueName(String uniqueName);
-
-    public default CacheKey<DBT> getKey(DbKey key, String uniqueName)
-    {
-        return new CacheKey<>(key, uniqueName);
-    }
-
-    public default CacheKey<DBT> getKey(DbKey key)
-    {
-        return new CacheKey<>(key, null);
-    }
-
-    public default CacheKey<DBT> getKey(String uniqueName)
-    {
-        return new CacheKey<>(null, uniqueName);
-    }
-
+    
     /**
      * Used by caches like in ComputationDAO that must also check a last modify
      * time in the database to determine if a cached object needs to be reloaded.
@@ -70,6 +76,10 @@ public interface DbObjectCache<DBT extends CachableDbObject> {
      */
     DBT getByUniqueName(String uniqueName, DaoBase daoBase);
 
+    /**
+     * Retrieve the current cache size.
+     * @return
+     */
     int size();
 
     /**
@@ -91,6 +101,10 @@ public interface DbObjectCache<DBT extends CachableDbObject> {
      */
     void clear();
 
+    /**
+     * Set maxAge in milliseconds
+     * @param maxAge
+     */
     void setMaxAge(long maxAge);
-    
+
 }

--- a/src/main/java/org/opendcs/database/DbObjectCache.java
+++ b/src/main/java/org/opendcs/database/DbObjectCache.java
@@ -1,0 +1,96 @@
+package org.opendcs.database;
+
+import java.util.Iterator;
+
+import decodes.sql.DbKey;
+import opendcs.dao.CachableDbObject;
+import opendcs.dao.DaoBase;
+
+public interface DbObjectCache<DBT extends CachableDbObject> {
+
+    /**
+     * Place an object in the cache.
+     * @param dbObj the object to cache
+     */
+    void put(DBT dbObj);
+
+    /**
+     * Removes an object from the cache.
+     *
+     * @param key DbKey of the object to be removed.
+     */
+    void remove(DbKey key);
+
+    /**
+     * Retrieve an object by its surrogate database key
+     * @param key the surrogate database key
+     * @return the object
+     */
+    DBT getByKey(DbKey key);
+
+    /**
+     * Used by caches like in ComputationDAO that must also check a last modify
+     * time in the database to determine if a cached object needs to be reloaded.
+     * Before returning an object from the cache, the dao's check method is consulted.
+     * @param key The key of the object
+     * @param daoBase the DAO
+     * @return the object or null if cached object doesn't exist or is not OK.
+     */
+    DBT getByKey(DbKey key, DaoBase daoBase);
+
+    /**
+     * Retrieve an object by its unique name
+     * @param uniqueName the unique name
+     * @return the object
+     */
+    DBT getByUniqueName(String uniqueName);
+
+    public default CacheKey<DBT> getKey(DbKey key, String uniqueName)
+    {
+        return new CacheKey<>(key, uniqueName);
+    }
+
+    public default CacheKey<DBT> getKey(DbKey key)
+    {
+        return new CacheKey<>(key, null);
+    }
+
+    public default CacheKey<DBT> getKey(String uniqueName)
+    {
+        return new CacheKey<>(null, uniqueName);
+    }
+
+    /**
+     * Used by caches like in ComputationDAO that must also check a last modify
+     * time in the database to determine if a cached object needs to be reloaded.
+     * Before returning an object from the cache, the dao's check method is consulted.
+     * @param uniqueName The unique name of the object
+     * @param daoBase the DAO
+     * @return the object or null if cached object doesn't exist or is not OK.
+     */
+    DBT getByUniqueName(String uniqueName, DaoBase daoBase);
+
+    int size();
+
+    /**
+     * Searches the cache for an object that is 'equal to' the passed comparator.
+     * This method does a linear search of the objects in the cache, so it is not
+     * necessary that the Comparable be consistent in a sorting sense.
+     * @param cmp The comparator
+     * @return a matching object, or null if non is found.
+     */
+    DBT search(Comparable<DBT> cmp);
+
+    /**
+     * @return iterator into the list of cached values.
+     */
+    Iterator<DBT> iterator();
+
+    /**
+     * Completely clear the cache.
+     */
+    void clear();
+
+    void setMaxAge(long maxAge);
+    
+}

--- a/src/main/java/org/opendcs/database/DbObjectCache.java
+++ b/src/main/java/org/opendcs/database/DbObjectCache.java
@@ -106,5 +106,4 @@ public interface DbObjectCache<DBT extends CachableDbObject> {
      * @param maxAge
      */
     void setMaxAge(long maxAge);
-
 }

--- a/src/test/java/fixtures/NonPoolingConnectionOwner.java
+++ b/src/test/java/fixtures/NonPoolingConnectionOwner.java
@@ -37,7 +37,7 @@ import opendcs.dai.TimeSeriesDAI;
 import opendcs.dai.TsGroupDAI;
 import opendcs.dai.XmitRecordDAI;
 import opendcs.dao.CachableDbObject;
-import opendcs.dao.DbObjectCache;
+import opendcs.dao.ScheduledReloadDbObjectCache;
 
 public class NonPoolingConnectionOwner implements TestConnectionOwner
 {
@@ -345,7 +345,7 @@ public class NonPoolingConnectionOwner implements TestConnectionOwner
     }
 
     @Override
-    public <Type extends CachableDbObject> DbObjectCache<Type> getCache(Class<? extends CachableDbObject> dataType) {
+    public <Type extends CachableDbObject> ScheduledReloadDbObjectCache<Type> getCache(Class<? extends CachableDbObject> dataType) {
         // TODO Auto-generated method stub
         return null;
     }

--- a/src/test/java/fixtures/NonPoolingConnectionOwner.java
+++ b/src/test/java/fixtures/NonPoolingConnectionOwner.java
@@ -23,6 +23,7 @@ import opendcs.dai.CompDependsDAI;
 import opendcs.dai.CompDependsNotifyDAI;
 import opendcs.dai.ComputationDAI;
 import opendcs.dai.DacqEventDAI;
+import opendcs.dai.DaiBase;
 import opendcs.dai.DataTypeDAI;
 import opendcs.dai.DeviceStatusDAI;
 import opendcs.dai.EnumDAI;
@@ -35,6 +36,8 @@ import opendcs.dai.SiteDAI;
 import opendcs.dai.TimeSeriesDAI;
 import opendcs.dai.TsGroupDAI;
 import opendcs.dai.XmitRecordDAI;
+import opendcs.dao.CachableDbObject;
+import opendcs.dao.DbObjectCache;
 
 public class NonPoolingConnectionOwner implements TestConnectionOwner
 {
@@ -339,6 +342,12 @@ public class NonPoolingConnectionOwner implements TestConnectionOwner
     public CompDependsNotifyDAI makeCompDependsNotifyDAO() {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'makeCompDependsNotifyDAO'");
+    }
+
+    @Override
+    public <Type extends CachableDbObject> DbObjectCache<Type> getCache(Class<? extends CachableDbObject> dataType) {
+        // TODO Auto-generated method stub
+        return null;
     }
     
 }

--- a/src/test/java/org/opendcs/database/SimpleCacheTest.java
+++ b/src/test/java/org/opendcs/database/SimpleCacheTest.java
@@ -159,6 +159,21 @@ public class SimpleCacheTest {
         public void setMaxAge(long maxAge)
         {
         }
+
+        private CacheKey<DBT> getKey(DbKey key, String uniqueName)
+        {
+            return new CacheKey<>(key, uniqueName);
+        }
+
+        private CacheKey<DBT> getKey(DbKey key)
+        {
+            return new CacheKey<>(key, null);
+        }
+
+        private CacheKey<DBT> getKey(String uniqueName)
+        {
+            return new CacheKey<>(null, uniqueName);
+        }
     }
 
 }

--- a/src/test/java/org/opendcs/database/SimpleCacheTest.java
+++ b/src/test/java/org/opendcs/database/SimpleCacheTest.java
@@ -1,0 +1,164 @@
+package org.opendcs.database;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
+
+import decodes.sql.DbKey;
+import decodes.util.DecodesSettings.DbTypes;
+import opendcs.dao.CachableDbObject;
+import opendcs.dao.DaoBase;
+
+public class SimpleCacheTest {
+    
+    @Test
+    void test_cache_key() throws Exception
+    {
+        DbObjectCache<TestDbObject> testCache = new SimpleCache<>();
+        final String searchString = "two";
+
+        final TestDbObject object1 = new TestDbObject(DbKey.createDbKey(1), "Object1", "one");
+        final TestDbObject object2 = new TestDbObject(DbKey.createDbKey(2), "Object2", searchString);
+
+        testCache.put(object1);
+        testCache.put(object2);
+
+        assertEquals(2, testCache.size());
+
+        final TestDbObject result1Key = testCache.getByKey(object1.getKey());
+        assertNotNull(result1Key, "Unable to lookup object by key.");
+        assertEquals(object1, result1Key, "Correct object not retrieved.");
+
+        final TestDbObject result1Unique = testCache.getByUniqueName(object1.getUniqueName());
+        assertNotNull(result1Unique, "Unable to lookup object by uniqueName.");
+        assertEquals(object1, result1Unique, "Correct object not retrieved.");
+        
+        final TestDbObject resultSearch = testCache.search(inCache -> inCache.value.compareTo(searchString));
+        assertNotNull(resultSearch, "Search returned no results.");
+        assertEquals(object2, resultSearch, "Correct object not retrieved.");
+
+        testCache.clear();
+        assertEquals(0, testCache.size(), "Cache did not clear correctly.");
+    }
+
+    public static class TestDbObject implements CachableDbObject
+    {
+        final private DbKey key;
+        final private String uniqueName;
+        final private String value;
+
+        public TestDbObject(DbKey key, String uniqueName, String value)
+        {
+            this.key = key;
+            this.uniqueName = uniqueName;
+            this.value = value;
+        }
+
+        @Override
+        public DbKey getKey()
+        {
+            return key;
+        }
+
+        @Override
+        public String getUniqueName()
+        {
+            return uniqueName;
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+        
+    }
+
+    public static class SimpleCache<DBT extends CachableDbObject> implements DbObjectCache<DBT>
+    {
+        Map<CacheKey<DBT>,DBT> cache = new TreeMap<>();
+
+        @Override
+        public void put(DBT dbObj)
+        {
+            CacheKey<DBT> cacheKey = getKey(dbObj.getKey(), dbObj.getUniqueName());
+            cache.put(cacheKey, dbObj);
+
+        }
+
+        @Override
+        public void remove(DbKey key)
+        {
+            CacheKey<DBT> cacheKey = getKey(key);
+            cache.remove(cacheKey);
+        }
+
+        @Override
+        public DBT getByKey(DbKey key) 
+        {
+            CacheKey<DBT> cacheKey = getKey(key);
+            return cache.get(cacheKey);
+        }
+
+        @Override
+        public DBT getByKey(DbKey key, DaoBase daoBase) {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'getByKey'");
+        }
+
+        @Override
+        public DBT getByUniqueName(String uniqueName)
+        {
+            CacheKey<DBT> cacheKey = getKey(uniqueName);
+            return cache.get(cacheKey);
+        }
+
+        @Override
+        public DBT getByUniqueName(String uniqueName, DaoBase daoBase) {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'getByUniqueName'");
+        }
+
+        @Override
+        public int size()
+        {
+            return cache.size();
+        }
+
+        @Override
+        public DBT search(Comparable<DBT> cmp)
+        {
+            for (DBT obj: cache.values())
+            {
+                if (cmp.compareTo(obj) == 0)
+                {
+                    return obj;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Iterator<DBT> iterator()
+        {
+            return cache.values().iterator();
+        }
+
+        @Override
+        public void clear()
+        {
+            cache.clear();
+        }
+
+        @Override
+        public void setMaxAge(long maxAge)
+        {
+        }
+    }
+
+}


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
 

<!-- if you are referencing a specific issue a problem description is not required -->
Existing caching implementation was causing performance issues as the DAO objects we're constantly getting reset so each would need calculate that it needed to fill the cache.

While the cache was static, and thus should've been fine, this work moves the actual Cache up a level, and create an interface to allow alternative cache implementations in the future.

After discussion with @agilmore2 reviewed current design and implemented a possible solution that will be useful going forward.

## Solution

Create interface for DbObjectCache.
Move Site cache to TimeseriesDb/SqlDatabaseIO (NOTE: this does mean there will be two caches, not available easily, if at all in the current design.)

TODOs:
- [ ] Add a Cached "null" return for cases where the same name was recently search and not found (this helps with compedit rendering the group for a computation... and probably compdepends as well.)
- [x] Rename the original implementation.
- [ ] MXBeans for tracking cache usage from JMX.
- [ ] Move the cache somewhere that can be shared between SqlDatabaseIO and TimeseriesDatabase. Like something related to DecodesSettings (if made immutable can be used as a hashkey).

## how you tested the change

Test of the interface created.

Integration tests already cover object cache usage. (All SiteDAO implementations use the cache in some way.)

## Where the following done:

- [x] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
