### PR TITLE
explicitly include opendcs-annotations.jar in class path in batch/bash files

### DIFF
--- a/install/bin/decj
+++ b/install/bin/decj
@@ -48,7 +48,7 @@ if [ ! -d "$DCSTOOL_USERDIR" ]; then
 fi
 
 # Build classpath
-CP=$DH/bin/opendcs.jar:
+CP=$DH/bin/opendcs.jar:$DH/bin/opendcs-annotations.jar
 
 # # For CWMS Installations, add the HEC and RMA Jars.
 # if [ -n "$CWMS_JAR_DIR" -a -d "$CWMS_JAR_DIR" ]

--- a/install/bin/decj.bat
+++ b/install/bin/decj.bat
@@ -7,7 +7,7 @@ pushd "%BIN_PATH%.."
 set "APP_PATH=%CD%"
 popd
 
-set "CLASSPATH=%BIN_PATH%opendcs.jar;%BIN_PATH%hibernate.cfg.xml;"
+set "CLASSPATH=%BIN_PATH%opendcs.jar;%BIN_PATH%opendcs-annotations.jar;%BIN_PATH%hibernate.cfg.xml;"
 
 if defined CP_SHARED_JAR_DIR (
  for /R "%CP_SHARED_JAR_DIR%" %%a in (*.jar) do (


### PR DESCRIPTION
fixes error some developers are getting:

```
  java.lang.NoClassDefFoundError: org/opendcs/annotations/PropertySpec
```


