### PR TITLE
Refactor/513 switch to jaxrs

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -79,7 +79,18 @@
         </dependency>
         <dependency org="mil.army.usace.hec" name="hec-cwms-ratings-core" rev="1.1.0"/>
         <dependency org="org.slf4j" name="slf4j-api" rev="${slf4j.version}"/>
-        <dependency org="io.javalin" name="javalin" rev="4.6.8" />
+
+        <dependency org="org.eclipse.jetty" name="jetty-jsp" rev="${jetty.jsp.version}"/>
+        <dependency org="org.eclipse.jetty" name="jetty-annotations" rev="${jetty.version}"/>
+        <dependency org="org.eclipse.jetty" name="jetty-server" rev="${jetty.version}"/>
+        <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="${jetty.version}"/>
+        <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="${jetty.version}"/>
+        <dependency org="org.eclipse.jetty" name="jetty-webapp" rev="${jetty.version}"/>
+        <dependency org="javax.servlet" name="javax.servlet-api" rev="${servlet/api.version}"/>
+        <dependency org="org.glassfish.jersey.containers" name="jersey-container-servlet" rev="${jersey.version}"/>
+        <dependency org="org.glassfish.jersey.inject" name="jersey-hk2" rev="${jersey.version}"/>
+        <dependency org="javax" name="javaee-api" rev="7.0"/>
+
         <dependency org="org.jdbi" name="jdbi3-core" rev="3.38.2"/>
         <dependency org="org.jdbi" name="jdbi3-sqlobject" rev="3.38.2"/>
         <dependency org="org.jdbi" name="jdbi3-postgres" rev="3.38.2"/>

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -7,6 +7,10 @@
     <property name="snapshot-time" value="${snapshot.time}"/>
     <property name="root-version" value="${version}"/>
     <property name="slf4j.version" value="2.0.7"/>
+    <property name="jetty.version" value="9.4.53.v20231009"/>
+    <property name="jetty.jsp.version" value="9.2.30.v20200428"/>
+    <property name="jersey.version" value="2.40"/>
+    <property name="servlet.api.version" value="4.0.1"/>
     <property name="junit.platform.version" value="1.10.2"/>
     <property name="junit.jupiter.version" value="5.10.2"/>
     <settings defaultResolver="default">

--- a/src/main/java/org/opendcs/lrgs/http/LrgsHealth.java
+++ b/src/main/java/org/opendcs/lrgs/http/LrgsHealth.java
@@ -1,10 +1,10 @@
 package org.opendcs.lrgs.http;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -18,23 +18,24 @@ import lrgs.lrgsmain.LrgsMain;
 public class LrgsHealth
 {
     private static final Logger log = LoggerFactory.getLogger(LrgsHealth.class);
+
     @Context
-    Configuration configuration;
+    ServletContext servletContext;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response get()
     {
         log.info("Sending Health status.");
-        LrgsMain lrgs = (LrgsMain)configuration.getProperty("lrgs");
+        LrgsMain lrgs = (LrgsMain)servletContext.getAttribute("lrgs");
         if (lrgs != null && lrgs.getDdsServer().statusProvider.getStatusSnapshot().isUsable)
         {
-            return Response.ok("Active").build();
+            return Response.ok("\"Active\"").build();
         }
         else
         {
             return Response.status(HttpServletResponse.SC_SERVICE_UNAVAILABLE)
-                           .entity("Inactive")
+                           .entity("\"Inactive\"")
                            .build();
         }
     }

--- a/src/main/java/org/opendcs/lrgs/http/LrgsHealth.java
+++ b/src/main/java/org/opendcs/lrgs/http/LrgsHealth.java
@@ -1,28 +1,41 @@
 package org.opendcs.lrgs.http;
 
-import io.javalin.http.Context;
-import io.javalin.http.HttpCode;
-import lrgs.archive.MsgArchive;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import lrgs.lrgsmain.LrgsMain;
 
+@Path("/health")
 public class LrgsHealth
 {
-    /**
-     * Simple LRGS status report for simple health checks.
-     *
-     * @param ctx Javalin Archive.
-     * @param archive Lrgs MsgArchive to pull stats.
-     * @param lrgs LrgsMain handle to get more information.
-     */
-    public static void get(Context ctx, MsgArchive archive, LrgsMain lrgs)
+    private static final Logger log = LoggerFactory.getLogger(LrgsHealth.class);
+    @Context
+    Configuration configuration;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response get()
     {
-        if (lrgs.getDdsServer().statusProvider.getStatusSnapshot().isUsable)
+        log.info("Sending Health status.");
+        LrgsMain lrgs = (LrgsMain)configuration.getProperty("lrgs");
+        if (lrgs != null && lrgs.getDdsServer().statusProvider.getStatusSnapshot().isUsable)
         {
-            ctx.status(HttpCode.OK).json("Active");
+            return Response.ok("Active").build();
         }
         else
         {
-            ctx.status(HttpCode.SERVICE_UNAVAILABLE).json("Inactive");
+            return Response.status(HttpServletResponse.SC_SERVICE_UNAVAILABLE)
+                           .entity("Inactive")
+                           .build();
         }
     }
 }

--- a/src/main/java/org/opendcs/lrgs/http/LrgsHttpInterface.java
+++ b/src/main/java/org/opendcs/lrgs/http/LrgsHttpInterface.java
@@ -2,11 +2,16 @@ package org.opendcs.lrgs.http;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ilex.xml.XmlOutputStream;
-import io.javalin.Javalin;
-import io.javalin.http.ContentType;
-import io.javalin.http.HttpCode;
 import lrgs.archive.MsgArchive;
 import lrgs.lrgsmain.LoadableLrgsInputInterface;
 import lrgs.lrgsmain.LrgsInputException;
@@ -17,9 +22,10 @@ import lrgs.statusxml.LrgsStatusSnapshotExt;
 
 public class LrgsHttpInterface implements LoadableLrgsInputInterface
 {
+    private static Logger log = LoggerFactory.getLogger(LrgsHttpInterface.class);
     private static final String TYPE = "HTTP";
 
-    private Javalin app;
+    private org.eclipse.jetty.server.Server server = null;
     private int slot;
     private int port = 7000;
     private String interfaceName;
@@ -33,12 +39,14 @@ public class LrgsHttpInterface implements LoadableLrgsInputInterface
     }
 
     @Override
-    public void setSlot(int slot) {
+    public void setSlot(int slot)
+    {
         this.slot = slot;
     }
 
     @Override
-    public int getSlot() {
+    public int getSlot()
+    {
         return slot;
     }
 
@@ -51,8 +59,22 @@ public class LrgsHttpInterface implements LoadableLrgsInputInterface
     @Override
     public void initLrgsInput() throws LrgsInputException
     {
-        app = Javalin.create()
-            .get("/health", ctx -> LrgsHealth.get(ctx, archive, lrgs))
+        server = new org.eclipse.jetty.server.Server();
+		ServletContextHandler ctx = new ServletContextHandler(ServletContextHandler.SESSIONS);
+		ctx.setContextPath("/");
+		server.setHandler(ctx);
+        ServletHolder serHol = ctx.addServlet(ServletContainer.class, "/*");
+		serHol.setInitOrder(1);
+		serHol.setInitParameter("jersey.config.server.provider.packages", "org.opendcs.lrgs.http");
+
+        server.setAttribute("lrgs", this.lrgs);
+        server.setAttribute("archive", this.archive);
+
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(this.port);
+        server.addConnector(connector);
+
+        /*
             .get("/status", ctx -> {
                 LrgsStatusSnapshotExt status = lrgs.getStatusProvider().getStatusSnapshot();
                 DetailReportGenerator gen = lrgs.getReportGenerator();
@@ -70,18 +92,39 @@ public class LrgsHttpInterface implements LoadableLrgsInputInterface
                 }
             })
             ;
+            */
     }
 
     @Override
     public void shutdownLrgsInput()
     {
-        app.stop();
+        try
+        {
+            server.stop();
+        }
+        catch (Exception ex)
+        {
+            log.atError()
+               .setCause(ex)
+               .log("Unable to stop Jetty Server");
+        }
     }
 
     @Override
     public void enableLrgsInput(boolean enabled)
     {
-        app.start(port);
+        try
+        {
+            server.setAttribute("lrgs", this.lrgs);
+            server.setAttribute("archive", this.archive);
+            server.start();
+        }
+        catch (Exception ex)
+        {
+            log.atError()
+               .setCause(ex)
+               .log("Unable to stop Jetty Server");
+        }
     }
 
     @Override
@@ -149,11 +192,19 @@ public class LrgsHttpInterface implements LoadableLrgsInputInterface
     public void setMsgArchive(MsgArchive archive)
     {
         this.archive = archive;
+        if (server != null)
+        {            
+            server.setAttribute("archive", this.archive);
+        }
     }
 
     @Override
     public void setLrgsMain(LrgsMain lrgsMain)
     {
         this.lrgs = lrgsMain;
+        if (server != null)
+        {
+            server.setAttribute("lrgs", this.lrgs);
+        }
     }
 }

--- a/src/main/java/org/opendcs/lrgs/http/LrgsStatus.java
+++ b/src/main/java/org/opendcs/lrgs/http/LrgsStatus.java
@@ -1,0 +1,47 @@
+package org.opendcs.lrgs.http;
+
+import java.io.ByteArrayOutputStream;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import ilex.xml.XmlOutputStream;
+import lrgs.lrgsmain.LrgsMain;
+import lrgs.lrgsmon.DetailReportGenerator;
+import lrgs.statusxml.LrgsStatusSnapshotExt;
+
+@Path("/status")
+public class LrgsStatus
+{
+
+    @Context
+    ServletContext servletContext;
+
+    
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public Response getStatus()
+    {        
+        LrgsMain lrgs = (LrgsMain)servletContext.getAttribute("lrgs");
+        LrgsStatusSnapshotExt status = lrgs.getStatusProvider().getStatusSnapshot();
+        DetailReportGenerator gen = lrgs.getReportGenerator();
+        try(ByteArrayOutputStream bos = new ByteArrayOutputStream();)
+        {
+            XmlOutputStream xos = new XmlOutputStream(bos, "html");
+            gen.writeReport(xos, status.hostname, status, 10);
+            return Response.ok(bos.toByteArray()).build();
+        }
+        catch (Exception ex)
+        {
+            return Response.serverError()
+                           .entity("\"Cannot generate report.\"")
+                           .type(MediaType.APPLICATION_JSON)
+                           .build();
+        }            
+    }
+}

--- a/src/main/java/org/opendcs/lrgs/http/LrgsWebApp.java
+++ b/src/main/java/org/opendcs/lrgs/http/LrgsWebApp.java
@@ -1,0 +1,10 @@
+package org.opendcs.lrgs.http;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class LrgsWebApp extends Application
+{
+    
+}

--- a/src/main/java/org/opendcs/lrgs/http/LrgsWebApp.java
+++ b/src/main/java/org/opendcs/lrgs/http/LrgsWebApp.java
@@ -1,10 +1,14 @@
 package org.opendcs.lrgs.http;
 
+import javax.servlet.ServletContext;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
 
 @ApplicationPath("/")
 public class LrgsWebApp extends Application
 {
+    @Context
+    ServletContext servletContext;
     
 }


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #513 . 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Removed Javalin, added in Jetty directly and the jersey implementation of JAX-RS.
This aligns the main project with the choice of API that the https://github.com/opendcs/rest_api made.

## how you tested the change

Manually. LRGS setup with no data /health correctly returns "inactive" and HTTP 503, with data returns "active" and HTTP 200 OK.
/status returns the appropriate "lrgs status" page correctly in either case.

Jetty starts and stops correctly.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
