### PR TITLE
Refactor/property edit panel to mvc

### DIFF
--- a/src/main/java/decodes/dbeditor/ConfigSensorEditDialog.java
+++ b/src/main/java/decodes/dbeditor/ConfigSensorEditDialog.java
@@ -35,6 +35,7 @@ import decodes.db.Database;
 import decodes.util.TimeOfDay;
 import decodes.db.Constants;
 import decodes.gui.GuiDialog;
+import decodes.gui.properties.PropertiesEditPanelController;
 
 /**
 Dialog for editing a configuration sensor.
@@ -154,9 +155,9 @@ public class ConfigSensorEditDialog extends GuiDialog
 			 && theSensor.getUsgsStatCode() == null)
 				theSensor.setUsgsStatCode(sc); 
 
-		    propertiesEditPanel = new PropertiesEditPanel(theProperties);
+		    propertiesEditPanel = PropertiesEditPanel.from(theProperties);
 			propertiesEditPanel.setOwnerDialog(this);
-			propertiesEditPanel.setPropertiesOwner(cs);
+			propertiesEditPanel.getModel().setPropertiesOwner(cs);
             jbInit();
             pack();
 			fillValues();
@@ -348,7 +349,7 @@ public class ConfigSensorEditDialog extends GuiDialog
 
 		theSensor.timeOfFirstSample = firstSampleTime;
 		theSensor.recordingInterval = recordingInterval;
-		propertiesEditPanel.saveChanges();
+		propertiesEditPanel.getModel().saveChanges();
 		theSensor.getProperties().clear();
 		PropertiesUtil.copyProps(theSensor.getProperties(), theProperties);
 		return true;

--- a/src/main/java/decodes/dbeditor/ConfigSensorEditDialog.java
+++ b/src/main/java/decodes/dbeditor/ConfigSensorEditDialog.java
@@ -1,6 +1,6 @@
 /*
 *  $Id$
-*  
+*
 *  $Log$
 *  Revision 1.2  2014/09/25 18:08:34  mmaloney
 *  Enum fields encapsulated.
@@ -35,7 +35,6 @@ import decodes.db.Database;
 import decodes.util.TimeOfDay;
 import decodes.db.Constants;
 import decodes.gui.GuiDialog;
-import decodes.gui.properties.PropertiesEditPanelController;
 
 /**
 Dialog for editing a configuration sensor.
@@ -43,10 +42,9 @@ Dialog for editing a configuration sensor.
 @SuppressWarnings("serial")
 public class ConfigSensorEditDialog extends GuiDialog
 {
-	static ResourceBundle genericLabels = DbEditorFrame.getGenericLabels();
-	static ResourceBundle dbeditLabels = DbEditorFrame.getDbeditLabels();
+    static ResourceBundle genericLabels = DbEditorFrame.getGenericLabels();
+    static ResourceBundle dbeditLabels = DbEditorFrame.getDbeditLabels();
 
-	private static final int MID_COL_WIDTH = 60;
 
     JPanel outerPanel = new JPanel();
     JPanel jPanel1 = new JPanel();
@@ -90,316 +88,325 @@ public class ConfigSensorEditDialog extends GuiDialog
     JLabel dataTypesStandardLabel = new JLabel();
     JLabel jLabel6 = new JLabel();
     JLabel jLabel7 = new JLabel();
-    JComboBox samplingIntervalCombo = new JComboBox(
-		new String[] { "01:00:00", "00:30:00", "00:20:00", "00:15:00",
-			"00:10:00", "00:05:00" });
+    JComboBox<String> samplingIntervalCombo =
+        new JComboBox<String>(
+            new String[] { "01:00:00", "00:30:00", "00:20:00", "00:15:00", "00:10:00", "00:05:00" }
+        );
     GridBagLayout gridBagLayout2 = new GridBagLayout();
     JLabel jLabel4 = new JLabel();
     JLabel usgsStatCodeLabel = new JLabel();
     JTextField usgsStatCodeField = new JTextField();
 
-	/** The object being edited */
-	ConfigSensor theSensor;
+    /** The object being edited */
+    ConfigSensor theSensor;
 
-	/** The equipment model associated with this sensor (if there is one). */
-	EquipmentModel theEquipmentModel;
+    /** The equipment model associated with this sensor (if there is one). */
+    EquipmentModel theEquipmentModel;
 
-	/** Configuration Sensor Properties */
-	Properties theProperties;
+    /** Configuration Sensor Properties */
+    Properties theProperties;
 
-  	/**
-   	* This member, if true, indicates that the ConfigSensor being edited by
-   	* this box was newly added with the "Add" button.
-   	* If that's the case, and the user presses "Cancel", then we'll need to
-   	* delete this ConfigSensor.
-   	*/
+      /**
+       * This member, if true, indicates that the ConfigSensor being edited by
+       * this box was newly added with the "Add" button.
+       * If that's the case, and the user presses "Cancel", then we'll need to
+       * delete this ConfigSensor.
+       */
     boolean _csNewlyAdded;
 
-  	/** Default constructor for jbuilder.  */
-	public ConfigSensorEditDialog()
-	{
-		this(null);
-	}
+      /** Default constructor for jbuilder.  */
+    public ConfigSensorEditDialog()
+    {
+        this(null);
+    }
 
-  	/**
-	  Construct with an object to be edited.
-	  @param cs the sensor to edit.
-	*/
-	public ConfigSensorEditDialog(ConfigSensor cs)
-	{
-	    this(cs, false);
-	}
+      /**
+      Construct with an object to be edited.
+      @param cs the sensor to edit.
+    */
+    public ConfigSensorEditDialog(ConfigSensor cs)
+    {
+        this(cs, false);
+    }
 
-  	/**
-   	* Construct with an object to be editted, and flag which allows the
-   	* caller to indicate that this is a newly added ConfigSensor.
-	  @param cs the sensor to edit.
-	  @param csNewlyAdded true if this sensor should be deleted on Cancel.
-   	*/
-	public ConfigSensorEditDialog(ConfigSensor cs, boolean csNewlyAdded)
-	{
+      /**
+       * Construct with an object to be editted, and flag which allows the
+       * caller to indicate that this is a newly added ConfigSensor.
+      @param cs the sensor to edit.
+      @param csNewlyAdded true if this sensor should be deleted on Cancel.
+       */
+    public ConfigSensorEditDialog(ConfigSensor cs, boolean csNewlyAdded)
+    {
         super(getDbEditFrame(), "", true);
 
-		_csNewlyAdded = csNewlyAdded;
-		theSensor = cs;
-		theEquipmentModel = cs.equipmentModel;
+        _csNewlyAdded = csNewlyAdded;
+        theSensor = cs;
+        theEquipmentModel = cs.equipmentModel;
         try
-		{
-			theProperties = new Properties();
-			if (cs != null)
-				PropertiesUtil.copyProps(theProperties, cs.getProperties());
+        {
+            theProperties = new Properties();
+            if (cs != null)
+            {
+                PropertiesUtil.copyProps(theProperties, cs.getProperties());
+            }
 
-			String sc = PropertiesUtil.rmIgnoreCase(theProperties,
-				"StatisticsCode");
-			if (sc != null && sc.length() > 0
-			 && theSensor.getUsgsStatCode() == null)
-				theSensor.setUsgsStatCode(sc); 
+            String sc = PropertiesUtil.rmIgnoreCase(theProperties,
+                "StatisticsCode");
+            if (sc != null && sc.length() > 0
+             && theSensor.getUsgsStatCode() == null)
+            {
+                theSensor.setUsgsStatCode(sc);
+            }
 
-		    propertiesEditPanel = PropertiesEditPanel.from(theProperties);
-			propertiesEditPanel.setOwnerDialog(this);
-			propertiesEditPanel.getModel().setPropertiesOwner(cs);
+            propertiesEditPanel = PropertiesEditPanel.from(theProperties);
+            propertiesEditPanel.setOwnerDialog(this);
+            propertiesEditPanel.getModel().setPropertiesOwner(cs);
             jbInit();
             pack();
-			fillValues();
-			getRootPane().setDefaultButton(okButton);
+            fillValues();
+            getRootPane().setDefaultButton(okButton);
         }
-        catch(Exception ex) {
+        catch(Exception ex)
+        {
             ex.printStackTrace();
         }
-		addWindowListener(
-			new WindowAdapter()
-			{
-				boolean started=false;
-				public void windowActivated(WindowEvent e)
-				{
-					if (!started)
-						sensorNameField.requestFocus();
-					started = true;
-				}
-			});
+        addWindowListener(
+            new WindowAdapter()
+            {
+                boolean started=false;
+                public void windowActivated(WindowEvent e)
+                {
+                    if (!started)
+                    {
+                        sensorNameField.requestFocus();
+                    }
+                    started = true;
+                }
+            }
+        );
     }
 
 
-	/** Fills the GUI components with values from the object being edited. */
-	void fillValues()
-	{
-		if (theSensor == null)
-			return;
-		if (theSensor.platformConfig != null)
-	        configNameField.setText(theSensor.platformConfig.configName);
-		sensorNumberField.setText("" + theSensor.sensorNumber);
-	    sensorNameField.setText(theSensor.sensorName);
+    /** Fills the GUI components with values from the object being edited. */
+    void fillValues()
+    {
+        if (theSensor == null)
+        {
+            return;
+        }
+        if (theSensor.platformConfig != null)
+        {
+            configNameField.setText(theSensor.platformConfig.configName);
+        }
+        sensorNumberField.setText("" + theSensor.sensorNumber);
+        sensorNameField.setText(theSensor.sensorName);
 
-		int i=0;
-		for(Iterator it = theSensor.getDataTypes(); it.hasNext() && i < 3; i++)
-		{
-			DataType dt = (DataType)it.next();
-			dtStdCombo[i].setDataTypeStandard(dt.getStandard());
-		    dataTypeField[i].setText(dt.getCode());
-			dtStdCombo[i].setEnabled(true);
-		    dataTypeField[i].setEnabled(true);
-		}
-		// Set the remaining 'Standard' settings to something different
-		// than the ones above.
-		decodes.db.DbEnum dtsenum = Database.getDb().getDbEnum("DataTypeStandard");
-		for(; i < 3; i++)  // for each remaining slot...
-		{
-			Iterator enit = dtsenum.iterator();
-			boolean set = false;
-			while(enit.hasNext())
-			{
-				EnumValue ev = (EnumValue)enit.next();
-				// Is this 'standard' used in one of the slots above?
-				int j=0;
-				for(; j<i; j++)
-				{
-					String std = dtStdCombo[j].getDataTypeStandard();
-					if (ev.getValue().equalsIgnoreCase(std))
-						break;
-				}
-				if (j == i) // Didn't use this std yet?
-				{
-					dtStdCombo[j].setSelectedItem(ev.getValue());
-		    		dataTypeField[i].setText("");
-					dtStdCombo[i].setEnabled(true);
-		    		dataTypeField[i].setEnabled(true);
-					set = true;
-					break; // go on to next slot.
-				}
-			}
-			if (!set) // fell through while loop, all standards represented.
-			{
-		    	dataTypeField[i].setEnabled(false);
-				dtStdCombo[i].setEnabled(false);
-			}
-		}
+        int i=0;
+        for(Iterator<DataType> it = theSensor.getDataTypes(); it.hasNext() && i < 3; i++)
+        {
+            DataType dt = it.next();
+            dtStdCombo[i].setDataTypeStandard(dt.getStandard());
+            dataTypeField[i].setText(dt.getCode());
+            dtStdCombo[i].setEnabled(true);
+            dataTypeField[i].setEnabled(true);
+        }
+        // Set the remaining 'Standard' settings to something different
+        // than the ones above.
+        decodes.db.DbEnum dtsenum = Database.getDb().getDbEnum("DataTypeStandard");
+        for(; i < 3; i++)  // for each remaining slot...
+        {
+            Iterator<EnumValue> enit = dtsenum.iterator();
+            boolean set = false;
+            while(enit.hasNext())
+            {
+                EnumValue ev = enit.next();
+                // Is this 'standard' used in one of the slots above?
+                int j=0;
+                for(; j<i; j++)
+                {
+                    String std = dtStdCombo[j].getDataTypeStandard();
+                    if (ev.getValue().equalsIgnoreCase(std))
+                    {
+                        break;
+                    }
+                }
+                if (j == i) // Didn't use this std yet?
+                {
+                    dtStdCombo[j].setSelectedItem(ev.getValue());
+                    dataTypeField[i].setText("");
+                    dtStdCombo[i].setEnabled(true);
+                    dataTypeField[i].setEnabled(true);
+                    set = true;
+                    break; // go on to next slot.
+                }
+            }
+            if (!set) // fell through while loop, all standards represented.
+            {
+                dataTypeField[i].setEnabled(false);
+                dtStdCombo[i].setEnabled(false);
+            }
+        }
 
-		if (theEquipmentModel != null)
-		    equipmentModelField.setText(theEquipmentModel.name);
-		recordingModeCombo.setSelection(theSensor.recordingMode);
-		firstSampleTimeField.setText(
-		    TimeOfDay.seconds2hhmmss(theSensor.timeOfFirstSample));
-		String si = TimeOfDay.seconds2hhmmss(theSensor.recordingInterval);
-		samplingIntervalCombo.setSelectedItem(si);
-//		samplingIntervalField.setText(
-//		    TimeOfDay.seconds2hhmmss(theSensor.recordingInterval));
-		if (theSensor.absoluteMin != Constants.undefinedDouble)
-			absoluteMinField.setText("" + theSensor.absoluteMin);
-		if (theSensor.absoluteMax != Constants.undefinedDouble)
-			absoluteMaxField.setText("" + theSensor.absoluteMax);
+        if (theEquipmentModel != null)
+        {
+            equipmentModelField.setText(theEquipmentModel.name);
+        }
+        recordingModeCombo.setSelection(theSensor.recordingMode);
+        firstSampleTimeField.setText(TimeOfDay.seconds2hhmmss(theSensor.timeOfFirstSample));
+        String si = TimeOfDay.seconds2hhmmss(theSensor.recordingInterval);
+        samplingIntervalCombo.setSelectedItem(si);
 
-		String c = theSensor.getUsgsStatCode();
-		usgsStatCodeField.setText(c == null ? "" : c);
-	}
+        if (theSensor.absoluteMin != Constants.undefinedDouble)
+        {
+            absoluteMinField.setText("" + theSensor.absoluteMin);
+        }
+        if (theSensor.absoluteMax != Constants.undefinedDouble)
+        {
+            absoluteMaxField.setText("" + theSensor.absoluteMax);
+        }
 
-	/**
-	  Validates and saves the values being edited back into the object.
-	  DOES NO Database IO -- just back to the object.
-	  @return true if validation passed.
-	*/
-	boolean saveValues()
-	{
-		if (theSensor == null)
-			return true;
+        String c = theSensor.getUsgsStatCode();
+        usgsStatCodeField.setText(c == null ? "" : c);
+    }
 
-		int firstSampleTime = 0;
-		int recordingInterval = 0;
-		try
-		{
-			firstSampleTime =
-				TimeOfDay.hhmmss2seconds(firstSampleTimeField.getText());
-		}
-		catch(NumberFormatException e)
-		{
-			showError(
-				dbeditLabels.getString("ConfigSensorEditDialog.badTOD"));
-			return false;
-		}
-		try
-		{
-			recordingInterval =
-				TimeOfDay.hhmmss2seconds(
-					(String)samplingIntervalCombo.getSelectedItem());
-//				TimeOfDay.hhmmss2seconds(samplingIntervalField.getText());
-		}
-		catch(NumberFormatException e)
-		{
-			showError(
-				dbeditLabels.getString("ConfigSensorEditDialog.badInterval"));
-			return false;
-		}
+    /**
+      Validates and saves the values being edited back into the object.
+      DOES NO Database IO -- just back to the object.
+      @return true if validation passed.
+    */
+    boolean saveValues()
+    {
+        if (theSensor == null)
+        {
+            return true;
+        }
 
-		String s = absoluteMinField.getText();
-		if (s != null && !TextUtil.isAllWhitespace(s))
-			try { theSensor.absoluteMin = Double.parseDouble(s); }
-			catch(NumberFormatException e)
-			{
-				showError(
-					dbeditLabels.getString("ConfigSensorEditDialog.badMin"));
-				return false;
-			}
-		else
-			theSensor.absoluteMin = Constants.undefinedDouble;
+        int firstSampleTime = 0;
+        int recordingInterval = 0;
+        try
+        {
+            firstSampleTime = TimeOfDay.hhmmss2seconds(firstSampleTimeField.getText());
+        }
+        catch(NumberFormatException e)
+        {
+            showError(dbeditLabels.getString("ConfigSensorEditDialog.badTOD"));
+            return false;
+        }
+        try
+        {
+            recordingInterval = TimeOfDay.hhmmss2seconds((String)samplingIntervalCombo.getSelectedItem());
+        }
+        catch(NumberFormatException e)
+        {
+            showError(dbeditLabels.getString("ConfigSensorEditDialog.badInterval"));
+            return false;
+        }
 
-		s = absoluteMaxField.getText();
-		if (s != null && !TextUtil.isAllWhitespace(s))
-			try { theSensor.absoluteMax = Double.parseDouble(s); }
-			catch(NumberFormatException e)
-			{
-				showError(
-					dbeditLabels.getString("ConfigSensorEditDialog.badMax"));
-				return false;
-			}
-		else
-			theSensor.absoluteMax = Constants.undefinedDouble;
+        String s = absoluteMinField.getText();
+        if (s != null && !TextUtil.isAllWhitespace(s))
+        {
+            try
+            {
+                theSensor.absoluteMin = Double.parseDouble(s);
+            }
+            catch(NumberFormatException e)
+            {
+                showError(dbeditLabels.getString("ConfigSensorEditDialog.badMin"));
+                return false;
+            }
+        }
+        else
+        {
+            theSensor.absoluteMin = Constants.undefinedDouble;
+        }
 
-		theSensor.sensorName = sensorNameField.getText();
-		if (theSensor.sensorName == null
-		 || TextUtil.isAllWhitespace(theSensor.sensorName))
-		{
-			showError(
-				dbeditLabels.getString("ConfigSensorEditDialog.blankName"));
-			return false;
-		}
+        s = absoluteMaxField.getText();
+        if (s != null && !TextUtil.isAllWhitespace(s))
+        {
+            try
+            {
+                theSensor.absoluteMax = Double.parseDouble(s);
+            }
+            catch(NumberFormatException e)
+            {
+                showError(dbeditLabels.getString("ConfigSensorEditDialog.badMax"));
+                return false;
+            }
+        }
+        else
+        {
+            theSensor.absoluteMax = Constants.undefinedDouble;
+        }
 
-		theSensor.clearDataTypes();
-		int ndt = 0;
-		for(int i = 0; i<3; i++)
-		{
-		    String std = dtStdCombo[i].getDataTypeStandard();
-			String code = dataTypeField[i].getText().trim();
-			if (code.length() > 0)
-			{
-				theSensor.addDataType(DataType.getDataType(std, code));
-				ndt++;
-			}
-		}
-		if (ndt == 0)
-		{
-			showError(
-				dbeditLabels.getString("ConfigSensorEditDialog.oneDataType"));
-			return false;
-		}
+        theSensor.sensorName = sensorNameField.getText();
+        if (theSensor.sensorName == null || TextUtil.isAllWhitespace(theSensor.sensorName))
+        {
+            showError(dbeditLabels.getString("ConfigSensorEditDialog.blankName"));
+            return false;
+        }
 
-		theSensor.equipmentModel = theEquipmentModel;
-		theSensor.recordingMode = recordingModeCombo.getSelection();
+        theSensor.clearDataTypes();
+        int ndt = 0;
+        for(int i = 0; i<3; i++)
+        {
+            String std = dtStdCombo[i].getDataTypeStandard();
+            String code = dataTypeField[i].getText().trim();
+            if (code.length() > 0)
+            {
+                theSensor.addDataType(DataType.getDataType(std, code));
+                ndt++;
+            }
+        }
+        if (ndt == 0)
+        {
+            showError(dbeditLabels.getString("ConfigSensorEditDialog.oneDataType"));
+            return false;
+        }
 
-		s = usgsStatCodeField.getText().trim();
-		theSensor.setUsgsStatCode(s.length() > 0 ? s : null);
+        theSensor.equipmentModel = theEquipmentModel;
+        theSensor.recordingMode = recordingModeCombo.getSelection();
 
-		theSensor.timeOfFirstSample = firstSampleTime;
-		theSensor.recordingInterval = recordingInterval;
-		propertiesEditPanel.getModel().saveChanges();
-		theSensor.getProperties().clear();
-		PropertiesUtil.copyProps(theSensor.getProperties(), theProperties);
-		return true;
-	}
+        s = usgsStatCodeField.getText().trim();
+        theSensor.setUsgsStatCode(s.length() > 0 ? s : null);
 
-	/** Initializes GUI components. */
+        theSensor.timeOfFirstSample = firstSampleTime;
+        theSensor.recordingInterval = recordingInterval;
+        propertiesEditPanel.getModel().saveChanges();
+        theSensor.getProperties().clear();
+        PropertiesUtil.copyProps(theSensor.getProperties(), theProperties);
+        return true;
+    }
+
+    /** Initializes GUI components. */
     void jbInit() throws Exception
-	{
-    	dtStdCombo[0] = new DataTypeCodeCombo();
-    	dtStdCombo[1] = new DataTypeCodeCombo();
-    	dtStdCombo[2] = new DataTypeCodeCombo();
-        dtStdCombo[0].setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.selectStd"));
-        dtStdCombo[1].setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.selectStd"));
-        dtStdCombo[2].setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.selectStd"));
-    	dataTypeField[0] = new JTextField();
-    	dataTypeField[1] = new JTextField();
-    	dataTypeField[2] = new JTextField();
-        dataTypeField[0].setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.enterCode"));
-        dataTypeField[1].setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.enterCode"));
-        dataTypeField[2].setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.enterCode"));
+    {
+        dtStdCombo[0] = new DataTypeCodeCombo();
+        dtStdCombo[1] = new DataTypeCodeCombo();
+        dtStdCombo[2] = new DataTypeCodeCombo();
+        dtStdCombo[0].setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.selectStd"));
+        dtStdCombo[1].setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.selectStd"));
+        dtStdCombo[2].setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.selectStd"));
+        dataTypeField[0] = new JTextField();
+        dataTypeField[1] = new JTextField();
+        dataTypeField[2] = new JTextField();
+        dataTypeField[0].setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.enterCode"));
+        dataTypeField[1].setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.enterCode"));
+        dataTypeField[2].setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.enterCode"));
         titledBorder1 = new TitledBorder(BorderFactory.createLineBorder(new Color(153, 153, 153),2),"");
         border1 = BorderFactory.createCompoundBorder(titledBorder1,BorderFactory.createEmptyBorder(2,2,2,2));
         outerPanel.setLayout(borderLayout2);
         jPanel1.setLayout(flowLayout1);
-        configurationLabel.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.configLabel"));
+        configurationLabel.setText(dbeditLabels.getString("ConfigSensorEditDialog.configLabel"));
         configNameField.setEditable(false);
 
-        jLabel2.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.sensorLabel"));
+        jLabel2.setText(dbeditLabels.getString("ConfigSensorEditDialog.sensorLabel"));
         sensorNumberField.setEditable(false);
 
         okButton.setText(genericLabels.getString("OK"));
-        okButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                okButton_actionPerformed(e);
-            }
-        });
+        okButton.addActionListener(e -> okButton_actionPerformed(e));
         cancelButton.setText(genericLabels.getString("cancel"));
-        cancelButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                cancelButton_actionPerformed(e);
-            }
-        });
+        cancelButton.addActionListener(e -> cancelButton_actionPerformed(e));
+
         southButtonPanel.setLayout(flowLayout2);
         flowLayout2.setHgap(35);
         flowLayout2.setVgap(10);
@@ -414,63 +421,40 @@ public class ConfigSensorEditDialog extends GuiDialog
         outerPanel.setPreferredSize(new Dimension(480, 600));//450, 570
         jPanel1.setBorder(border1);
         sensorNameLabel.setHorizontalAlignment(SwingConstants.RIGHT);
-        sensorNameLabel.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.nameLabel"));
-        sensorNameField.setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.nameTT"));
+        sensorNameLabel.setText(dbeditLabels.getString("ConfigSensorEditDialog.nameLabel"));
+        sensorNameField.setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.nameTT"));
         dataTypeLabel.setHorizontalAlignment(SwingConstants.RIGHT);
-        dataTypeLabel.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.stdLabel"));
-        codeLabel1.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.codeLabel"));
-        codeLabel2.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.codeLabel"));
-        codeLabel3.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.codeLabel"));
+        dataTypeLabel.setText(dbeditLabels.getString("ConfigSensorEditDialog.stdLabel"));
+        codeLabel1.setText(dbeditLabels.getString("ConfigSensorEditDialog.codeLabel"));
+        codeLabel2.setText(dbeditLabels.getString("ConfigSensorEditDialog.codeLabel"));
+        codeLabel3.setText(dbeditLabels.getString("ConfigSensorEditDialog.codeLabel"));
         valueRangeLabel.setHorizontalAlignment(SwingConstants.RIGHT);
-        valueRangeLabel.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.validMinLabel"));
-        absoluteMinField.setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.validMinTT"));
+        valueRangeLabel.setText(dbeditLabels.getString("ConfigSensorEditDialog.validMinLabel"));
+        absoluteMinField.setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.validMinTT"));
         maxLabel.setHorizontalAlignment(SwingConstants.RIGHT);
-        maxLabel.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.validMaxLabel"));
-        absoluteMaxField.setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.validMaxTT"));
+        maxLabel.setText(dbeditLabels.getString("ConfigSensorEditDialog.validMaxLabel"));
+        absoluteMaxField.setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.validMaxTT"));
         recordingModeLabel.setHorizontalAlignment(SwingConstants.RIGHT);
-        recordingModeLabel.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.recModeLabel"));
-        recordingModeCombo.setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.recModeTT"));
+        recordingModeLabel.setText(dbeditLabels.getString("ConfigSensorEditDialog.recModeLabel"));
+        recordingModeCombo.setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.recModeTT"));
         firstSampleTimeLabel.setHorizontalAlignment(SwingConstants.RIGHT);
-        firstSampleTimeLabel.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.firstSampTimeLabel"));
-        firstSampleTimeField.setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.firstSampTimeTT"));
+        firstSampleTimeLabel.setText(dbeditLabels.getString("ConfigSensorEditDialog.firstSampTimeLabel"));
+        firstSampleTimeField.setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.firstSampTimeTT"));
         hhmmss1label.setText("(HH:MM:SS)");
         samplingIntervalLabel.setHorizontalAlignment(SwingConstants.RIGHT);
-        samplingIntervalLabel.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.intLabel"));
-        equipmentModelField.setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.equipTT"));
+        samplingIntervalLabel.setText(dbeditLabels.getString("ConfigSensorEditDialog.intLabel"));
+        equipmentModelField.setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.equipTT"));
         equipmentModelField.setEditable(false);
         selectEquipmentModelButton.setText(genericLabels.getString("select"));
-        selectEquipmentModelButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                selectEquipmentModelButton_actionPerformed(e);
-            }
-        });
+        selectEquipmentModelButton.addActionListener(e -> selectEquipmentModelButton_actionPerformed(e));
+
         equipmentModelLabel.setHorizontalAlignment(SwingConstants.RIGHT);
-        equipmentModelLabel.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.equipLabel"));
-        dataTypesStandardLabel.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.dtStdLabel"));
-        jLabel6.setText(
-			dbeditLabels.getString("ConfigSensorEditDialog.stdLabel"));
+        equipmentModelLabel.setText(dbeditLabels.getString("ConfigSensorEditDialog.equipLabel"));
+        dataTypesStandardLabel.setText(dbeditLabels.getString("ConfigSensorEditDialog.dtStdLabel"));
+        jLabel6.setText(dbeditLabels.getString("ConfigSensorEditDialog.stdLabel"));
         jLabel4.setText("(HH:MM:SS)");
-    	usgsStatCodeLabel.setText("USGS Stat Code:");
-        samplingIntervalCombo.setToolTipText(
-			dbeditLabels.getString("ConfigSensorEditDialog.intTT"));
+        usgsStatCodeLabel.setText("USGS Stat Code:");
+        samplingIntervalCombo.setToolTipText(dbeditLabels.getString("ConfigSensorEditDialog.intTT"));
         getContentPane().add(outerPanel);
         outerPanel.add(jPanel1, BorderLayout.NORTH);
         jPanel1.add(configurationLabel, null);
@@ -481,195 +465,203 @@ public class ConfigSensorEditDialog extends GuiDialog
         southButtonPanel.add(okButton, null);
         southButtonPanel.add(cancelButton, null);
         outerPanel.add(centerPanel, BorderLayout.CENTER);
-        centerPanel.add(fieldEntryPanel, 
-			new GridBagConstraints(0, 0, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.CENTER, GridBagConstraints.BOTH, 
-				new Insets(0, 0, 0, 0), 0, 0));
-        fieldEntryPanel.add(sensorNameLabel, 
-			new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE, 
-				new Insets(3, 0, 3, 3), 35, 0));
-        fieldEntryPanel.add(sensorNameField, 
-			new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0,
-           		GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, 
-				new Insets(3, 0, 3, 0), 0, 0));
-        fieldEntryPanel.add(dataTypeLabel, 
-			new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE, 
-				new Insets(3, 0, 3, 3), 0, 0));
-        fieldEntryPanel.add(dtStdCombo[0], 
-			new GridBagConstraints(1, 1, 1, 1, 1.0, 1.0,
-            	GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL, 
-				new Insets(3, 0, 3, 0), 0, 0));
-        fieldEntryPanel.add(codeLabel1, 
-			new GridBagConstraints(2, 1, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE, 
-				new Insets(3, 0, 3, 3), 0, 0));
-        fieldEntryPanel.add(dataTypeField[0], 
-			new GridBagConstraints(3, 1, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, 
-				new Insets(3, 0, 3, 20), 0, 0));
+        centerPanel.add(fieldEntryPanel,
+            new GridBagConstraints(0, 0, 1, 1, 1.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                new Insets(0, 0, 0, 0), 0, 0));
+        fieldEntryPanel.add(sensorNameLabel,
+            new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 0, 3, 3), 35, 0));
+        fieldEntryPanel.add(sensorNameField,
+            new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0,
+                   GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 0), 0, 0));
+        fieldEntryPanel.add(dataTypeLabel,
+            new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 0, 3, 3), 0, 0));
+        fieldEntryPanel.add(dtStdCombo[0],
+            new GridBagConstraints(1, 1, 1, 1, 1.0, 1.0,
+                GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 0), 0, 0));
+        fieldEntryPanel.add(codeLabel1,
+            new GridBagConstraints(2, 1, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 0, 3, 3), 0, 0));
+        fieldEntryPanel.add(dataTypeField[0],
+            new GridBagConstraints(3, 1, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 20), 0, 0));
 
-        fieldEntryPanel.add(dataTypesStandardLabel, 
-			new GridBagConstraints(0, 2, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE, 
-				new Insets(3, 10, 3, 3), 0, 0));
-        fieldEntryPanel.add(dtStdCombo[1], 
-			new GridBagConstraints(1, 2, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, 
-				new Insets(3, 0, 3, 0), 0, 0));
-        fieldEntryPanel.add(codeLabel2, 
-			new GridBagConstraints(2, 2, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE, 
-				new Insets(3, 0, 3, 3), 0, 0));
-        fieldEntryPanel.add(dataTypeField[1], 
-			new GridBagConstraints(3, 2, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, 
-				new Insets(3, 0, 3, 20), 0, 0));
+        fieldEntryPanel.add(dataTypesStandardLabel,
+            new GridBagConstraints(0, 2, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 10, 3, 3), 0, 0));
+        fieldEntryPanel.add(dtStdCombo[1],
+            new GridBagConstraints(1, 2, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 0), 0, 0));
+        fieldEntryPanel.add(codeLabel2,
+            new GridBagConstraints(2, 2, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 0, 3, 3), 0, 0));
+        fieldEntryPanel.add(dataTypeField[1],
+            new GridBagConstraints(3, 2, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 20), 0, 0));
 
         fieldEntryPanel.add(jLabel6,
-			new GridBagConstraints(0, 3, 1, 1, 0.0, 0.0
+            new GridBagConstraints(0, 3, 1, 1, 0.0, 0.0
             ,GridBagConstraints.EAST, GridBagConstraints.NONE,
-				new Insets(3, 0, 3, 3), 0, 0));
+                new Insets(3, 0, 3, 3), 0, 0));
         fieldEntryPanel.add(dtStdCombo[2],
-			new GridBagConstraints(1, 3, 1, 1, 1.0, 0.0
+            new GridBagConstraints(1, 3, 1, 1, 1.0, 0.0
             ,GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-				new Insets(3, 0, 3, 0), 0, 0));
-        fieldEntryPanel.add(codeLabel3, 
-			new GridBagConstraints(2, 3, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE, 
-				new Insets(3, 5, 3, 3), 0, 0));
-        fieldEntryPanel.add(dataTypeField[2], 
-				new GridBagConstraints(3, 3, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, 
-				new Insets(3, 0, 3, 20), 0, 0));
+                new Insets(3, 0, 3, 0), 0, 0));
+        fieldEntryPanel.add(codeLabel3,
+            new GridBagConstraints(2, 3, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 5, 3, 3), 0, 0));
+        fieldEntryPanel.add(dataTypeField[2],
+                new GridBagConstraints(3, 3, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 20), 0, 0));
 
         fieldEntryPanel.add(usgsStatCodeLabel,
-			new GridBagConstraints(0, 4, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE,
-				new Insets(3, 0, 3, 3), 0, 0));
+            new GridBagConstraints(0, 4, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 0, 3, 3), 0, 0));
         fieldEntryPanel.add(usgsStatCodeField,
-			new GridBagConstraints(1, 4, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-				new Insets(3, 0, 3, 0), 0, 0));
+            new GridBagConstraints(1, 4, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 0), 0, 0));
 
         fieldEntryPanel.add(valueRangeLabel,
-			new GridBagConstraints(0, 5, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE,
-				new Insets(3, 0, 3, 3), 0, 0));
+            new GridBagConstraints(0, 5, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 0, 3, 3), 0, 0));
         fieldEntryPanel.add(absoluteMinField,
-			new GridBagConstraints(1, 5, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-				new Insets(3, 0, 3, 0), 0, 0));
+            new GridBagConstraints(1, 5, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 0), 0, 0));
         fieldEntryPanel.add(maxLabel,
-			new GridBagConstraints(2, 5, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE,
-				new Insets(3, 5, 3, 4), 0, 0));
+            new GridBagConstraints(2, 5, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 5, 3, 4), 0, 0));
         fieldEntryPanel.add(absoluteMaxField,
-			new GridBagConstraints(3, 5, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-				new Insets(3, 0, 3, 20), 0, 0));
+            new GridBagConstraints(3, 5, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 20), 0, 0));
 
         fieldEntryPanel.add(recordingModeLabel,
-			new GridBagConstraints(0, 6, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE,
-				new Insets(3, 0, 3, 3), 0, 0));
+            new GridBagConstraints(0, 6, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 0, 3, 3), 0, 0));
         fieldEntryPanel.add(recordingModeCombo,
-			new GridBagConstraints(1, 6, 1, 1, 1.0, 1.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-				new Insets(3, 0, 3, 0), 0, 0));
+            new GridBagConstraints(1, 6, 1, 1, 1.0, 1.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 0), 0, 0));
 
         fieldEntryPanel.add(firstSampleTimeLabel,
-			new GridBagConstraints(0, 7, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE,
-				new Insets(3, 0, 3, 3), 0, 0));
+            new GridBagConstraints(0, 7, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 0, 3, 3), 0, 0));
         fieldEntryPanel.add(firstSampleTimeField,
-			new GridBagConstraints(1, 7, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-				new Insets(3, 0, 3, 0), 0, 0));
+            new GridBagConstraints(1, 7, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 0), 0, 0));
         fieldEntryPanel.add(hhmmss1label,
-			new GridBagConstraints(2, 7, 2, 1, 0.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.NONE,
-				new Insets(3, 5, 3, 0), 0, 0));
+            new GridBagConstraints(2, 7, 2, 1, 0.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.NONE,
+                new Insets(3, 5, 3, 0), 0, 0));
 
         fieldEntryPanel.add(samplingIntervalLabel,
-			new GridBagConstraints(0, 8, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE,
-				new Insets(3, 0, 3, 3), 0, 0));
+            new GridBagConstraints(0, 8, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 0, 3, 3), 0, 0));
         fieldEntryPanel.add(samplingIntervalCombo,
-			new GridBagConstraints(1, 8, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-				new Insets(3, 0, 3, 0), 0, 0));
+            new GridBagConstraints(1, 8, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 3, 0), 0, 0));
         fieldEntryPanel.add(jLabel4,
-			new GridBagConstraints(2, 8, 2, 1, 0.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.NONE,
-				new Insets(3, 5, 3, 0), 0, 0));
+            new GridBagConstraints(2, 8, 2, 1, 0.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.NONE,
+                new Insets(3, 5, 3, 0), 0, 0));
 
-        fieldEntryPanel.add(equipmentModelLabel, 
-			new GridBagConstraints(0, 9, 1, 1, 0.0, 0.0,
-            	GridBagConstraints.EAST, GridBagConstraints.NONE, 
-				new Insets(3, 0, 10, 3), 0, 0));
-        fieldEntryPanel.add(equipmentModelField, 
-			new GridBagConstraints(1, 9, 1, 1, 1.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, 
-				new Insets(3, 0, 10, 0), 0, 0));
+        fieldEntryPanel.add(equipmentModelLabel,
+            new GridBagConstraints(0, 9, 1, 1, 0.0, 0.0,
+                GridBagConstraints.EAST, GridBagConstraints.NONE,
+                new Insets(3, 0, 10, 3), 0, 0));
+        fieldEntryPanel.add(equipmentModelField,
+            new GridBagConstraints(1, 9, 1, 1, 1.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+                new Insets(3, 0, 10, 0), 0, 0));
         fieldEntryPanel.add(selectEquipmentModelButton,
-			new GridBagConstraints(2, 9, 2, 1, 0.0, 0.0,
-            	GridBagConstraints.WEST, GridBagConstraints.NONE,
-				new Insets(3, 10, 10, 0), 0, 0));
+            new GridBagConstraints(2, 9, 2, 1, 0.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.NONE,
+                new Insets(3, 10, 10, 0), 0, 0));
 
-        centerPanel.add(propertiesEditPanel, 
-			new GridBagConstraints(0, 1, 1, 1, 1.0, 1.0,
-            	GridBagConstraints.CENTER, GridBagConstraints.BOTH, 
-				new Insets(0, 0, 0, 0), 0, 0));
-		samplingIntervalCombo.setEditable(true);
+        centerPanel.add(propertiesEditPanel,
+            new GridBagConstraints(0, 1, 1, 1, 1.0, 1.0,
+                GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                new Insets(0, 0, 0, 0), 0, 0));
+        samplingIntervalCombo.setEditable(true);
     }
 
-	/**
-	  Called when the Select Equipment Model button is pressed.
-	  @param e ignored.
-	*/
+    /**
+      Called when the Select Equipment Model button is pressed.
+      @param e ignored.
+    */
     void selectEquipmentModelButton_actionPerformed(ActionEvent e)
-	{
-		EquipmentModelSelectDialog dlg = new EquipmentModelSelectDialog();
-		dlg.setSelection(theEquipmentModel);
-		dlg.setVisible(true);
-		if (!dlg.cancelled())
-		{
-			theEquipmentModel = dlg.getSelectedEquipmentModel();
-			if (theEquipmentModel != null) // selection was made?
-				equipmentModelField.setText(theEquipmentModel.name);
-			else
-				equipmentModelField.setText("");
-		}
+    {
+        EquipmentModelSelectDialog dlg = new EquipmentModelSelectDialog();
+        dlg.setSelection(theEquipmentModel);
+        dlg.setVisible(true);
+        if (!dlg.cancelled())
+        {
+            theEquipmentModel = dlg.getSelectedEquipmentModel();
+            if (theEquipmentModel != null) // selection was made?
+            {
+                equipmentModelField.setText(theEquipmentModel.name);
+            }
+            else
+            {
+                equipmentModelField.setText("");
+            }
+        }
     }
 
-	/**
-	  Called when the OK button is pressed.
-	  @param e ignored.
-	*/
+    /**
+      Called when the OK button is pressed.
+      @param e ignored.
+    */
     void okButton_actionPerformed(ActionEvent e)
-	{
-		if (saveValues() == false)
-			return;
-		closeDlg();
+    {
+        if (saveValues() == false)
+        {
+            return;
+        }
+        closeDlg();
     }
 
-	/** Closes the dialog. */
-	void closeDlg()
-	{
-		setVisible(false);
-		dispose();
-	}
+    /** Closes the dialog. */
+    void closeDlg()
+    {
+        setVisible(false);
+        dispose();
+    }
 
-	/**
-	  Called when the Cancel button is pressed.
-	  @param e ignored.
-	*/
+    /**
+      Called when the Cancel button is pressed.
+      @param e ignored.
+    */
     void cancelButton_actionPerformed(ActionEvent e)
-	{
-		if (_csNewlyAdded)
-			theSensor.platformConfig.removeSensor(theSensor);
-		closeDlg();
+    {
+        if (_csNewlyAdded)
+        {
+            theSensor.platformConfig.removeSensor(theSensor);
+        }
+        closeDlg();
     }
 }

--- a/src/main/java/decodes/dbeditor/EquipmentEditPanel.java
+++ b/src/main/java/decodes/dbeditor/EquipmentEditPanel.java
@@ -63,8 +63,7 @@ public class EquipmentEditPanel extends DbEditorTab
     public EquipmentEditPanel()
 	{
 		Properties props = new Properties();
-		propertiesEditPanel =
-			new PropertiesEditPanel(props);
+		propertiesEditPanel = PropertiesEditPanel.from(props);
         try {
             jbInit();
         }
@@ -100,7 +99,7 @@ public class EquipmentEditPanel extends DbEditorTab
 			enableFields();
 			theObject = origObject.copy();
 			setTopObject(origObject);
-			propertiesEditPanel.setProperties(theObject.properties);
+			propertiesEditPanel.getModel().setProperties(theObject.properties);
 			fillFields();
 		}
 	}
@@ -114,7 +113,7 @@ public class EquipmentEditPanel extends DbEditorTab
 	{
 		enableFields();
 		theObject.copyFrom(imported);
-		propertiesEditPanel.setProperties(theObject.properties);
+		propertiesEditPanel.getModel().setProperties(theObject.properties);
 		fillFields();
 	}
 
@@ -183,7 +182,7 @@ public class EquipmentEditPanel extends DbEditorTab
 		if (TextUtil.isAllWhitespace(theObject.model))
 			theObject.model = null;
 		theObject.equipmentType = equipmentTypeSelector.getSelection();
-		propertiesEditPanel.saveChanges();
+		propertiesEditPanel.getModel().saveChanges();
 		return theObject;
 	}
 

--- a/src/main/java/decodes/dbeditor/PlatformSensorEditDialog.java
+++ b/src/main/java/decodes/dbeditor/PlatformSensorEditDialog.java
@@ -23,8 +23,9 @@ import decodes.db.DataType;
 import decodes.db.PlatformSensor;
 import decodes.db.Site;
 import decodes.db.SiteName;
-import decodes.gui.PropertiesEditPanel;
 import decodes.gui.GuiDialog;
+import decodes.gui.PropertiesEditPanel;
+import decodes.gui.properties.PropertiesEditPanelController;
 import decodes.util.DecodesSettings;
 
 /**
@@ -67,7 +68,7 @@ public class PlatformSensorEditDialog extends GuiDialog
 	JLabel usgsDdnoLabel = new JLabel();
 	JComboBox usgsDdnoCombo = new JComboBox();
 	GridBagLayout gridBagLayout2 = new GridBagLayout();
-	PropertiesEditPanel propsPanel = new PropertiesEditPanel(new Properties());
+	PropertiesEditPanel propsPanel = PropertiesEditPanel.from(new Properties());
 	GridBagLayout gridBagLayout3 = new GridBagLayout();
 	Border border5 = BorderFactory.createEtchedBorder(Color.white,
 		new Color(165, 163, 151));
@@ -401,14 +402,14 @@ public class PlatformSensorEditDialog extends GuiDialog
 		if (curpos != -1)
 			usgsDdnoCombo.setSelectedIndex(curpos);
 
-		propsPanel.setProperties(theProperties);
-		propsPanel.setPropertiesOwner(ps);
+		propsPanel.getModel().setProperties(theProperties);
+		propsPanel.getModel().setPropertiesOwner(ps);
 	}
 
 	private boolean saveChanges()
 	{
 		// Save properties changes and copy them back to the sensor object.
-		propsPanel.saveChanges();
+		propsPanel.getModel().saveChanges();
 		platformSensor.getProperties().clear();
 		PropertiesUtil.copyProps(platformSensor.getProperties(), theProperties);
 

--- a/src/main/java/decodes/dbeditor/RoutingSpecEditPanel.java
+++ b/src/main/java/decodes/dbeditor/RoutingSpecEditPanel.java
@@ -62,7 +62,7 @@ public class RoutingSpecEditPanel
 	static ResourceBundle dbeditLabels = DbEditorFrame.getDbeditLabels();
 
 	private EntityOpsPanel entityOpsPanel = new EntityOpsPanel(this);
-	private PropertiesEditPanel propertiesEditPanel = new PropertiesEditPanel(new Properties());
+	private PropertiesEditPanel propertiesEditPanel = PropertiesEditPanel.from(new Properties());
 	private SearchCriteriaEditPanel scEditPanel = new SearchCriteriaEditPanel();
 	private JTextField nameField = new JTextField();
 	private JLabel consumerArgLabel = new JLabel();
@@ -244,8 +244,8 @@ public class RoutingSpecEditPanel
 		consumerTypeSelected();
 		outputFormatSelected();
 
-		propertiesEditPanel.setProperties(editProps);
-		propertiesEditPanel.setPropertiesOwner(this);
+		propertiesEditPanel.getModel().setProperties(editProps);
+		propertiesEditPanel.getModel().setPropertiesOwner(this);
 	}
 
 	/**
@@ -267,7 +267,7 @@ public class RoutingSpecEditPanel
 				(String)presentationGroupCombo.getSelectedItem();
 
 		// Get the properties
-		propertiesEditPanel.saveChanges(); // saves to editProps
+		propertiesEditPanel.getModel().saveChanges(); // saves to editProps
 		
 		theObject.getProperties().clear();
 		PropertiesUtil.copyProps(theObject.getProperties(), editProps);
@@ -539,7 +539,7 @@ Logger.instance().debug3("Added netlist name '" + nln + "'");
 		
 		combinedProps = new PropertySpec[propSpecs.size()];
 		propSpecs.toArray(combinedProps);
-		propertiesEditPanel.setPropertiesOwner(this);
+		propertiesEditPanel.getModel().setPropertiesOwner(this);
 	}
 
 	private void adjustSearchCritFor(DataSourceExec currentDataSource)
@@ -692,4 +692,3 @@ Logger.instance().debug3("Added netlist name '" + nln + "'");
 		return true;
 	}
 }
-

--- a/src/main/java/decodes/dbeditor/SiteEditPanel.java
+++ b/src/main/java/decodes/dbeditor/SiteEditPanel.java
@@ -92,7 +92,7 @@ public class SiteEditPanel extends DbEditorTab
 	{
 		super();
 	    entityOpsPanel = new EntityOpsPanel(this);
-		propsPanel = new PropertiesEditPanel(null);
+		propsPanel = PropertiesEditPanel.from(null);
         try {
             jbInit();
 			TableColumnAdjuster.adjustColumnWidths(siteNameTable,
@@ -144,7 +144,7 @@ public class SiteEditPanel extends DbEditorTab
 			DatabaseIO dbio = site.getDatabase().getDbIo();
 			isCwms = dbio instanceof CwmsSqlDatabaseIO;
 			enableFields();
-			propsPanel.setProperties(theSite.getProperties());
+			propsPanel.getModel().setProperties(theSite.getProperties());
 			fillFields(theSite);
 		}
 	}
@@ -507,7 +507,7 @@ public class SiteEditPanel extends DbEditorTab
 		if (!TextUtil.strEqualIgnoreCase(eu, theSite.getElevationUnits()))
 			return true;
 
-		if (propsPanel.hasChanged())
+		if (propsPanel.getModel().hasChanged())
 			return true;
 
 		return namesChanged;
@@ -558,7 +558,7 @@ public class SiteEditPanel extends DbEditorTab
 			pn = null;
 		theSite.setPublicName(pn);
 
-		propsPanel.saveChanges();
+		propsPanel.getModel().saveChanges();
 
 		return true;
 	}

--- a/src/main/java/decodes/dbeditor/SourceEditPanel.java
+++ b/src/main/java/decodes/dbeditor/SourceEditPanel.java
@@ -80,7 +80,7 @@ public class SourceEditPanel extends DbEditorTab
 			if (dataSource.getDataSourceArg() == null)
 				dataSource.setDataSourceArg("");
 			theProperties = PropertiesUtil.string2props(dataSource.getDataSourceArg());
-			propertiesEditPanel = new PropertiesEditPanel(theProperties);
+			propertiesEditPanel = PropertiesEditPanel.from(theProperties);
 			propertiesEditPanel.setOwnerFrame(getParentFrame());
 
 			groupMemberListModel = new GroupMemberListModel(dataSource);
@@ -129,7 +129,7 @@ public class SourceEditPanel extends DbEditorTab
 	{
 		dataSource.setName(nameField.getText());
 		dataSource.dataSourceType = (String)sourceTypeCombo.getSelectedItem();
-		propertiesEditPanel.saveChanges();
+		propertiesEditPanel.getModel().saveChanges();
 		dataSource.setDataSourceArg(PropertiesUtil.props2string(theProperties));
 	}
 
@@ -218,7 +218,7 @@ public class SourceEditPanel extends DbEditorTab
 					Class<?> dsClass = dsEv.getExecClass();
 					Constructor<?> constructor = dsClass.getConstructor(DataSource.class, Database.class);
 					DataSourceExec exec = (DataSourceExec)constructor.newInstance(dataSource,getDb());
-					propertiesEditPanel.setPropertiesOwner(exec);
+					propertiesEditPanel.getModel().setPropertiesOwner(exec);
 				}
 				catch(Exception ex) {
 					log.error("Error setting properties for '{}'",dsType,ex);
@@ -528,5 +528,3 @@ class GroupMemberListModel extends AbstractListModel
 		this.fireContentsChanged(this, 0, getSize());
 	}
 }
-
-

--- a/src/main/java/decodes/gui/PropertiesEditDialog.java
+++ b/src/main/java/decodes/gui/PropertiesEditDialog.java
@@ -39,6 +39,7 @@ import ilex.util.LoadResourceBundle;
 import java.awt.*;
 import javax.swing.*;
 
+import decodes.gui.properties.PropertiesEditPanelController;
 import decodes.util.DecodesSettings;
 import decodes.util.PropertiesOwner;
 
@@ -49,7 +50,7 @@ import java.awt.event.*;
 
 /**
 Dialog wrapper for a properties edit panel.
-@see PropertiesEditPanel
+@see PropertiesEditPanelController
 */
 public class PropertiesEditDialog extends JDialog 
 {
@@ -84,7 +85,7 @@ public class PropertiesEditDialog extends JDialog
         		entityName));
 
 		this.entityName = entityName;
-        propertiesEditPanel = new PropertiesEditPanel(properties);
+        propertiesEditPanel = PropertiesEditPanel.from(properties);
 		propertiesEditPanel.setOwnerDialog(this);
 
 		try {
@@ -99,7 +100,7 @@ public class PropertiesEditDialog extends JDialog
     
 	public void setPropertiesOwner(PropertiesOwner propertiesOwner)
 	{
-		propertiesEditPanel.setPropertiesOwner(propertiesOwner);
+		propertiesEditPanel.getModel().setPropertiesOwner(propertiesOwner);
 	}
 
 	/**
@@ -160,7 +161,7 @@ public class PropertiesEditDialog extends JDialog
 	*/
     void okButton_actionPerformed(ActionEvent e)
 	{
-		propertiesEditPanel.saveChanges();
+		propertiesEditPanel.getModel().saveChanges();
 		closeDlg();
 		okPressed = true;
     }

--- a/src/main/java/decodes/gui/PropertiesEditPanel.java
+++ b/src/main/java/decodes/gui/PropertiesEditPanel.java
@@ -1,14 +1,10 @@
-/*
- *  $Id$
- */
-
 package decodes.gui;
-
 import java.awt.*;
 
 import javax.swing.*;
 import javax.swing.table.*;
 
+import org.cobraparser.html.domimpl.HTMLElementBuilder.P;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
@@ -23,6 +19,8 @@ import java.util.Enumeration;
 
 import javax.swing.border.*;
 
+import decodes.gui.properties.PropertiesEditPanelController;
+import decodes.gui.properties.PropertiesTableModel;
 import decodes.util.DynamicPropertiesOwner;
 import decodes.util.PropertiesOwner;
 import decodes.util.PropertySpec;
@@ -35,773 +33,246 @@ import ilex.util.TextUtil;
 
 /**
  * A panel that allows you to edit a group of Properties.
- * 
- * @see PropertiesEditDialog
- */
+*
+* @see PropertiesEditDialog
+*/
 @SuppressWarnings("serial")
 public class PropertiesEditPanel extends JPanel
 {
-	private static ResourceBundle genericLabels = null;
-	private JScrollPane jScrollPane1 = new JScrollPane();
-//	private SortingListTable propertiesTable;
-	private JTable propertiesTable;
-	private PropertiesTableModel ptm;
-	private TitledBorder titledBorder1;
-	private JButton editButton = new JButton();
-	private JButton addButton = new JButton();
-	private GridBagLayout gridBagLayout1 = new GridBagLayout();
-	private JDialog ownerDialog;
-	private JFrame ownerFrame;
-	private HashMap<String, PropertySpec> propHash = null;
-	private PropertiesOwner propertiesOwner = null;
+    private static ResourceBundle genericLabels = null;
+    private JScrollPane jScrollPane1 = new JScrollPane();
+    private JTable propertiesTable;
+    private TitledBorder titledBorder1;
+    private JButton editButton = new JButton();
+    private JButton addButton = new JButton();
+    private GridBagLayout gridBagLayout1 = new GridBagLayout();
+    private PropertiesEditController controller = null;
 
-	/** Will be true after any changes were made. */
-	public boolean changesMade;
 
-	/**
-	 * Constructs a PropertiesEditPanel for the passed Properties set.
-	 * 
-	 * @param properties
-	 *            The properties set to edit.
-	 */
-	public PropertiesEditPanel(Properties properties)
-	{
-		this(properties, true);
-	}
+    /** Will be true after any changes were made. */
+    public boolean changesMade;
 
-	public PropertiesEditPanel(Properties properties, boolean canAddAndDelete)
-	{
-		try
-		{
-			genericLabels = PropertiesEditDialog.getGenericLabels();
-			ownerDialog = null;
-			ownerFrame = null;
-			ptm = new PropertiesTableModel(properties);
-			propertiesTable = new SortingListTable(ptm, new int[]{30, 70});
-			propertiesTable.getTableHeader().setReorderingAllowed(false);
-			jbInit(canAddAndDelete);
-		}
-		catch (Exception ex)
-		{
-			ex.printStackTrace();
-		}
-		changesMade = false;
-	}
+    /**
+     * Constructs a PropertiesEditPanel for the passed Properties set.
+    *
+    * @param properties The properties set to edit.
+    * @param canAddAndDelete Is the user allowed to manipulate what properties on in the list.
+    */
+    private PropertiesEditPanel(TableModel model, boolean canAddAndDelete, PropertiesEditController controller)
+    {
+        this.controller = controller;
+        try
+        {
+            genericLabels = PropertiesEditDialog.getGenericLabels();
+            //model, new int[]{30, 70})
+            propertiesTable = new JTable(model);
 
-	public void setTitle(String title)
-	{
-		titledBorder1.setTitle(title);
-	}
+            propertiesTable.setAutoCreateRowSorter(true);
+            propertiesTable.getTableHeader().setReorderingAllowed(false);
+            // Set column renderer so that tooltip is property description
+            TableColumn col = propertiesTable.getColumnModel().getColumn(0);
+            col.setCellRenderer(new ttCellRenderer());
+            col.setPreferredWidth(30);
+            col = propertiesTable.getColumnModel().getColumn(1);
+            col.setCellRenderer(new ttCellRenderer());
+            col.setPreferredWidth(70);
+            jbInit(canAddAndDelete);
+        }
+        catch (Exception ex)
+        {
+            ex.printStackTrace();
+        }
+        changesMade = false;
+    }
 
-	/**
-	 * Sets the owner dialog (if there is one).
-	 * 
-	 * @param dlg
-	 *            the owner dialog
-	 */
-	public void setOwnerDialog(JDialog dlg)
-	{
-		ownerDialog = dlg;
-	}
+    public void setTitle(String title)
+    {
+        titledBorder1.setTitle(title);
+    }
 
-	/**
-	 * Sets the owner frame.
-	 * 
-	 * @param frm
-	 *            the owner frame
-	 */
-	public void setOwnerFrame(JFrame frm)
-	{
-		ownerFrame = frm;
-	}
+    /*
+    * This internal class is used to add tooltip for known properties in the
+    * table
+    */
+    class ttCellRenderer extends DefaultTableCellRenderer
+    {
+        public Component getTableCellRendererComponent(JTable table, Object value,
+            boolean isSelected, boolean hasFocus, int row, int col)
+        {
+            JLabel cr = (JLabel) super.getTableCellRendererComponent(table, value, isSelected,
+                hasFocus, row, col);
+            cr.setOpaque(false);
+            PropertiesTableModel model = (PropertiesTableModel)table.getModel();
+            HashMap<String, PropertySpec> propHash = model.getPropHash();
+            if (propHash != null)
+            {
+                // property name is in column 0
+                int modelRow = table.convertRowIndexToModel(row);
+                String pn = ((String) model.getValueAt(modelRow, 0)).toUpperCase();
+                PropertySpec ps = propHash.get(pn);
+                cr.setToolTipText(ps != null ? ps.getDescription() : "");
+            }
+            if (value instanceof Color)
+            {
+                Color c = (Color)value;
+                cr.setOpaque(true);
+                cr.setBackground(c);
+                cr.setText("0x" + Integer.toHexString(c.getRGB()).substring(2));
+            }
+            return cr;
+        }
+    }
 
-	/**
-	 * Populates the panel with the passed set.
-	 * 
-	 * @param properties
-	 *            The properties to edit.
-	 */
-	public void setProperties(Properties properties)
-	{
-		ptm.setProperties(properties);
-		changesMade = false;
-	}
+    /** Initializes GUI components. */
+    private void jbInit(boolean canAddAndDelete) throws Exception
+    {
+        titledBorder1 = new TitledBorder(
+            BorderFactory.createLineBorder(new Color(153, 153, 153), 2),
+            genericLabels.getString("properties"));
+        this.setLayout(gridBagLayout1);
+        this.setBorder(titledBorder1);
+        JButton deleteButton = new JButton(genericLabels.getString("delete"));
+        deleteButton.addActionListener(e ->
+        {
+            int r = propertiesTable.getSelectedRow();
+            if (r != -1)
+            {
+                final int modelRow = propertiesTable.convertRowIndexToModel(r);
+                new SwingWorker<Void,Void>()
+                {
 
-	/*
-	 * This internal class is used to add tooltip for known properties in the
-	 * table
-	 */
-	class ttCellRenderer extends DefaultTableCellRenderer
-	{
-		public Component getTableCellRendererComponent(JTable table, Object value,
-			boolean isSelected, boolean hasFocus, int row, int col)
-		{
-			JLabel cr = (JLabel) super.getTableCellRendererComponent(table, value, isSelected,
-				hasFocus, row, col);
-			cr.setOpaque(false);
-			if (propHash != null)
-			{
-				// property name is in column 0
-				int modelRow = table.convertRowIndexToModel(row);
-				String pn = ((String) ptm.getValueAt(modelRow, 0)).toUpperCase();
-				PropertySpec ps = propHash.get(pn);
-				cr.setToolTipText(ps != null ? ps.getDescription() : "");
-			}
-			if (value instanceof Color)
-			{
-				Color c = (Color)value;
-				cr.setOpaque(true);
-				cr.setBackground(c);
-				cr.setText("0x" + Integer.toHexString(c.getRGB()).substring(2));
-			}
-			return cr;
-		}
-	}
+                    @Override
+                    protected Void doInBackground() throws Exception
+                    {
+                        controller.deleteButton_actionPerformed(modelRow);
+                        return null;
+                    }
 
-	/** Initializes GUI components. */
-	private void jbInit(boolean canAddAndDelete) throws Exception
-	{
-		titledBorder1 = new TitledBorder(
-			BorderFactory.createLineBorder(new Color(153, 153, 153), 2),
-			genericLabels.getString("properties"));
-		this.setLayout(gridBagLayout1);
-		this.setBorder(titledBorder1);
-		JButton deleteButton = new JButton(genericLabels.getString("delete"));
-		deleteButton.addActionListener(new java.awt.event.ActionListener()
-		{
-			public void actionPerformed(ActionEvent e)
-			{
-				deleteButton_actionPerformed(e);
-			}
-		});
-		addButton.setText(genericLabels.getString("add"));
-		addButton.addActionListener(new java.awt.event.ActionListener()
-		{
-			public void actionPerformed(ActionEvent e)
-			{
-				addButton_actionPerformed(e);
-			}
-		});
-		editButton.setText(genericLabels.getString("edit"));
-		editButton.addActionListener(new java.awt.event.ActionListener()
-		{
-			public void actionPerformed(ActionEvent e)
-			{
-				editPressed();
-			}
-		});
-		this.add(jScrollPane1, 
-			new GridBagConstraints(0, 0, 1, 3, 1.0, 1.0,
-				GridBagConstraints.CENTER, GridBagConstraints.BOTH, 
-				new Insets(2, 4, 2, 4), 0, 0));
-		if (canAddAndDelete)
-			this.add(addButton, 
-				new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0, 
-					GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL, 
-					new Insets(2, 4, 2, 4), 20, 0));
-		this.add(editButton,
-			new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0,
-				GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL, 
-				new Insets(2, 4, 2, 4), 20, 0));
-		if (canAddAndDelete)
-			this.add(deleteButton, 
-				new GridBagConstraints(1, 2, 1, 1, 0.0, 1.0,
-					GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL, 
-					new Insets(2, 4, 2, 4), 20, 0));
-		jScrollPane1.getViewport().add(propertiesTable, null);
-		propertiesTable.setModel(ptm);
-		
-		propertiesTable.addMouseListener(new MouseAdapter()
-		{
-			public void mouseClicked(MouseEvent e)
-			{
-				if (e.getClickCount() == 2)
-				{
-					editPressed();
-				}
-			}
-		} );
+                }.execute();
 
-	}
+            }
 
-	/**
-	 * Called when 'Add' button is pressed. Displays a sub-dialog for the user
-	 * to enter name and value.
-	 * 
-	 * @param e
-	 *            ignored.
-	 */
-	void addButton_actionPerformed(ActionEvent e)
-	{
-		PropertyEditDialog dlg = null;
-		PropertySpec propSpec = null;
-		
-		if (propertiesOwner != null
-		 && (propertiesOwner instanceof DynamicPropertiesOwner)
-		 && ((DynamicPropertiesOwner)propertiesOwner).dynamicPropsAllowed())
-		{
-			propSpec = new PropertySpec("", PropertySpec.STRING, "");
-			propSpec.setDynamic(true);
-		}
-			
-		if (ownerDialog != null)
-			dlg = new PropertyEditDialog(ownerDialog, "", "", propSpec);
-		else if (ownerFrame != null)
-			dlg = new PropertyEditDialog(ownerFrame, "", "", propSpec);
-		else
-			dlg = new PropertyEditDialog(TopFrame.instance(), "", "", propSpec);
-		dlg.setLocation(50, 50);
-		dlg.setLocationRelativeTo(this);
-		dlg.setVisible(true);
-		StringPair sp = dlg.getResult();
-		if (sp != null)
-			ptm.add(sp);
-		else
-			return;
-		
-		if (propSpec != null && propSpec.isDynamic())
-		{
-			((DynamicPropertiesOwner)propertiesOwner).setDynamicPropDescription(
-				sp.first, propSpec.getDescription());
-			propHash.put(propSpec.getName().toUpperCase(), propSpec);
-//System.out.println("Put '" + propSpec.getName() + "' desc=" + propSpec.getDescription()
-//+ " into propHash, dynamic=" + propSpec.isDynamic());
-//PropertySpec tps = propHash.get(propSpec.getName());
-//if (tps == null)
-//System.out.println("After putting, propHash still doesn't have '" + propSpec.getName() + "'");
-		}
-		
-		changesMade = true;
-	}
+        });
+        addButton.setText(genericLabels.getString("add"));
+        addButton.addActionListener(controller::addButton_actionPerformed);
+        editButton.setText(genericLabels.getString("edit"));
+        editButton.addActionListener(e -> fireEditRow());
+        this.add(jScrollPane1,
+            new GridBagConstraints(0, 0, 1, 3, 1.0, 1.0,
+                GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                new Insets(2, 4, 2, 4), 0, 0));
+        if (canAddAndDelete)
+            this.add(addButton,
+                new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
+                    GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                    new Insets(2, 4, 2, 4), 20, 0));
+        this.add(editButton,
+            new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                new Insets(2, 4, 2, 4), 20, 0));
+        if (canAddAndDelete)
+            this.add(deleteButton,
+                new GridBagConstraints(1, 2, 1, 1, 0.0, 1.0,
+                    GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL,
+                    new Insets(2, 4, 2, 4), 20, 0));
+        jScrollPane1.setViewportView(propertiesTable);
 
-	/**
-	 * Called when the 'Edit' button is pressed. Displays a sub-dialog for user
-	 * to edit the selected name/value.
-	 * 
-	 * @param e
-	 *            ignored.
-	 */
-	void editPressed()
-	{
-		int tablerow = propertiesTable.getSelectedRow();
-		if (tablerow == -1)
-			return;
-		//Get the correct row from the table model
-		int modelrow = propertiesTable.convertRowIndexToModel(tablerow);
-		StringPair sp = ptm.propAt(modelrow);
-		PropertySpec propSpec = null;
-		if (propHash != null)
-			propSpec = propHash.get(sp.first.toUpperCase());
-//System.out.println("Editing prop '" + sp.first + "' isDynamic=" + 
-//(propSpec != null && propSpec.isDynamic()));
+        propertiesTable.addMouseListener(new MouseAdapter()
+        {
+            public void mouseClicked(MouseEvent e)
+            {
+                if (e.getClickCount() == 2)
+                {
+                    fireEditRow();
+                }
+            }
+        } );
 
-		PropertyEditDialog dlg = null;
-		Logger.instance().debug3("Editing propspec=" + propSpec);
-		if (ownerDialog != null)
-			dlg = new PropertyEditDialog(ownerDialog, sp.first, sp.second, propSpec);
-		else if (ownerFrame != null)
-			dlg = new PropertyEditDialog(ownerFrame, sp.first, sp.second, propSpec);
-		else
-			dlg = new PropertyEditDialog(TopFrame.instance(), sp.first, sp.second, propSpec);
-		dlg.setLocation(50, 50);
-		dlg.setLocationRelativeTo(this);
-		dlg.setVisible(true);
-		StringPair res = dlg.getResult();
-		if (res != null)
-		{
-			ptm.setPropAt(modelrow, res);
-			changesMade = true;
-			saveChanges();
-		}
-		
-		if (propSpec != null && propSpec.isDynamic())
-		{
-			((DynamicPropertiesOwner)propertiesOwner).setDynamicPropDescription(
-				propSpec.getName(), propSpec.getDescription());
-			propHash.put(propSpec.getName().toUpperCase(), propSpec);
-		}
-	}
+    }
 
-	/**
-	 * Called when the 'Delete' button is pressed. Removes the selected property
-	 * from the table.
-	 * 
-	 * @param e
-	 *            ignored.
-	 */
-	void deleteButton_actionPerformed(ActionEvent e)
-	{
-		int r = propertiesTable.getSelectedRow();
-		if (r == -1)
-			return;
-		StringPair sp = ptm.propAt(r);
-		PropertySpec propSpec = 
-			propHash == null ? null : propHash.get(sp.first.toUpperCase());
-		if (propSpec != null)
-		{
-			propHash.remove(sp.first.toUpperCase());
-			if (propSpec.isDynamic())
-				((DynamicPropertiesOwner)propertiesOwner).setDynamicPropDescription(
-					propSpec.getName(), null);
 
-		}
+    /**
+     * Sets the owner dialog (if there is one).
+    *
+    * @param dlg
+    *            the owner dialog
+    */
+    public void setOwnerDialog(JDialog dlg)
+    {
+        this.controller.setOwnerDialog(dlg);
 
-		ptm.deletePropAt(r);
-		changesMade = true;
-	}
+    }
 
-	/** @return true if anything in the table has been changed. */
-	public boolean hasChanged()
-	{
-		return ptm.hasChanged();
-	}
+    /**
+     * Sets the owner frame.
+    *
+    * @param frm
+    *            the owner frame
+    */
+    public void setOwnerFrame(JFrame frm)
+    {
+        this.controller.setOwnerFrame(frm);
+    }
 
-	/** Saves the changes back to the properties set. */
-	public void saveChanges()
-	{
-		ptm.saveChanges();
-	}
+    public PropertiesTableModel getModel()
+    {
+        return controller.getModel();
+    }
 
-	/**
-	 * Used by the RetProcAdvancedPanel class to repaint the table when the new
-	 * button is pressed.
-	 */
-	public void redrawTable()
-	{
-		ptm.redrawTable();
-	}
+    private void fireEditRow()
+    {
+        int tableRow = propertiesTable.getSelectedRow();
+        if (tableRow == -1)
+            return ;
+        //Get the correct row from the table model
+        final int modelRow = propertiesTable.convertRowIndexToModel(tableRow);
+        new SwingWorker<Void,Void>()
+        {
 
-	/**
-	 * Adds empty properties with the passed names, but doesn't overwrite any
-	 * existing property settings.
-	 * 
-	 * @param propnames
-	 *            array of property names.
-	 */
-	public void addEmptyProps(String[] propnames)
-	{
-		ptm.addEmptyProps(propnames);
-	}
+            @Override
+            protected Void doInBackground() throws Exception
+            {
+                controller.editPressed(modelRow);
+                return null;
+            }
 
-	/**
-	 * Adds a default property name and value, only if a property with this name
-	 * doesn't already exist.
-	 */
-	// public void addDefaultProperty(String name, String value)
-	// {
-	// for(int i=0; i<ptm.props.size(); i++)
-	// if (name.equals(((Property)ptm.props.elementAt(i)).name))
-	// return;
-	// ptm.props.add(new Property(name, value));
-	// System.out.println("Added new property: " + name + "=" + value);
-	// ptm.fireTableDataChanged();
-	// }
+        }.execute();
+    }
 
-	/**
-	 * Return the property value if the name is defined in the table, or null if
-	 * not.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * @return the value of the property or null if undefined.
-	 */
-	public String getProperty(String name)
-	{
-		for (int row = 0; row < this.ptm.getRowCount(); row++)
-		{
-			StringPair sp = ptm.propAt(row);
-			if (sp != null && sp.first.equalsIgnoreCase(name))
-				return sp.second;
-		}
-		return null;
-	}
-	
-	public void rmProperty(String name)
-	{
-		for (int row = 0; row < this.ptm.getRowCount(); row++)
-		{
-			StringPair sp = ptm.propAt(row);
-			if (sp != null && sp.first.equalsIgnoreCase(name))
-			{
-				ptm.deletePropAt(row);
-				changesMade = true;
-				return;
-			}
-		}
-		
-	}
-	
-	public void setProperty(String name, String value)
-	{
-		for (int row = 0; row < this.ptm.getRowCount(); row++)
-		{
-			StringPair sp = ptm.propAt(row);
-			if (sp != null && sp.first.equalsIgnoreCase(name))
-			{
-				sp.second = value;
-				ptm.setPropAt(row, sp);
-				return;
-			}
-		}
-		// Fell through -- this is a new property
-		ptm.add(new StringPair(name, value));
-	}
+    public static PropertiesEditPanel from(Properties properties)
+    {
+        return from(properties, false);
+    }
 
-	/**
-	 * Call this method before setProperties(). The known properties will be
-	 * displayed in the table along with tool tips. Editor dialogs for known
-	 * properties will be tailored to the data type.
-	 * 
-	 * @param propertiesOwner
-	 *            The object owning the properties.
-	 */
-	public void setPropertiesOwner(PropertiesOwner propertiesOwner)
-	{
-		this.propertiesOwner = propertiesOwner;
-		if (propertiesOwner == null)
-		{
-			propHash = null;
-			return;
-		}
-		// For quick access, construct a hash with upper-case names.
-		propHash = new HashMap<String, PropertySpec>();
-		for (PropertySpec ps : propertiesOwner.getSupportedProps())
-			propHash.put(ps.getName().toUpperCase(), ps);
-		if (propertiesOwner instanceof DynamicPropertiesOwner)
-		{
-			DynamicPropertiesOwner dpo = (DynamicPropertiesOwner)propertiesOwner;
-			if (dpo.dynamicPropsAllowed())
-				for(PropertySpec ps : dpo.getDynamicPropSpecs())
-					propHash.put(ps.getName().toUpperCase(), ps);
-		}
 
-		// Set column renderer so that tooltip is property description
-		TableColumn col = propertiesTable.getColumnModel().getColumn(0);
-		col.setCellRenderer(new ttCellRenderer());
-		col = propertiesTable.getColumnModel().getColumn(1);
-		col.setCellRenderer(new ttCellRenderer());
-		ptm.setPropHash(propHash);
-	}
-	
-}
+    public static PropertiesEditPanel from(Properties properties, boolean canAddDelete)
+    {
+        PropertiesTableModel model = new PropertiesTableModel(properties);
+        return from(model, canAddDelete);
+    }
 
-/**
- * Table model for the properties shown in the panel. Table is two-columns for
- * name and value.
- */
-@SuppressWarnings("serial")
-class PropertiesTableModel extends AbstractTableModel
-	implements SortingListTableModel
-{
-	private static final org.slf4j.Logger log = LoggerFactory.getLogger(PropertiesTableModel.class);
-	private static ResourceBundle genericLabels = PropertiesEditDialog.getGenericLabels();
-	/** The properties as a list of StringPair object. */
-	ArrayList<StringPair> props = new ArrayList<StringPair>();
+    public static PropertiesEditPanel from(PropertiesTableModel model, boolean canAddDelete )
+    {
+        PropertiesEditPanelController controller = new PropertiesEditPanelController(model, null);
+        PropertiesEditPanel ret = new PropertiesEditPanel(model, canAddDelete, controller);
+        controller.setView(ret);
+        return ret;
+    }
 
-	/** Column names */
-	static String columnNames[];
 
-	/** The Properties set that we're editing. */
-	Properties origProps;
-
-	/** flag to keep track of changes */
-	boolean changed;
-
-	HashMap<String, PropertySpec> propHash = null;
-
-	/** Constructs a new table model for the passed Properties set. */
-	public PropertiesTableModel(Properties properties)
-	{
-		columnNames = new String[2];
-		columnNames[0] = genericLabels.getString("name");
-		columnNames[1] = genericLabels.getString("PropertiesEditDialog.value");
-		setProperties(properties);
-	}
-
-	/**
-	 * Sets a hash of property specs for known properties for this object. Known
-	 * properties will be shown in the table even if no value is assigned. Can
-	 * be called multiple times if the property specs change. Subsequent calls
-	 * will remove any unassigned properties that are no longer spec'ed.
-	 * 
-	 * @param propHash
-	 *            the has of specs
-	 */
-	public void setPropHash(HashMap<String, PropertySpec> propHash)
-	{
-		this.propHash = propHash;
-		for (String ucName : propHash.keySet())
-		{
-			boolean found = false;
-			for (StringPair prop : props)
-			{
-				if (prop.first.equalsIgnoreCase(ucName))
-				{
-					found = true;
-					break;
-				}
-			}
-			if (!found)
-			{
-				StringPair sp = new StringPair(propHash.get(ucName).getName(), "");
-				props.add(sp);
-				Logger.instance().debug3("Added spec'ed property '" + sp.first + "'");
-			}
-		}
-		// Now remove the unassigned props that are no longer spec'ed
-		for (Iterator<StringPair> spit = props.iterator(); spit.hasNext();)
-		{
-			StringPair sp = spit.next();
-			if ((sp.second == null || sp.second.length() == 0) // value
-																// unassigned
-				&& propHash.get(sp.first.toUpperCase()) == null) // not in spec
-																	// hash
-			{
-				spit.remove();
-				Logger.instance().debug3("Removed unspec'ed property '" + sp.first + "'");
-			}
-		}
-		Logger.instance().debug3("Property table now has " + props.size() + " rows.");
-		this.fireTableDataChanged();
-	}
-
-	/** Sets the properties set being edited. */
-	public void setProperties(Properties properties)
-	{
-		origProps = properties;
-		changed = false;
-
-		if (origProps == null)
-			return;
-
-		props.clear();
-		TreeSet<String> names = new TreeSet<String>();
-		Enumeration<?> pe = properties.propertyNames();
-		while (pe.hasMoreElements())
-			names.add((String) pe.nextElement());
-		if (propHash != null)
-			for (PropertySpec ps : propHash.values())
-				names.add(ps.getName());
-
-		for (String name : names)
-		{
-			String value = properties.getProperty(name);
-			if (value == null)
-				value = "";
-			props.add(new StringPair(name, value));
-		}
-	}
-
-	/** Returns number of rows */
-	public int getRowCount()
-	{
-		return props.size();
-	}
-
-	/** Returns number of columns */
-	public int getColumnCount()
-	{
-		return columnNames.length;
-	}
-
-	/** Returns column name */
-	public String getColumnName(int col)
-	{
-		return columnNames[col];
-	}
-
-	/** Returns a String value at specified row/column */
-	public Object getValueAt(int row, int column)
-	{
-		if (row >= getRowCount())
-			return null;
-		StringPair sp = props.get(row);
-		if (column == 0)
-			return sp.first;
-		if (sp.first != null 
-		 && (sp.first.toLowerCase().contains("password") || sp.first.toLowerCase().contains("passwd"))
-		 && !sp.first.equalsIgnoreCase("passwordCheckerClass")
-		 && sp.second != null && sp.second.length() > 0)
-			return "****";
-		PropertySpec ps = propHash != null ? propHash.get(sp.first.toUpperCase()) : null;
-		if (ps != null && ps.getType().equals(PropertySpec.COLOR))
-		{
-			log.trace("Returning a Color object.");
-			if (sp.second.toLowerCase().startsWith("0x"))
-			{
-				return new Color(Integer.parseInt(sp.second.substring(2), 16));
-			}
-			else
-			{
-				return sp.second;
-			}
-		}
-		else
-		{
-			return sp.second;
-		}
-	}
-	
-	/**
-	 * Return the current value of a given property, or null if it's not set.
-	 * @param propName the name of the property to retrieve.
-	 * @return the current value of a given property, or null if it's not set.
-	 */
-	public String getCurrentPropValue(String propName)
-	{
-		for(StringPair sp : props)
-			if (sp.first.equalsIgnoreCase(propName))
-				return sp.second;
-		return null;
-	}
-
-	/** Adds a new property to the model. */
-	public void add(StringPair prop)
-	{
-		if (TextUtil.isAllWhitespace(prop.first))
-		{
-			TopFrame.instance().showError(genericLabels.getString("PropertiesEditDialog.blankErr"));
-			return;
-		}
-
-		props.add(prop);
-		fireTableDataChanged();
-		changed = true;
-	}
-
-	/** Returns selected row-property as a StringPair object. */
-	public StringPair propAt(int row)
-	{
-		if (row >= getRowCount())
-			return null;
-		return props.get(row);
-	}
-
-	/** Sets selected row-property from a StringPair object. */
-	public void setPropAt(int row, StringPair prop)
-	{
-		if (row >= getRowCount())
-			return;
-		if (TextUtil.isAllWhitespace(prop.first))
-		{
-			TopFrame.instance().showError(genericLabels.getString("PropertiesEditDialog.blankErr"));
-			return;
-		}
-		props.set(row, prop);
-		fireTableDataChanged();
-		changed = true;
-	}
-
-	void addEmptyProps(String[] propnames)
-	{
-		int numAdded = 0;
-		for (String nm : propnames)
-		{
-			int row = 0;
-			for (; row < getRowCount(); row++)
-			{
-				StringPair sp = propAt(row);
-				if (nm.equalsIgnoreCase(sp.first))
-					break;
-			}
-			if (row >= getRowCount()) // fell through - not found.
-			{
-				add(new StringPair(nm, ""));
-				numAdded++;
-			}
-		}
-		if (numAdded > 0)
-		{
-			fireTableDataChanged();
-			changed = true;
-		}
-	}
-
-	/** Deletes specified row */
-	public void deletePropAt(int row)
-	{
-		if (row >= getRowCount())
-			return;
-		props.remove(row);
-		fireTableDataChanged();
-		changed = true;
-	}
-
-	/** Returns true if anything has been changed. */
-	public boolean hasChanged()
-	{
-		return changed;
-	}
-
-	/** Saves changes from the model back to the java.util.Properties set. */
-	public void saveChanges()
-	{
-		origProps.clear();
-		for (int i = 0; i < props.size(); i++)
-		{
-			StringPair sp = props.get(i);
-			if (sp.second != null && sp.second.trim().length() > 0)
-				origProps.setProperty(sp.first, sp.second);
-		}
-		changed = false;
-	}
-
-	/**
-	 * Used by the RetProcAdvancedPanel class to repaint the table when the new
-	 * button is pressed.
-	 */
-	public void redrawTable()
-	{
-		saveChanges();
-		fireTableDataChanged();
-	}
-
-	@Override
-	public void sortByColumn(int column)
-	{
-		if (column == 0)
-			Collections.sort(props,
-				new Comparator<StringPair>()
-				{
-					@Override
-					public int compare(StringPair o1, StringPair o2)
-					{
-						return o1.first.compareTo(o2.first);
-					}
-				});
-		else
-			Collections.sort(props,
-				new Comparator<StringPair>()
-				{
-					@Override
-					public int compare(StringPair o1, StringPair o2)
-					{
-						String s1 = o1.second;
-						String s2 = o2.second;
-						if (s1 == null || s1.trim().length() == 0)
-						{
-							if (s2 == null || s2.trim().length() == 0)
-								return o1.first.compareToIgnoreCase(o2.first);
-							else // sort non-empty strings to the front
-								return 1;
-						}
-						else // s1 is not empty
-						{
-							if (s2 == null || s2.trim().length() == 0)
-								return -1;
-							int r = s1.compareToIgnoreCase(s2);
-							if (r != 0)
-								return r;
-							return o1.first.compareToIgnoreCase(o2.first);
-						}
-					}
-				});
-		fireTableDataChanged();
-	}
-
-	@Override
-	public Object getRowObject(int row)
-	{
-		return props.get(row);
-	}
+    public static interface PropertiesEditController
+    {
+        void editPressed(int modelRow);
+        void deleteButton_actionPerformed(int modelRow);
+        void addButton_actionPerformed(ActionEvent e);
+        void setOwnerDialog(JDialog dlg);
+        /**
+         * Sets the owner frame.
+        *
+        * @param frm
+        *            the owner frame
+        */
+        void setOwnerFrame(JFrame frm);
+        PropertiesTableModel getModel();
+    }
 }

--- a/src/main/java/decodes/gui/PropertiesEditPanel.java
+++ b/src/main/java/decodes/gui/PropertiesEditPanel.java
@@ -4,39 +4,23 @@ import java.awt.*;
 import javax.swing.*;
 import javax.swing.table.*;
 
-import org.cobraparser.html.domimpl.HTMLElementBuilder.P;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Properties;
 import java.util.ResourceBundle;
-import java.util.TreeSet;
-import java.util.Enumeration;
 
 import javax.swing.border.*;
 
 import decodes.gui.properties.PropertiesEditPanelController;
 import decodes.gui.properties.PropertiesTableModel;
-import decodes.util.DynamicPropertiesOwner;
-import decodes.util.PropertiesOwner;
 import decodes.util.PropertySpec;
 
 import java.awt.event.*;
-
-import ilex.util.Logger;
-import ilex.util.StringPair;
-import ilex.util.TextUtil;
 
 /**
  * A panel that allows you to edit a group of Properties.
 *
 * @see PropertiesEditDialog
 */
-@SuppressWarnings("serial")
 public class PropertiesEditPanel extends JPanel
 {
     private static ResourceBundle genericLabels = null;

--- a/src/main/java/decodes/gui/PropertyEditDialog.java
+++ b/src/main/java/decodes/gui/PropertyEditDialog.java
@@ -22,7 +22,6 @@ import java.util.ResourceBundle;
 
 import ilex.util.AsciiUtil;
 import ilex.util.EnvExpander;
-import ilex.util.Logger;
 import ilex.util.StringPair;
 import ilex.util.TextUtil;
 
@@ -30,11 +29,9 @@ import ilex.util.TextUtil;
  * Dialog for editing a single property name and value.
  */
 @SuppressWarnings("serial")
-public class PropertyEditDialog 
-	extends GuiDialog
+public class PropertyEditDialog extends GuiDialog
 {
-	private static ResourceBundle genericLabels = 
-		PropertiesEditDialog.getGenericLabels();
+	private static ResourceBundle genericLabels = PropertiesEditDialog.getGenericLabels();
 	private JButton okButton = new JButton();
 	private JButton cancelButton = new JButton();
 	private String name, value;
@@ -49,7 +46,7 @@ public class PropertyEditDialog
 	/**
 	 * Construct dialog with frame owner.
 	 * 
-	 * @param owne the owner frame
+	 * @param owner the owner frame
 	 * @param name the property name
 	 * @param value the property value edited in a JTextField
 	 */
@@ -61,7 +58,7 @@ public class PropertyEditDialog
 	/**
 	 * Construct dialog with frame owner.
 	 * 
-	 * @param owne the owner frame
+	 * @param owner the owner frame
 	 * @param name the property name
 	 * @param value the property value edited in a JTextField
 	 * @param propSpec the Specification for this property

--- a/src/main/java/decodes/gui/properties/PropertiesEditPanelController.java
+++ b/src/main/java/decodes/gui/properties/PropertiesEditPanelController.java
@@ -47,7 +47,6 @@ import ilex.util.TextUtil;
 public class PropertiesEditPanelController implements PropertiesEditController
 {
     private PropertiesOwner propertiesOwner;
-    private HashMap<String, PropertySpec> propHash = null;
     private PropertiesEditPanel view;
     private PropertiesTableModel model;
     private JDialog ownerDialog;
@@ -141,7 +140,7 @@ public class PropertiesEditPanelController implements PropertiesEditController
         {
             ((DynamicPropertiesOwner)propertiesOwner).setDynamicPropDescription(
                 sp.first, propSpec.getDescription());
-            propHash.put(propSpec.getName().toUpperCase(), propSpec);
+            model.getPropHash().put(propSpec.getName().toUpperCase(), propSpec);
         }
 
         changesMade = true;
@@ -159,8 +158,8 @@ public class PropertiesEditPanelController implements PropertiesEditController
 
         StringPair sp = model.propAt(modelRow);
         PropertySpec propSpec = null;
-        if (propHash != null)
-            propSpec = propHash.get(sp.first.toUpperCase());
+        if (model.getPropHash() != null)
+            propSpec = model.getPropHash().get(sp.first.toUpperCase());
 //System.out.println("Editing prop '" + sp.first + "' isDynamic=" +
 //(propSpec != null && propSpec.isDynamic()));
 
@@ -187,7 +186,7 @@ public class PropertiesEditPanelController implements PropertiesEditController
         {
             ((DynamicPropertiesOwner)propertiesOwner).setDynamicPropDescription(
                 propSpec.getName(), propSpec.getDescription());
-            propHash.put(propSpec.getName().toUpperCase(), propSpec);
+            model.getPropHash().put(propSpec.getName().toUpperCase(), propSpec);
         }
     }
 
@@ -204,10 +203,10 @@ public class PropertiesEditPanelController implements PropertiesEditController
             return;
         StringPair sp = model.propAt(modelRow);
         PropertySpec propSpec =
-            propHash == null ? null : propHash.get(sp.first.toUpperCase());
+            model.getPropHash() == null ? null : model.getPropHash().get(sp.first.toUpperCase());
         if (propSpec != null)
         {
-            propHash.remove(sp.first.toUpperCase());
+            model.getPropHash().remove(sp.first.toUpperCase());
             if (propSpec.isDynamic())
                 ((DynamicPropertiesOwner)propertiesOwner).setDynamicPropDescription(
                     propSpec.getName(), null);

--- a/src/main/java/decodes/gui/properties/PropertiesEditPanelController.java
+++ b/src/main/java/decodes/gui/properties/PropertiesEditPanelController.java
@@ -1,0 +1,276 @@
+/*
+ *  $Id$
+ */
+
+package decodes.gui.properties;
+
+import java.awt.*;
+
+import javax.swing.*;
+import javax.swing.table.*;
+
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.ResourceBundle;
+import java.util.TreeSet;
+import java.util.Enumeration;
+
+import javax.swing.border.*;
+
+import decodes.gui.PropertiesEditDialog;
+import decodes.gui.PropertiesEditPanel;
+import decodes.gui.PropertyEditDialog;
+import decodes.gui.TopFrame;
+import decodes.gui.PropertiesEditPanel.PropertiesEditController;
+import decodes.util.DynamicPropertiesOwner;
+import decodes.util.PropertiesOwner;
+import decodes.util.PropertySpec;
+
+import java.awt.event.*;
+
+import ilex.util.Logger;
+import ilex.util.StringPair;
+import ilex.util.TextUtil;
+
+/**
+ * A panel that allows you to edit a group of Properties.
+ *
+ * @see PropertiesEditDialog
+ */
+@SuppressWarnings("serial")
+public class PropertiesEditPanelController implements PropertiesEditController
+{
+    private PropertiesOwner propertiesOwner;
+    private HashMap<String, PropertySpec> propHash = null;
+    private PropertiesEditPanel view;
+    private PropertiesTableModel model;
+    private JDialog ownerDialog;
+    private JFrame ownerFrame;
+    private boolean changesMade = false;
+
+    public PropertiesEditPanelController(PropertiesTableModel model, PropertiesEditPanel view)
+    {
+        this.model = model;
+        this.view = view;
+    }
+
+    /**
+     * Populates the panel with the passed set.
+    *
+    * @param properties
+    *            The properties to edit.
+    */
+    public void setProperties(Properties properties)
+    {
+        model.setProperties(properties);
+        changesMade = false;
+    }
+
+    public void setView(PropertiesEditPanel view)
+    {
+        this.view = view;
+    }
+
+    /**
+     * Sets the owner dialog (if there is one).
+    *
+    * @param dlg
+    *            the owner dialog
+    */
+    @Override
+    public void setOwnerDialog(JDialog dlg)
+    {
+        ownerDialog = dlg;
+    }
+
+    /**
+     * Sets the owner frame.
+    *
+    * @param frm
+    *            the owner frame
+    */
+    @Override
+    public void setOwnerFrame(JFrame frm)
+    {
+        ownerFrame = frm;
+    }
+
+
+    /**
+     * Called when 'Add' button is pressed. Displays a sub-dialog for the user
+    * to enter name and value.
+    *
+    * @param e
+    *            ignored.
+    */
+    public void addButton_actionPerformed(ActionEvent e)
+    {
+        PropertyEditDialog dlg = null;
+        PropertySpec propSpec = null;
+
+        if (propertiesOwner != null
+        && (propertiesOwner instanceof DynamicPropertiesOwner)
+        && ((DynamicPropertiesOwner)propertiesOwner).dynamicPropsAllowed())
+        {
+            propSpec = new PropertySpec("", PropertySpec.STRING, "");
+            propSpec.setDynamic(true);
+        }
+
+        if (ownerDialog != null)
+            dlg = new PropertyEditDialog(ownerDialog, "", "", propSpec);
+        else if (ownerFrame != null)
+            dlg = new PropertyEditDialog(ownerFrame, "", "", propSpec);
+        else
+            dlg = new PropertyEditDialog(TopFrame.instance(), "", "", propSpec);
+        dlg.setLocation(50, 50);
+        dlg.setLocationRelativeTo(view);
+        dlg.setVisible(true);
+        StringPair sp = dlg.getResult();
+        if (sp != null)
+            model.add(sp);
+        else
+            return;
+
+        if (propSpec != null && propSpec.isDynamic())
+        {
+            ((DynamicPropertiesOwner)propertiesOwner).setDynamicPropDescription(
+                sp.first, propSpec.getDescription());
+            propHash.put(propSpec.getName().toUpperCase(), propSpec);
+        }
+
+        changesMade = true;
+    }
+
+    /**
+     * Called when the 'Edit' button is pressed. Displays a sub-dialog for user
+    * to edit the selected name/value.
+    *
+    * @param e
+    *            ignored.
+    */
+    public void editPressed(int modelRow)
+    {
+
+        StringPair sp = model.propAt(modelRow);
+        PropertySpec propSpec = null;
+        if (propHash != null)
+            propSpec = propHash.get(sp.first.toUpperCase());
+//System.out.println("Editing prop '" + sp.first + "' isDynamic=" +
+//(propSpec != null && propSpec.isDynamic()));
+
+        PropertyEditDialog dlg = null;
+        Logger.instance().debug3("Editing propspec=" + propSpec);
+        if (ownerDialog != null)
+            dlg = new PropertyEditDialog(ownerDialog, sp.first, sp.second, propSpec);
+        else if (ownerFrame != null)
+            dlg = new PropertyEditDialog(ownerFrame, sp.first, sp.second, propSpec);
+        else
+            dlg = new PropertyEditDialog(TopFrame.instance(), sp.first, sp.second, propSpec);
+        dlg.setLocation(50, 50);
+        dlg.setLocationRelativeTo(view);
+        dlg.setVisible(true);
+        StringPair res = dlg.getResult();
+        if (res != null)
+        {
+            model.setPropAt(modelRow, res);
+            changesMade = true;
+            saveChanges();
+        }
+
+        if (propSpec != null && propSpec.isDynamic())
+        {
+            ((DynamicPropertiesOwner)propertiesOwner).setDynamicPropDescription(
+                propSpec.getName(), propSpec.getDescription());
+            propHash.put(propSpec.getName().toUpperCase(), propSpec);
+        }
+    }
+
+    /**
+     * Called when the 'Delete' button is pressed. Removes the selected property
+    * from the table.
+    *
+    * @param e
+    *            ignored.
+    */
+    public void deleteButton_actionPerformed(int modelRow)
+    {
+        if (modelRow == -1)
+            return;
+        StringPair sp = model.propAt(modelRow);
+        PropertySpec propSpec =
+            propHash == null ? null : propHash.get(sp.first.toUpperCase());
+        if (propSpec != null)
+        {
+            propHash.remove(sp.first.toUpperCase());
+            if (propSpec.isDynamic())
+                ((DynamicPropertiesOwner)propertiesOwner).setDynamicPropDescription(
+                    propSpec.getName(), null);
+
+        }
+
+        model.deletePropAt(modelRow);
+        changesMade = true;
+    }
+
+    /** @return true if anything in the table has been changed. */
+    public boolean hasChanged()
+    {
+        return model.hasChanged();
+    }
+
+    /** Saves the changes back to the properties set. */
+    public void saveChanges()
+    {
+        model.saveChanges();
+    }
+
+    /**
+     * Used by the RetProcAdvancedPanel class to repaint the table when the new
+    * button is pressed.
+    */
+    public void redrawTable()
+    {
+        model.redrawTable();
+    }
+
+    /**
+     * Adds empty properties with the passed names, but doesn't overwrite any
+    * existing property settings.
+    *
+    * @param propnames
+    *            array of property names.
+    */
+    public void addEmptyProps(String[] propnames)
+    {
+        model.addEmptyProps(propnames);
+    }
+
+    /**
+     * Adds a default property name and value, only if a property with this name
+    * doesn't already exist.
+    */
+    // public void addDefaultProperty(String name, String value)
+    // {
+    // for(int i=0; i<model.props.size(); i++)
+    // if (name.equals(((Property)model.props.elementAt(i)).name))
+    // return;
+    // model.props.add(new Property(name, value));
+    // System.out.println("Added new property: " + name + "=" + value);
+    // model.fireTableDataChanged();
+    // }
+
+
+
+
+    @Override
+    public PropertiesTableModel getModel()
+    {
+        return this.model;
+    }
+}

--- a/src/main/java/decodes/gui/properties/PropertiesTableModel.java
+++ b/src/main/java/decodes/gui/properties/PropertiesTableModel.java
@@ -29,19 +29,19 @@ public class PropertiesTableModel extends AbstractTableModel
      private static final org.slf4j.Logger log = LoggerFactory.getLogger(PropertiesTableModel.class);
      private static ResourceBundle genericLabels = PropertiesEditDialog.getGenericLabels();
      /** The properties as a list of StringPair object. */
-     ArrayList<StringPair> props = new ArrayList<StringPair>();
+     private ArrayList<StringPair> props = new ArrayList<StringPair>();
      private PropertiesOwner propertiesOwner;
 
      /** Column names */
-     static String columnNames[];
+     private static String columnNames[];
 
      /** The Properties set that we're editing. */
-     Properties origProps;
+     private Properties origProps;
 
      /** flag to keep track of changes */
-     boolean changed;
+     private boolean changed;
 
-     HashMap<String, PropertySpec> propHash = null;
+     private HashMap<String, PropertySpec> propHash = null;
 
      /** Constructs a new table model for the passed Properties set. */
      public PropertiesTableModel(Properties properties)
@@ -316,7 +316,9 @@ public class PropertiesTableModel extends AbstractTableModel
         // For quick access, construct a hash with upper-case names.
         propHash = new HashMap<String, PropertySpec>();
         for (PropertySpec ps : propertiesOwner.getSupportedProps())
+        {
             propHash.put(ps.getName().toUpperCase(), ps);
+        }
         if (propertiesOwner instanceof DynamicPropertiesOwner)
         {
             DynamicPropertiesOwner dpo = (DynamicPropertiesOwner)propertiesOwner;

--- a/src/main/java/decodes/gui/properties/PropertiesTableModel.java
+++ b/src/main/java/decodes/gui/properties/PropertiesTableModel.java
@@ -2,8 +2,6 @@ package decodes.gui.properties;
 
 import java.awt.Color;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -20,7 +18,6 @@ import decodes.gui.TopFrame;
 import decodes.util.DynamicPropertiesOwner;
 import decodes.util.PropertiesOwner;
 import decodes.util.PropertySpec;
-import ilex.util.Logger;
 import ilex.util.StringPair;
 import ilex.util.TextUtil;
 
@@ -83,7 +80,7 @@ public class PropertiesTableModel extends AbstractTableModel
              {
                  StringPair sp = new StringPair(propHash.get(ucName).getName(), "");
                  props.add(sp);
-                 Logger.instance().debug3("Added spec'ed property '" + sp.first + "'");
+                 log.trace("Added spec'ed property '{}'", sp.first);
              }
          }
          // Now remove the unassigned props that are no longer spec'ed
@@ -96,10 +93,10 @@ public class PropertiesTableModel extends AbstractTableModel
                                                                      // hash
              {
                  spit.remove();
-                 Logger.instance().debug3("Removed unspec'ed property '" + sp.first + "'");
+                 log.trace("Removed unspec'ed property '{}'", sp.first);
              }
          }
-         Logger.instance().debug3("Property table now has " + props.size() + " rows.");
+         log.trace("Property table now has {} rows.", props.size());
          this.fireTableDataChanged();
      }
 
@@ -233,10 +230,10 @@ public class PropertiesTableModel extends AbstractTableModel
          changed = true;
      }
 
-     public void addEmptyProps(String[] propnames)
+     public void addEmptyProps(String[] propNames)
      {
          int numAdded = 0;
-         for (String nm : propnames)
+         for (String nm : propNames)
          {
              int row = 0;
              for (; row < getRowCount(); row++)
@@ -384,4 +381,12 @@ public class PropertiesTableModel extends AbstractTableModel
         fireTableRowsInserted(props.size()-1, props.size()-1);
     }
 
+    /**
+     * Return the Property Owner in case a downstream component needs to check something.
+     * @return The set properties owner
+     */
+    public PropertiesOwner getPropertiesOwner()
+    {
+        return this.propertiesOwner;
+    }
  }

--- a/src/main/java/decodes/gui/properties/PropertiesTableModel.java
+++ b/src/main/java/decodes/gui/properties/PropertiesTableModel.java
@@ -1,0 +1,385 @@
+package decodes.gui.properties;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.ResourceBundle;
+import java.util.TreeSet;
+
+import javax.swing.table.AbstractTableModel;
+
+import org.slf4j.LoggerFactory;
+
+import decodes.gui.PropertiesEditDialog;
+import decodes.gui.TopFrame;
+import decodes.util.DynamicPropertiesOwner;
+import decodes.util.PropertiesOwner;
+import decodes.util.PropertySpec;
+import ilex.util.Logger;
+import ilex.util.StringPair;
+import ilex.util.TextUtil;
+
+public class PropertiesTableModel extends AbstractTableModel
+ {
+     private static final org.slf4j.Logger log = LoggerFactory.getLogger(PropertiesTableModel.class);
+     private static ResourceBundle genericLabels = PropertiesEditDialog.getGenericLabels();
+     /** The properties as a list of StringPair object. */
+     ArrayList<StringPair> props = new ArrayList<StringPair>();
+     private PropertiesOwner propertiesOwner;
+
+     /** Column names */
+     static String columnNames[];
+
+     /** The Properties set that we're editing. */
+     Properties origProps;
+
+     /** flag to keep track of changes */
+     boolean changed;
+
+     HashMap<String, PropertySpec> propHash = null;
+
+     /** Constructs a new table model for the passed Properties set. */
+     public PropertiesTableModel(Properties properties)
+     {
+         columnNames = new String[2];
+         columnNames[0] = genericLabels.getString("name");
+         columnNames[1] = genericLabels.getString("PropertiesEditDialog.value");
+         setProperties(properties);
+     }
+
+     public HashMap<String,PropertySpec> getPropHash() {
+        return propHash;
+     }
+
+     /**
+      * Sets a hash of property specs for known properties for this object. Known
+      * properties will be shown in the table even if no value is assigned. Can
+      * be called multiple times if the property specs change. Subsequent calls
+      * will remove any unassigned properties that are no longer spec'ed.
+      *
+      * @param propHash
+      *            the has of specs
+      */
+     public void setPropHash(HashMap<String, PropertySpec> propHash)
+     {
+         this.propHash = propHash;
+         for (String ucName : propHash.keySet())
+         {
+             boolean found = false;
+             for (StringPair prop : props)
+             {
+                 if (prop.first.equalsIgnoreCase(ucName))
+                 {
+                     found = true;
+                     break;
+                 }
+             }
+             if (!found)
+             {
+                 StringPair sp = new StringPair(propHash.get(ucName).getName(), "");
+                 props.add(sp);
+                 Logger.instance().debug3("Added spec'ed property '" + sp.first + "'");
+             }
+         }
+         // Now remove the unassigned props that are no longer spec'ed
+         for (Iterator<StringPair> spit = props.iterator(); spit.hasNext();)
+         {
+             StringPair sp = spit.next();
+             if ((sp.second == null || sp.second.length() == 0) // value
+                                                                 // unassigned
+                 && propHash.get(sp.first.toUpperCase()) == null) // not in spec
+                                                                     // hash
+             {
+                 spit.remove();
+                 Logger.instance().debug3("Removed unspec'ed property '" + sp.first + "'");
+             }
+         }
+         Logger.instance().debug3("Property table now has " + props.size() + " rows.");
+         this.fireTableDataChanged();
+     }
+
+     /** Sets the properties set being edited. */
+     public void setProperties(Properties properties)
+     {
+         origProps = properties;
+         changed = false;
+
+         if (origProps == null)
+             return;
+
+         props.clear();
+         TreeSet<String> names = new TreeSet<String>();
+         Enumeration<?> pe = properties.propertyNames();
+         while (pe.hasMoreElements())
+             names.add((String) pe.nextElement());
+         if (propHash != null)
+             for (PropertySpec ps : propHash.values())
+                 names.add(ps.getName());
+
+         for (String name : names)
+         {
+             String value = properties.getProperty(name);
+             if (value == null)
+                 value = "";
+             props.add(new StringPair(name, value));
+         }
+     }
+
+     /** Returns number of rows */
+     public int getRowCount()
+     {
+         return props.size();
+     }
+
+     /** Returns number of columns */
+     public int getColumnCount()
+     {
+         return columnNames.length;
+     }
+
+     /** Returns column name */
+     public String getColumnName(int col)
+     {
+         return columnNames[col];
+     }
+
+     /** Returns a String value at specified row/column */
+     public Object getValueAt(int row, int column)
+     {
+         if (row >= getRowCount())
+             return null;
+         StringPair sp = props.get(row);
+         if (column == 0)
+             return sp.first;
+         if (sp.first != null
+          && (sp.first.toLowerCase().contains("password") || sp.first.toLowerCase().contains("passwd"))
+          && !sp.first.equalsIgnoreCase("passwordCheckerClass")
+          && sp.second != null && sp.second.length() > 0)
+             return "****";
+         PropertySpec ps = propHash != null ? propHash.get(sp.first.toUpperCase()) : null;
+         if (ps != null && ps.getType().equals(PropertySpec.COLOR))
+         {
+             if (sp.second.toLowerCase().startsWith("0x"))
+             {
+                 return new Color(Integer.parseInt(sp.second.substring(2), 16));
+             }
+             else
+             {
+                 return sp.second;
+             }
+         }
+         else
+         {
+             return sp.second;
+         }
+     }
+
+     /**
+      * Return the current value of a given property, or null if it's not set.
+      * @param propName the name of the property to retrieve.
+      * @return the current value of a given property, or null if it's not set.
+      */
+     public String getCurrentPropValue(String propName)
+     {
+        for(StringPair sp : props)
+        {
+            if (sp.first.equalsIgnoreCase(propName))
+            {
+                return sp.second;
+            }
+        }
+        return null;
+     }
+
+     /** Adds a new property to the model. */
+     public void add(StringPair prop)
+     {
+         if (TextUtil.isAllWhitespace(prop.first))
+         {
+             TopFrame.instance().showError(genericLabels.getString("PropertiesEditDialog.blankErr"));
+             return;
+         }
+
+         props.add(prop);
+         fireTableRowsInserted(props.size()-1, props.size()-1);
+         changed = true;
+     }
+
+     /** Returns selected row-property as a StringPair object. */
+     public StringPair propAt(int row)
+     {
+         if (row >= getRowCount())
+             return null;
+         return props.get(row);
+     }
+
+     /** Sets selected row-property from a StringPair object. */
+     public void setPropAt(int row, StringPair prop)
+     {
+         if (row >= getRowCount())
+             return;
+         if (TextUtil.isAllWhitespace(prop.first))
+         {
+             TopFrame.instance().showError(genericLabels.getString("PropertiesEditDialog.blankErr"));
+             return;
+         }
+         props.set(row, prop);
+         fireTableRowsUpdated(row, row);
+         changed = true;
+     }
+
+     public void addEmptyProps(String[] propnames)
+     {
+         int numAdded = 0;
+         for (String nm : propnames)
+         {
+             int row = 0;
+             for (; row < getRowCount(); row++)
+             {
+                 StringPair sp = propAt(row);
+                 if (nm.equalsIgnoreCase(sp.first))
+                     break;
+             }
+             if (row >= getRowCount()) // fell through - not found.
+             {
+                 add(new StringPair(nm, ""));
+                 numAdded++;
+             }
+         }
+         if (numAdded > 0)
+         {
+             fireTableDataChanged();
+             changed = true;
+         }
+     }
+
+     /** Deletes specified row */
+     public void deletePropAt(int row)
+     {
+         if (row >= getRowCount())
+             return;
+         props.remove(row);
+         fireTableDataChanged();
+         changed = true;
+     }
+
+     /** Returns true if anything has been changed. */
+     public boolean hasChanged()
+     {
+         return changed;
+     }
+
+     /** Saves changes from the model back to the java.util.Properties set. */
+     public void saveChanges()
+     {
+         origProps.clear();
+         for (int i = 0; i < props.size(); i++)
+         {
+             StringPair sp = props.get(i);
+             if (sp.second != null && sp.second.trim().length() > 0)
+                 origProps.setProperty(sp.first, sp.second);
+         }
+         changed = false;
+     }
+
+     /**
+      * Used by the RetProcAdvancedPanel class to repaint the table when the new
+      * button is pressed.
+      */
+     public void redrawTable()
+     {
+         saveChanges();
+         fireTableDataChanged();
+     }
+
+     /**
+     * Call this method before setProperties(). The known properties will be
+    * displayed in the table along with tool tips. Editor dialogs for known
+    * properties will be tailored to the data type.
+    *
+    * @param propertiesOwner
+    *            The object owning the properties.
+    */
+    public void setPropertiesOwner(PropertiesOwner propertiesOwner)
+    {
+        this.propertiesOwner = propertiesOwner;
+        if (propertiesOwner == null)
+        {
+            propHash = null;
+            return;
+        }
+        // For quick access, construct a hash with upper-case names.
+        propHash = new HashMap<String, PropertySpec>();
+        for (PropertySpec ps : propertiesOwner.getSupportedProps())
+            propHash.put(ps.getName().toUpperCase(), ps);
+        if (propertiesOwner instanceof DynamicPropertiesOwner)
+        {
+            DynamicPropertiesOwner dpo = (DynamicPropertiesOwner)propertiesOwner;
+            if (dpo.dynamicPropsAllowed())
+                for(PropertySpec ps : dpo.getDynamicPropSpecs())
+                    propHash.put(ps.getName().toUpperCase(), ps);
+        }
+
+
+        this.setPropHash(propHash);
+        fireTableDataChanged();
+    }
+
+
+    /**
+     * Return the property value if the name is defined in the table, or null if
+    * not.
+    *
+    * @param name
+    *            the name of the property
+    * @return the value of the property or null if undefined.
+    */
+    public String getProperty(String name)
+    {
+        for (StringPair sp: this.props)
+        {
+            if (sp != null && sp.first.equalsIgnoreCase(name))
+            {
+                return sp.second;
+            }
+        }
+        return null;
+    }
+
+    public void rmProperty(String name)
+    {
+        for (int row = 0; row < props.size(); row++)
+        {
+            StringPair sp = props.get(row);
+            if (sp != null && sp.first.equalsIgnoreCase(name))
+            {
+                deletePropAt(row);
+                changed = true;
+                return;
+            }
+        }
+    }
+
+    public void setProperty(String name, String value)
+    {
+        for (int row = 0; row < props.size(); row++)
+        {
+            StringPair sp = props.get(row);
+            if (sp != null && sp.first.equalsIgnoreCase(name))
+            {
+                sp.second = value;
+                setPropAt(row, sp);
+                return;
+            }
+        }
+        // Fell through -- this is a new property
+        props.add(new StringPair(name, value));
+        fireTableRowsInserted(props.size()-1, props.size()-1);
+    }
+
+ }

--- a/src/main/java/decodes/launcher/DecodesPropsPanel.java
+++ b/src/main/java/decodes/launcher/DecodesPropsPanel.java
@@ -15,6 +15,7 @@ import ilex.util.UserAuthFile;
 import ilex.gui.LoginDialog;
 import decodes.gui.PropertiesEditPanel;
 import decodes.gui.TopFrame;
+import decodes.gui.properties.PropertiesTableModel;
 import decodes.util.DecodesSettings;
 
 import org.opendcs.authentication.AuthSourceService;
@@ -115,7 +116,8 @@ public class DecodesPropsPanel extends JPanel
 
         dbPasswordButton.addActionListener(e -> dbPasswordButtonPressed());
 
-        propsEditPanel = new PropertiesEditPanel(origProps, false);
+        propsEditPanel = PropertiesEditPanel.from(origProps, false);
+        // note, this seems wrong.
         propsEditPanel.setBorder(new TitledBorder(
             labels.getString("DecodesPropsPanel.preferences")));
         this.add(propsEditPanel, BorderLayout.CENTER);
@@ -126,17 +128,18 @@ public class DecodesPropsPanel extends JPanel
     protected void editDbTypeChanged()
     {
         String dbType = (String)editDbTypeCombo.getSelectedItem();
+        PropertiesTableModel model = propsEditPanel.getModel();
         if (dbType.equalsIgnoreCase("CWMS"))
         {
-            propsEditPanel.setProperty("dbClassName", "decodes.cwms.CwmsTimeSeriesDb");
-            propsEditPanel.setProperty("jdbcDriverClass", "oracle.jdbc.driver.OracleDriver");
-            propsEditPanel.setProperty("sqlKeyGenerator", "decodes.sql.OracleSequenceKeyGenerator");
+            model.setProperty("dbClassName", "decodes.cwms.CwmsTimeSeriesDb");
+            model.setProperty("jdbcDriverClass", "oracle.jdbc.driver.OracleDriver");
+            model.setProperty("sqlKeyGenerator", "decodes.sql.OracleSequenceKeyGenerator");
         }
         else if (dbType.equalsIgnoreCase("HDB"))
         {
-            propsEditPanel.setProperty("dbClassName", "decodes.hdb.HdbTimeSeriesDb");
-            propsEditPanel.setProperty("jdbcDriverClass", "oracle.jdbc.driver.OracleDriver");
-            propsEditPanel.setProperty("sqlKeyGenerator", "decodes.sql.OracleSequenceKeyGenerator");
+            model.setProperty("dbClassName", "decodes.hdb.HdbTimeSeriesDb");
+            model.setProperty("jdbcDriverClass", "oracle.jdbc.driver.OracleDriver");
+            model.setProperty("sqlKeyGenerator", "decodes.sql.OracleSequenceKeyGenerator");
         }
     }
 
@@ -164,8 +167,8 @@ public class DecodesPropsPanel extends JPanel
         // them from the properties list.
         PropertiesUtil.rmIgnoreCase(origProps, "editDatabaseType");
         PropertiesUtil.rmIgnoreCase(origProps, "editDatabaseLocation");
-        propsEditPanel.setProperties(origProps);
-        propsEditPanel.setPropertiesOwner(settings);
+        propsEditPanel.getModel().setProperties(origProps);
+        propsEditPanel.getModel().setPropertiesOwner(settings);
 
         int typ = settings.editDatabaseTypeCode;
         editDbTypeCombo.setSelectedIndex(
@@ -181,7 +184,7 @@ public class DecodesPropsPanel extends JPanel
     DecodesSettings saveToSettings()
     {
         DecodesSettings settings = new DecodesSettings();
-        propsEditPanel.saveChanges(); // this saves back to 'origProps'
+        propsEditPanel.getModel().saveChanges(); // this saves back to 'origProps'
         settings.loadFromProperties(origProps);
 
         int idx = editDbTypeCombo.getSelectedIndex();

--- a/src/main/java/decodes/tsdb/compedit/AlgorithmsEditPanel.java
+++ b/src/main/java/decodes/tsdb/compedit/AlgorithmsEditPanel.java
@@ -227,7 +227,7 @@ public class AlgorithmsEditPanel
 
 		propCopy = new Properties();
 		PropertiesUtil.copyProps(propCopy, editedObject.getProperties());
-		propertiesPanel.setProperties(propCopy);
+		propertiesPanel.getModel().setProperties(propCopy);
 		algoParmTableModel.fill(editedObject);
 		String clsName = dca.getExecClass();
 		try
@@ -274,7 +274,7 @@ Logger.instance().debug1("AlgoPanel.setEditedObject algo has " + editedObject.ge
 			}
 		}
 
-		propertiesPanel.setPropertiesOwner(this);
+		propertiesPanel.getModel().setPropertiesOwner(this);
 	}
 
 	public DbCompAlgorithm getEditedObject()
@@ -530,7 +530,7 @@ Logger.instance().debug1("AlgoPanel.setEditedObject algo has " + editedObject.ge
 		ob.setName(nm);
 		ob.setComment(commentsText.getText());
 		ob.setExecClass(execClassField.getText().trim());
-		propertiesPanel.saveChanges();
+		propertiesPanel.getModel().saveChanges();
 		ob.getProperties().clear();
 		PropertiesUtil.copyProps(ob.getProperties(), propCopy);
 		algoParmTableModel.saveTo(ob);
@@ -569,7 +569,7 @@ Logger.instance().debug1("AlgoPanel.setEditedObject algo has " + editedObject.ge
 	protected JPanel getPropertiesPanel()
 	{
 		if (propertiesPanel == null) {
-			propertiesPanel = new PropertiesEditPanel(new Properties());
+			propertiesPanel = PropertiesEditPanel.from(new Properties());
 			propertiesPanel.setOwnerFrame(CAPEdit.instance().getFrame());
 		}
 		return propertiesPanel;

--- a/src/main/java/decodes/tsdb/compedit/ComputationsEditPanel.java
+++ b/src/main/java/decodes/tsdb/compedit/ComputationsEditPanel.java
@@ -25,6 +25,7 @@ import decodes.db.Constants;
 import decodes.dbeditor.SiteSelectPanel;
 import decodes.gui.PropertiesEditPanel;
 import decodes.gui.SortingListTable;
+import decodes.gui.properties.PropertiesEditPanelController;
 import decodes.sql.DbKey;
 import decodes.tsdb.CompAppInfo;
 import decodes.tsdb.DbAlgorithmExecutive;
@@ -147,7 +148,7 @@ public class ComputationsEditPanel
                 GridBagConstraints.CENTER, GridBagConstraints.BOTH,
                 new Insets(2,2,2,2), 0, 60));
 
-        propertiesPanel = new PropertiesEditPanel(new Properties());
+        propertiesPanel = PropertiesEditPanel.from(new Properties());
         propertiesPanel.setTitle(
             ceResources.getString("ComputationsEditPanel.PropertiesPanelTitle"));
         propertiesPanel.setOwnerFrame(CAPEdit.instance().getFrame());
@@ -278,7 +279,7 @@ public class ComputationsEditPanel
             }
         }
 
-        propertiesPanel.setProperties(propCopy);
+        propertiesPanel.getModel().setProperties(propCopy);
         setPropertiesPanelOwner();
 
         String s;
@@ -836,7 +837,7 @@ Logger.instance().debug1("after expand, dcp.sdi=" + dcp.getSiteDataTypeId() + ",
             break;
         }
 
-        propertiesPanel.saveChanges();
+        propertiesPanel.getModel().saveChanges();
         ob.getProperties().clear();
         PropertiesUtil.copyProps(ob.getProperties(), propCopy);
         PropertiesUtil.copyProps(ob.getProperties(), hiddenProps);
@@ -955,7 +956,7 @@ Logger.instance().debug1("after expand, dcp.sdi=" + dcp.getSiteDataTypeId() + ",
                         plist.append(dcp.getRoleName());
                     }
                 }
-                propertiesPanel.saveChanges();
+                propertiesPanel.getModel().saveChanges();
             nextCompProp:
                 for(Enumeration cpnenum = propCopy.propertyNames(); cpnenum.hasMoreElements(); )
                 {
@@ -1036,10 +1037,10 @@ Logger.instance().debug1("after expand, dcp.sdi=" + dcp.getSiteDataTypeId() + ",
                         propCopy.setProperty(pname, value);
                 }
             }
-            propertiesPanel.setProperties(propCopy);
+            propertiesPanel.getModel().setProperties(propCopy);
             setPropertiesPanelOwner();
 
-            propertiesPanel.redrawTable();
+            propertiesPanel.getModel().redrawTable();
         }
     }
 
@@ -1057,7 +1058,7 @@ Logger.instance().debug1("after expand, dcp.sdi=" + dcp.getSiteDataTypeId() + ",
             if (executive instanceof AW_AlgorithmBase)
             {
                 ((AW_AlgorithmBase)executive).initForGUI();
-                propertiesPanel.setPropertiesOwner((AW_AlgorithmBase)executive);
+                propertiesPanel.getModel().setPropertiesOwner((AW_AlgorithmBase)executive);
             }
         }
         catch (Exception ex)
@@ -1232,7 +1233,7 @@ Logger.instance().debug1("after expand, dcp.sdi=" + dcp.getSiteDataTypeId() + ",
      */
     public String getProperty(String name)
     {
-        return propertiesPanel.getProperty(name);
+        return propertiesPanel.getModel().getProperty(name);
     }
 
     public DbCompAlgorithm getAlgorithm()

--- a/src/main/java/decodes/tsdb/compedit/ProcessEditPanel.java
+++ b/src/main/java/decodes/tsdb/compedit/ProcessEditPanel.java
@@ -94,8 +94,8 @@ public class ProcessEditPanel extends EditPanel
 		panelProps.clear();
 		PropertiesUtil.copyProps(panelProps, cai.getProperties());
 		panelProps.remove("appType");
-		propsPanel.setPropertiesOwner(cai);
-		propsPanel.setProperties(panelProps);
+		propsPanel.getModel().setPropertiesOwner(cai);
+		propsPanel.getModel().setProperties(panelProps);
 		processTypeSelected();
 	}
 
@@ -155,7 +155,7 @@ public class ProcessEditPanel extends EditPanel
 				GridBagConstraints.NORTH, GridBagConstraints.NONE,
 				new Insets(5, 20, 5, 20), 0, 0));
 
-		propsPanel = new PropertiesEditPanel(panelProps);
+		propsPanel = PropertiesEditPanel.from(panelProps);
 		propsPanel.setTitle(" "+compeditDescriptions.getString("ProcessEditPanel.PropsPanelTitle")+" ");
 		
 		if (listPanel != null)
@@ -191,7 +191,7 @@ public class ProcessEditPanel extends EditPanel
 		String pt = processTypeCombo.getSelection();
 		if (pt == null || pt.trim().length() == 0)
 		{
-			propsPanel.setPropertiesOwner(null);
+			propsPanel.getModel().setPropertiesOwner(null);
 			return;
 		}
 
@@ -205,7 +205,7 @@ public class ProcessEditPanel extends EditPanel
 			{
 				execClass = procType.getExecClass();
 				propOwner = (PropertiesOwner)execClass.newInstance();
-				propsPanel.setPropertiesOwner(propOwner);
+				propsPanel.getModel().setPropertiesOwner(propOwner);
 			}
 		}
 		catch(ClassCastException ex)
@@ -219,7 +219,7 @@ public class ProcessEditPanel extends EditPanel
 			System.err.println(msg);
 			ex.printStackTrace(System.err);
 		}
-		propsPanel.setPropertiesOwner(propOwner);
+		propsPanel.getModel().setPropertiesOwner(propOwner);
 	}
 
 	/**
@@ -330,7 +330,7 @@ public class ProcessEditPanel extends EditPanel
 		cai.setAppName(nameField.getText());
 		cai.setComment(commentsText.getText());
 		cai.setManualEditApp(manualEditCheck.isSelected());
-		propsPanel.saveChanges();
+		propsPanel.getModel().saveChanges();
 		cai.setProperties(panelProps);
 		String s = processTypeCombo.getSelection().trim();
 		if (s.length() > 0)

--- a/src/main/java/lrgs/rtstat/LrgsConfigDialog.java
+++ b/src/main/java/lrgs/rtstat/LrgsConfigDialog.java
@@ -318,7 +318,7 @@ public class LrgsConfigDialog extends GuiDialog
         hritFileCfgPanel.fillFields(lrgsConfig);
         edlConfigPanel.fillFields(lrgsConfig);
 
-        miscPanel.setProperties(lrgsConfig.getOtherProps());
+        miscPanel.getModel().setProperties(lrgsConfig.getOtherProps());
 
         //dds server tab
         getDdsListenPortField().setText(String.valueOf(lrgsConfig.ddsListenPort));
@@ -354,7 +354,7 @@ public class LrgsConfigDialog extends GuiDialog
         networkDcpCfgPanel.setContents(networkDcpSettings,
             lrgsConfig.networkDcpEnable);
 
-        miscPanel.setPropertiesOwner(lrgsConfig);
+        miscPanel.getModel().setPropertiesOwner(lrgsConfig);
     }
 
     /**
@@ -682,9 +682,9 @@ public class LrgsConfigDialog extends GuiDialog
             }
 
             // On the 'misc' tab
-            if (miscPanel.hasChanged())
+            if (miscPanel.getModel().hasChanged())
             {
-                miscPanel.saveChanges();
+                miscPanel.getModel().saveChanges();
                 changed = true;
             }
         }
@@ -1046,7 +1046,7 @@ public class LrgsConfigDialog extends GuiDialog
         JLabel lab = new JLabel(labels.getString(
                 "LrgsConfigDialog.miscPars"));
         miscConfigTab.add(lab, BorderLayout.NORTH);
-        miscPanel = new PropertiesEditPanel(new Properties());
+        miscPanel = PropertiesEditPanel.from(new Properties());
         miscConfigTab.add(miscPanel, BorderLayout.CENTER);
         return miscConfigTab;
     }


### PR DESCRIPTION
## Problem Description


<!-- if you are referencing a specific issue a problem description is not required -->
Our GUIs do not provide a proper seperation of concerns. This hasn't generally been an issue but now that we've introduced the SPI system for properties tools like the eclipse WindowBuilder can't reload the design which makes tweaking gui elements difficult (personally I'd prefer not to do that by hand).

## Solution

I took the PropertiesEditPanel and converted it to more of a control that uses a model-view-controller architecture (maybe model-view-presenter... frankly I've decided not to get too hung up on details so long as there's a reasonable separation of concerns.)
This particular Panel wasn't affected by the SPI issue and was chosen due to a reasonable balance of complexity and simplicity to demonstrate the conversion.

Doing this separation of concerns also made it easier to know when and where to use SwingWorkerThreads. Again not nearly as critical for this panel, but the purpose was to have a reference available for more complex interfaces to be converted.

## how you tested the change

Manually. Interacted with the various panels that used PropertiesEditPanel to verify operations remain unchanged.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
