### PR TITLE
Wrap property provide log message in a feature flag to avoid excessiv…

### DIFF
--- a/src/main/java/org/opendcs/utils/Property.java
+++ b/src/main/java/org/opendcs/utils/Property.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import java.util.ServiceLoader;
 
 import org.opendcs.spi.properties.PropertyValueProvider;
+import org.opendcs.utils.properties.PropertySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,9 +122,10 @@ public class Property
                 }
             }
             /*
-             * We really only need this when debugging.
-             */
-            if (log.isTraceEnabled())
+             * We really only need this when debugging. So only enable if 
+             * property is intentionally set.
+            */
+            if (PropertySettings.TRACE_PROPERTY_PROVIDERS == true && log.isTraceEnabled())
             {
                 log.atTrace()
                    .setCause(new Exception("Unable to find variable processor."))

--- a/src/main/java/org/opendcs/utils/properties/PropertySettings.java
+++ b/src/main/java/org/opendcs/utils/properties/PropertySettings.java
@@ -1,0 +1,18 @@
+package org.opendcs.utils.properties;
+
+public class PropertySettings {
+
+    /**
+     * Allows the user to see where a property wasn't picked up correctly 
+     * while diagnosing using external sources for property values.
+     * Turn this on sparingly as it generates a lot of noise for properties that 
+     * Don't reference an external source but just have a raw value.
+     * @since 7.0.14
+     */
+    public static final boolean TRACE_PROPERTY_PROVIDERS = 
+        Boolean.parseBoolean(
+                System.getProperty("opendcs.property.providers.trace", "false")
+            );
+
+    private PropertySettings() {}
+}


### PR DESCRIPTION
…e logging.

## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Since just about every property ends up going through the new property provider interface the was some excessive logging.
This disables that logging unless specifically needed.

## Solution

Defined a new system property to enable the extra logging if desired.

## how you tested the change

Manually ran a program to see logging result. Seemed to me a speed up in application as well - which makes sense that was a lot of stack traces to create and print.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
