### PR TITLE
Add some basic support for JFR recording into run target.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -773,6 +773,37 @@ more information about each.
             </fileset>
         </chmod>
         <mkdir dir="${build.dir}/run"/>
+        <if>
+            <and>
+                <islessthan arg1="${java.specification.version}" arg2="11"/>
+                <isset property="opendcs.jfr"/>
+            </and>
+            <then>
+                <property name="jfrOpts" value=""/>
+                <echo leve="warning">Can only run Java Flight recorder on JDK 11 or above</echo>
+            </then>
+            <elseif>
+                <isset property="opendcs.jfr"/>
+                <then>
+                    <property name="can_jfr" value="true"/>
+                    <property name="jfrOpts"
+                                value="-XX:StartFlightRecording=disk=true,dumponexit=true,filename=${build.dir}/run/${opendcs.app}.recording.jfr,settings=profile"/>
+                </then>
+            </elseif>
+            <else>
+                <property name="jfrOpts" value=""/>
+            </else>
+        </if>
+
+        <condition property="debugOpts"
+                   value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"
+                   else="">
+            <isset property="debugPort"/>
+        </condition>
+
+        <property name="decj_opts" value="${debugOpts} ${jfrOpts}"/>
+        <echo message="with opts: ${decj_opts}"/>
+
         <exec executable="${stage.dir}/bin/${opendcs.app}" osfamily="unix">
             <env key="DCSTOOL_HOME" value="${stage.absolute.dir}"/>
             <env key="DECODES_INSTALL_DIR" value="${stage.absolute.dir}"/>
@@ -780,9 +811,7 @@ more information about each.
             <arg value="-l"/><arg value="/dev/stdout"/>
             <arg if:set="opendcs.profile" value="-P"/>
             <arg if:set="opendcs.profile" value="${opendcs.profile}"/>
-            <env if:set="debugPort"
-                 key="DECJ_OPTS"
-                 value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
+            <env key="DECJ_OPTS" value="${decj_opts}"/>
         </exec>
         <exec executable="${stage.absolute.dir}/bin/${opendcs.app}.bat" osfamily="windows" vmlauncher="false">
             <env key="DCSTOOL_HOME" value="${stage.absolute.dir}"/>
@@ -791,9 +820,7 @@ more information about each.
             <arg value="-l"/><arg value="CON:"/>
             <arg if:set="opendcs.profile" value="-P"/>
             <arg if:set="opendcs.profile" value="${opendcs.profile}"/>
-            <env if:set="debugPort"
-                 key="DECJ_OPTS"
-                 value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort}"/>
+            <env key="DECJ_OPTS" value="${decj_opts}"/>
         </exec>
     </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -774,6 +774,15 @@ more information about each.
         </chmod>
         <mkdir dir="${build.dir}/run"/>
         <if>
+            <isset property="opendcs.profile"/>
+            <then>
+                <basename property="opendcs.profile.name" file="${opendcs.profile}" suffix=".profile"/>
+            </then>
+            <else>
+                <property name="opendcs.profile.name" value="default"/>
+            </else>
+        </if>
+        <if>
             <and>
                 <islessthan arg1="${java.specification.version}" arg2="11"/>
                 <isset property="opendcs.jfr"/>
@@ -787,7 +796,7 @@ more information about each.
                 <then>
                     <property name="can_jfr" value="true"/>
                     <property name="jfrOpts"
-                                value="-XX:StartFlightRecording=disk=true,dumponexit=true,filename=${build.dir}/run/${opendcs.app}.recording.jfr,settings=profile"/>
+                                value="-XX:StartFlightRecording=disk=true,dumponexit=true,filename=${build.dir}/run/${opendcs.app}.${opendcs.profile.name}.recording.jfr,settings=profile"/>
                 </then>
             </elseif>
             <else>

--- a/build.xml
+++ b/build.xml
@@ -780,7 +780,7 @@ more information about each.
             </and>
             <then>
                 <property name="jfrOpts" value=""/>
-                <echo leve="warning">Can only run Java Flight recorder on JDK 11 or above</echo>
+                <echo level="warning">Can only run Java Flight recorder on JDK 11 or above</echo>
             </then>
             <elseif>
                 <isset property="opendcs.jfr"/>

--- a/common.xml
+++ b/common.xml
@@ -213,8 +213,8 @@
     </target>
 
     <target name="resolve.build" description="--> retreive dependencies with ivy" depends="check.ivy.build,resolve,resolve.build.real,resolve.build.cached">
-        <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="build.classpath"/>
         <taskdef resource="net/sf/antcontrib/antlib.xml" classpathref="build.classpath"/>
+        <typedef name="islessthan" classname="net.sf.antcontrib.logic.condition.IsLessThan" classpathref="build.classpath"/>
 
         <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties"
                  classpathref="build.classpath"/>

--- a/docs/source/dev-docs.rst
+++ b/docs/source/dev-docs.rst
@@ -348,6 +348,19 @@ The following prefixes are reserved:
 |file      |Values from files on the file system. |
 +----------+--------------------------------------+
 
+Additional Logging
+==================
+
+Similar to the connection pool tracing above, if you are having difficulty with a provider
+you can log missed results with the following feature flag.
+
+.. code-block:: bash
+
+    DECJ_MAXHEAP="-Dopendcs.property.providers.trace=true" routsched ...
+
+This will cause excessive logging and drastically slow execution. We do not recommend
+leaving this setting on for any length of time beyond a debugging session.
+
 Code Analysis
 -------------
 

--- a/docs/source/dev-docs.rst
+++ b/docs/source/dev-docs.rst
@@ -149,7 +149,7 @@ the "stage" directory is used as DCSTOOL_HOME and DCSTOOL_USERDIR is the same de
     ant run -Dopendcs.app=compedit
 
     # to run a specific app with a profile
-    ant run -Dopendcs.app=dbedit -Popendcs.profile="full path to a profile or .properties file"
+    ant run -Dopendcs.app=dbedit -Dopendcs.profile="full path to a profile or .properties file"
 
     # to run with the java remote debugger enabled
     ant run -DdebugPort=5006
@@ -159,6 +159,8 @@ the "stage" directory is used as DCSTOOL_HOME and DCSTOOL_USERDIR is the same de
     # recordings will be in the run directory of the build (default build/run)
     # with the name <opendcs.app>.recording.jfr where opendcs.app is the value of the property provided
     # or the default "launcher_start" app if the property is not set.
+
+All of the options above can be in any combination.
 
 The logs are set to the highest debug level and printed to stdout.
 

--- a/docs/source/dev-docs.rst
+++ b/docs/source/dev-docs.rst
@@ -154,6 +154,12 @@ the "stage" directory is used as DCSTOOL_HOME and DCSTOOL_USERDIR is the same de
     # to run with the java remote debugger enabled
     ant run -DdebugPort=5006
 
+    # to run with Java Flight Recorder
+    ant run -Dopendcs.jfr
+    # recordings will be in the run directory of the build (default build/run)
+    # with the name <opendcs.app>.recording.jfr where opendcs.app is the value of the property provided
+    # or the default "launcher_start" app if the property is not set.
+
 The logs are set to the highest debug level and printed to stdout.
 
 .. NOTE::

--- a/docs/source/dev-docs.rst
+++ b/docs/source/dev-docs.rst
@@ -155,7 +155,7 @@ the "stage" directory is used as DCSTOOL_HOME and DCSTOOL_USERDIR is the same de
     ant run -DdebugPort=5006
 
     # to run with Java Flight Recorder
-    ant run -Dopendcs.jfr
+    ant run -Dopendcs.jfr=true
     # recordings will be in the run directory of the build (default build/run)
     # with the name <opendcs.app>.recording.jfr where opendcs.app is the value of the property provided
     # or the default "launcher_start" app if the property is not set.


### PR DESCRIPTION
## Problem Description

Makes it easier to perform some basic profiling to see where hot spots may be.

## Solution

Added logic to add appropriate JFR activation settings to java options passed into the JDK.

## how you tested the change

Manually, ran with JFR on, performed operations, closed app, opened recording in VisualVM (2.1.8) to see results.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [x] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
