### PR TITLE
Refactor/649 tsdao find

### DIFF
--- a/src/main/java/decodes/cwms/CwmsConnectionPool.java
+++ b/src/main/java/decodes/cwms/CwmsConnectionPool.java
@@ -21,7 +21,6 @@ import javax.management.JMException;
 import javax.management.ObjectName;
 import javax.management.openmbean.OpenDataException;
 
-import org.eclipse.jetty.server.Authentication.Wrapped;
 import org.opendcs.jmx.ConnectionPoolMXBean;
 import org.opendcs.jmx.WrappedConnectionMBean;
 import org.opendcs.utils.sql.SqlSettings;

--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
@@ -246,7 +246,10 @@ public class CwmsTimeSeriesDAO
         }
 
         TimeSeriesIdentifier ret = null;
-        synchronized(cache) { ret = cache.getByUniqueName(uniqueString); }
+        synchronized(cache)
+        {
+            ret = cache.getByUniqueName(uniqueString);
+        }
         if (ret != null)
         {
             if (displayName != null)
@@ -254,6 +257,10 @@ public class CwmsTimeSeriesDAO
                 ret.setDisplayName(displayName);
             }
             return FailableResult.success(ret);
+        }
+        else if (ret == null && lastCacheReloadWithin(1, TimeUnit.HOURS))
+        {
+            return FailableResult.failure(new NoSuchObjectException("No TimeSeries in fresh cache."));
         }
 
         DbKey ts_code = ts_id2ts_code(uniqueString);
@@ -307,6 +314,11 @@ public class CwmsTimeSeriesDAO
         return Constants.undefinedId;
     }
 
+    private static boolean lastCacheReloadWithin(long time, TimeUnit units)
+    {
+        final long within = units.toMillis(time);
+        return (System.currentTimeMillis() - lastCacheReload) < within;
+    }
 
     @Override
     public void close()

--- a/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
+++ b/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
@@ -16,7 +16,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/decodes/hdb/HdbTimeSeriesDb.java
+++ b/src/main/java/decodes/hdb/HdbTimeSeriesDb.java
@@ -855,7 +855,7 @@ public class HdbTimeSeriesDb
 	}
 
 	@Override
-	public TimeSeriesIdentifier transformTsidByCompParm(
+	public TimeSeriesIdentifier transformTsidByCompParm(TimeSeriesDAI timeSeriesDAO,
 			TimeSeriesIdentifier tsid, DbCompParm parm, boolean createTS,
 			boolean fillInParm, String timeSeriesDisplayName) 
 		throws DbIoException, NoSuchObjectException, BadTimeSeriesException
@@ -871,7 +871,6 @@ public class HdbTimeSeriesDb
 			String uniqueString = tsidRet.getUniqueString();
 			Logger.instance().debug3("HdbTimeSeriesDb.transformTsid new string='"
 				+ uniqueString);
-			TimeSeriesDAI timeSeriesDAO = makeTimeSeriesDAO();
 
 			try 
 			{
@@ -896,10 +895,6 @@ public class HdbTimeSeriesDb
 						+ "no such time series '" + uniqueString + "' and createFlag=false");
 					return null;
 				}
-			}
-			finally
-			{
-				timeSeriesDAO.close();
 			}
 		}
 		else

--- a/src/main/java/decodes/sql/SqlDatabaseIO.java
+++ b/src/main/java/decodes/sql/SqlDatabaseIO.java
@@ -2446,7 +2446,7 @@ public class SqlDatabaseIO
     }
 
     @Override
-    public TimeSeriesIdentifier transformTsidByCompParm(TimeSeriesIdentifier tsid, DbCompParm parm,
+    public TimeSeriesIdentifier transformTsidByCompParm(TimeSeriesDAI tsDAI, TimeSeriesIdentifier tsid, DbCompParm parm,
         boolean createTS, boolean fillInParm, String timeSeriesDisplayName) throws DbIoException,
         NoSuchObjectException, BadTimeSeriesException
     {

--- a/src/main/java/opendcs/dai/TimeSeriesDAI.java
+++ b/src/main/java/opendcs/dai/TimeSeriesDAI.java
@@ -5,6 +5,7 @@ import ilex.var.TimedVariable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Optional;
 
 import opendcs.dao.DbObjectCache;
 
@@ -20,8 +21,7 @@ import decodes.tsdb.TimeSeriesIdentifier;
  * Public interface for accessing time series data.
  * @author mmaloney Mike Maloney, Cove Software, LLC
  */
-public interface TimeSeriesDAI
-	extends DaiBase
+public interface TimeSeriesDAI extends DaiBase
 {
 	/**
 	 * When calling the listTimeSeries() method, don't reload the cache
@@ -42,6 +42,10 @@ public interface TimeSeriesDAI
 		getTimeSeriesIdentifier(String uniqueString)
 		throws DbIoException, NoSuchObjectException;
 
+
+	public Optional<TimeSeriesIdentifier> findTimeSeriesIdentifier(String uniqueString)
+		throws DbIoException;
+		
 	/**
 	 * Retrieve a time series identifier by unique surrogate key.
 	 * @param key the key

--- a/src/main/java/opendcs/dai/TimeSeriesDAI.java
+++ b/src/main/java/opendcs/dai/TimeSeriesDAI.java
@@ -7,6 +7,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Optional;
 
+import org.opendcs.utils.FailableResult;
+
 import opendcs.dao.DbObjectCache;
 
 import decodes.sql.DbKey;
@@ -16,6 +18,7 @@ import decodes.tsdb.DataCollection;
 import decodes.tsdb.DbIoException;
 import decodes.tsdb.NoSuchObjectException;
 import decodes.tsdb.TimeSeriesIdentifier;
+import decodes.tsdb.TsdbException;
 
 /**
  * Public interface for accessing time series data.
@@ -38,14 +41,12 @@ public interface TimeSeriesDAI extends DaiBase
 	 * @throws DbIoException if SQL exception occurs during operation
 	 * @throws NoSuchObjectException if no matching time series exists.
 	 */
-	public TimeSeriesIdentifier
-		getTimeSeriesIdentifier(String uniqueString)
+	public TimeSeriesIdentifier getTimeSeriesIdentifier(String uniqueString)
 		throws DbIoException, NoSuchObjectException;
 
-
-	public Optional<TimeSeriesIdentifier> findTimeSeriesIdentifier(String uniqueString)
-		throws DbIoException;
+	public FailableResult<TimeSeriesIdentifier,TsdbException> findTimeSeriesIdentifier(String uniqueString);
 		
+	public FailableResult<TimeSeriesIdentifier,TsdbException> findTimeSeriesIdentifier(DbKey key);
 	/**
 	 * Retrieve a time series identifier by unique surrogate key.
 	 * @param key the key
@@ -53,9 +54,7 @@ public interface TimeSeriesDAI extends DaiBase
 	 * @throws DbIoException on SQL errors
 	 * @throws NoSuchObjectException if no such time series
 	 */
-	public TimeSeriesIdentifier
-		getTimeSeriesIdentifier(DbKey key)
-		throws DbIoException, NoSuchObjectException;
+	public TimeSeriesIdentifier getTimeSeriesIdentifier(DbKey key) throws DbIoException, NoSuchObjectException;
 
 	/**
 	 * Fills the meta data for the time series.

--- a/src/main/java/opendcs/dao/DatabaseConnectionOwner.java
+++ b/src/main/java/opendcs/dao/DatabaseConnectionOwner.java
@@ -329,11 +329,22 @@ public interface DatabaseConnectionOwner
 	 * @throws NoSuchObjectException if (createTS) and failed to create TS in database
 	 * @throws BadTimeSeriesException on attempt to create new TS with invalid TSID.
 	 */
-	public abstract TimeSeriesIdentifier transformTsidByCompParm(
+	TimeSeriesIdentifier transformTsidByCompParm(TimeSeriesDAI tsDAI,
 		TimeSeriesIdentifier tsid, DbCompParm parm, boolean createTS,
 		boolean fillInParm, String timeSeriesDisplayName)
 		throws DbIoException, NoSuchObjectException, BadTimeSeriesException;
 	
+	default TimeSeriesIdentifier transformTsidByCompParm(
+		TimeSeriesIdentifier tsid, DbCompParm parm, boolean createTS,
+		boolean fillInParm, String timeSeriesDisplayName)
+		throws DbIoException, NoSuchObjectException, BadTimeSeriesException
+	{
+		try (TimeSeriesDAI tsDai = this.makeTimeSeriesDAO())
+		{
+			return this.transformTsidByCompParm(tsDai, tsid, parm, createTS, fillInParm, timeSeriesDisplayName);
+		}
+	}
+
 	/**
 	 * Construct a DAO for reading writing DeviceStatus structures.
 	 */

--- a/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
+++ b/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
@@ -1963,8 +1963,16 @@ debug1("Time series " + tsid.getUniqueString() + " already has offset = "
 	@Override
 	public TimeSeriesIdentifier getTimeSeriesIdentifier(String uniqueString)
 			throws DbIoException, NoSuchObjectException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'getTimeSeriesIdentifier'");
+		FailableResult<TimeSeriesIdentifier,TsdbException> ret = findTimeSeriesIdentifier(uniqueString);
+		if (ret.isSuccess())
+		{
+			return ret.getSuccess();
+		}
+		else
+		{
+			return ExceptionHelpers.throwDbIoNoSuchObject(ret.getFailure());
+		}
+
 	}
 
 	@Override

--- a/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
+++ b/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
@@ -63,6 +63,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.TimeZone;
 
 import org.slf4j.LoggerFactory;
@@ -145,7 +146,7 @@ public class OpenTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 	}
 
 	@Override
-	public TimeSeriesIdentifier getTimeSeriesIdentifier(String uniqueString) throws DbIoException, NoSuchObjectException
+	public Optional<TimeSeriesIdentifier> findTimeSeriesIdentifier(String uniqueString) throws DbIoException
 	{
 		int paren = uniqueString.lastIndexOf('(');
 		String displayName = null;
@@ -167,7 +168,7 @@ public class OpenTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 			{
 				tsid.setDisplayName(displayName);
 			}
-			return tsid;
+			return Optional.of(tsid);
 		}
 			
 		tsid = new CwmsTsId();
@@ -222,11 +223,12 @@ public class OpenTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 				{
 					ret.setDisplayName(displayName);
 				}
-				return ret;
+				return Optional.of(ret);
 			}
 			else
 			{
-				throw new NoSuchObjectException("No Time Series matching '" + uniqueString + "'");
+				return Optional.empty();
+				//throw new NoSuchObjectException("No Time Series matching '" + uniqueString + "'");
 			}
 		}
 		catch (SQLException ex)

--- a/src/main/java/opendcs/opentsdb/OpenTsdb.java
+++ b/src/main/java/opendcs/opentsdb/OpenTsdb.java
@@ -216,7 +216,7 @@ public class OpenTsdb extends TimeSeriesDb
 	}
 
 	@Override
-	public TimeSeriesIdentifier transformTsidByCompParm(
+	public TimeSeriesIdentifier transformTsidByCompParm(TimeSeriesDAI timeSeriesDAO,
 		TimeSeriesIdentifier tsid, DbCompParm parm, boolean createTS,
 		boolean fillInParm, String timeSeriesDisplayName) throws DbIoException,
 		NoSuchObjectException, BadTimeSeriesException
@@ -233,7 +233,6 @@ public class OpenTsdb extends TimeSeriesDb
 			String uniqueString = tsidRet.getUniqueString();
 			debug3(module + " origString='" + origString + "', new string='"
 				+ uniqueString + "', parm=" + parm);
-			TimeSeriesDAI timeSeriesDAO = makeTimeSeriesDAO();
 
 			try
 			{
@@ -260,10 +259,6 @@ public class OpenTsdb extends TimeSeriesDb
 					debug3(module + " no such time series '" + uniqueString + "'");
 					return null;
 				}
-			}
-			finally
-			{
-				timeSeriesDAO.close();
 			}
 		}
 		else

--- a/src/main/java/opendcs/util/sql/WrappedConnection.java
+++ b/src/main/java/opendcs/util/sql/WrappedConnection.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.Executor;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.management.openmbean.CompositeData;
@@ -57,6 +58,14 @@ public class WrappedConnection implements Connection, WrappedConnectionMBean
     private ZonedDateTime end = null;
     private final Thread openingThread;
 
+
+    private Predicate<String> stackTraceFilter = (l) ->
+               l.startsWith("org.opendcs")
+            || l.startsWith("opendcs")
+            || l.startsWith("decodes")
+            || l.startsWith("ilex")
+            || l.startsWith("java")
+        ;
 
     public WrappedConnection(Connection realConnection){
         this(realConnection, (c) -> {},false);
@@ -115,8 +124,8 @@ public class WrappedConnection implements Connection, WrappedConnectionMBean
         {
             closeTrace = new ArrayList<>();
             StackTraceElement ste[] = Thread.currentThread().getStackTrace();
-            // start at 3, after this constructor and the getThread/Stack trace call
-            for(int i = 3; i < ste.length; i++)
+            // start at 2, after this method and the getThread/Stack trace call
+            for(int i = 0; i < ste.length; i++)
             {
                 closeTrace.add(ste[i]);
             }
@@ -530,10 +539,22 @@ public class WrappedConnection implements Connection, WrappedConnectionMBean
 		return openTrace != null
                     ? openTrace.stream()
                                .map(ste->ste.toString())
+                               .filter(stackTraceFilter)
                                .collect(Collectors.toList())
                                .toArray(new String[0])
                     : new String[]{"No Trace."};
 	}
+
+    public String[] getClosedStackTrace()
+    {
+        return closeTrace != null
+                    ? closeTrace.stream()
+                               .map(ste->ste.toString())
+                               .filter(stackTraceFilter)
+                               .collect(Collectors.toList())
+                               .toArray(new String[0])
+                    : new String[]{"No Trace."};
+    }
 
 	@Override
 	public boolean getTracingOn()

--- a/src/main/java/org/opendcs/database/ExceptionHelpers.java
+++ b/src/main/java/org/opendcs/database/ExceptionHelpers.java
@@ -1,0 +1,27 @@
+package org.opendcs.database;
+
+import decodes.tsdb.DbIoException;
+import decodes.tsdb.NoSuchObjectException;
+
+public class ExceptionHelpers
+{
+    private ExceptionHelpers()
+    {
+    }
+   
+    public static <T> T throwDbIoNoSuchObject(Throwable cause) throws DbIoException, NoSuchObjectException
+    {
+        if (cause instanceof NoSuchObjectException)
+        {
+            throw (NoSuchObjectException)cause;
+        }
+        else if (cause instanceof DbIoException)
+        {
+            throw (DbIoException)cause;
+        }
+        else
+        {
+            throw new DbIoException("Database Error", cause);
+        }
+    }
+}

--- a/src/main/java/org/opendcs/utils/FailableResult.java
+++ b/src/main/java/org/opendcs/utils/FailableResult.java
@@ -1,0 +1,66 @@
+package org.opendcs.utils;
+
+import java.util.function.Consumer;
+
+/**
+ * Pair objects used for returning Successful and failed results for processing in a stream.
+ * @param <SuccessType> Desired Object
+ * @param <FailType> Object containing error details. Most commonly an Exception, but can be anything.
+ */
+public class FailableResult<SuccessType, FailType>
+{
+    private final SuccessType successResult;
+    private final FailType failResult;
+
+    private FailableResult(SuccessType successResult, FailType failResult)
+    {
+        this.successResult = successResult;
+        this.failResult = failResult;
+    }
+
+    public boolean isSuccess()
+    {
+        return failResult == null;
+    }
+
+    public boolean isFailure()
+    {
+        return failResult != null;
+    }
+
+    public SuccessType getSuccess()
+    {
+        if (isFailure())
+        {
+            throw new IllegalStateException("Attempt to retrieve 'success' result of a failure result.");
+        }
+        return successResult;
+    }
+
+    public FailType getFailure()
+    {
+        if (!isFailure())
+        {
+            throw new IllegalStateException("Attempt to retrieve 'failure' result of a succesfull result.");
+        }
+        return failResult;
+    }
+
+    public void handleError(Consumer<FailType> consumer)
+    {
+        if (isFailure())
+        {
+            consumer.accept(failResult);
+        }
+    }
+
+    public static <SuccessType, FailType> FailableResult<SuccessType, FailType> success(SuccessType successResult)
+    {
+        return new FailableResult<>(successResult, null);
+    }
+
+    public static <SuccessType, FailType> FailableResult<SuccessType, FailType> failure(FailType failResult)
+    {
+        return new FailableResult<>(null, failResult);
+    }
+}

--- a/src/test/java/fixtures/NonPoolingConnectionOwner.java
+++ b/src/test/java/fixtures/NonPoolingConnectionOwner.java
@@ -340,5 +340,13 @@ public class NonPoolingConnectionOwner implements TestConnectionOwner
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'makeCompDependsNotifyDAO'");
     }
+
+    @Override
+    public TimeSeriesIdentifier transformTsidByCompParm(TimeSeriesDAI tsDAI, TimeSeriesIdentifier tsid, DbCompParm parm,
+            boolean createTS, boolean fillInParm, String timeSeriesDisplayName)
+            throws DbIoException, NoSuchObjectException, BadTimeSeriesException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'transformTsidByCompParm'");
+    }
     
 }


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #649.
Fixes #496  

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

- A combination of allowing less drastic error handling
  - returning a (result,failure) pair so that users of the result can determine if it's a normal condition or something more critical.
- Fixing some SQL usage
  - Using a transaction to use only one connection.
  - Fixing the transaction DAO connection closing logic so it's correctly closed
  - Fixing withTransaction to use the correct java.sql.Connection (original design was always new, however that breaks using the same connection if used in a transaction (note: I think I'm going to need some additional logic here as that behavior is otherwise desired)
- Tweaking the behavior of a time series identifier "cache" miss to no go to the database. The group in question or #496 starts with 14,000+ time series, but only ~71 are needed for the list, so there's 14,000 calls to the database to decide the time series identifier actually doesn't exist... about 2 seconds after we just pulled every time series identifier into a cache. Took me a while to realize that, but once I saw it it seemed, crazy.

I'm not super happy with the primary logic of just "cache updated within" but I think the cache design needs to be expanded more before that's addressed in a better way. I'll have to rebase #626 on to this if merged, but I think worth the hassle and some of the improvements I made to lend themselves to providing say, the last time this was searched for and missed and actually having the cache, through callback, do the search to track that. But definitely beyond scope of this PR, which is already a bit unwieldy.

It's entirely plausible the cache behavior tweak at the end is the only thing required, it would thusly bypass a lot of exception, but I think this work overall is worth the effort and a few hidden bugs need to be fixed.

NOTE: I haven't implemented that "cache miss is actually because data missing" tweak in the OpenDCS reference impl or HDB. But easy to do so if @agilmore2 thinks good for HDB.
Will likely do so for OpenDCS, but don't have a sufficiently large DB at hand to test and measure improvements.

I do want to do some additional testing, but I think the logic is reasonable and it's certainly time for some review and sanity checks.


## how you tested the change

Integration tests cover existing behavior. Manually to time results.

- Original performance was 40+ minutes.
- Removing excess exception throwing brought it 30 minutes.
- Reducing db connection opens, and fixing transaction connection handling, brought it to 10 minutes.
- Telling CwmsTsDao to assume the "miss" is correct when it polls the cache if the last load is recent, brought it to 11 seconds.

VisualVM's sampler and profiler were used to determine hotspots and where in the loops things were taking too long.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
