### PR TITLE
RtStat host combo behavior

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -843,7 +843,13 @@ more information about each.
             <isset property="debugPort"/>
         </condition>
 
-        <property name="decj_opts" value="${debugOpts} ${jfrOpts}"/>
+        <condition property="lang"
+                   value="-Duser.language=${opendcs.lang}"
+                   else="">
+            <isset property="opendcs.lang"/>
+        </condition>
+
+        <property name="decj_opts" value="${debugOpts} ${jfrOpts} ${lang}"/>
         <echo message="with opts: ${decj_opts}"/>
 
         <exec executable="${stage.dir}/bin/${opendcs.app}" osfamily="unix">

--- a/src/main/java/ilex/gui/JobDialog.java
+++ b/src/main/java/ilex/gui/JobDialog.java
@@ -227,7 +227,6 @@ public class JobDialog
     void closeDlg()
     {
         setVisible(false);
-        dispose();
     }
 
     /**

--- a/src/main/java/ilex/util/DesEncrypter.java
+++ b/src/main/java/ilex/util/DesEncrypter.java
@@ -174,4 +174,3 @@ public class DesEncrypter
 		System.out.println(decrypted);
 	}
 }
-

--- a/src/main/java/lrgs/db/LrgsConstants.java
+++ b/src/main/java/lrgs/db/LrgsConstants.java
@@ -38,6 +38,8 @@ public class LrgsConstants
 	public static final char maxClientExceeded = 'M';
 	public static final char badIpAddress = 'I';
 	
+	public static final int DEFAULT_LRGS_PORT = 16003;
+
 	public static String outageTypeName(char code)
 	{
 		switch(code)

--- a/src/main/java/lrgs/gui/MessageBrowser.java
+++ b/src/main/java/lrgs/gui/MessageBrowser.java
@@ -1,6 +1,6 @@
 /*
 *  $Id$
-*  
+*
 *  $Log$
 *  Revision 1.5  2016/04/15 19:31:22  mmaloney
 *  LRGS Server List sorted by access time, most-recent-first.
@@ -64,6 +64,7 @@ import lrgs.ldds.*;
 import lrgs.rtstat.RtStatFrame;
 import lrgs.rtstat.hosts.LrgsConnection;
 import lrgs.rtstat.hosts.LrgsConnectionComboBoxModel;
+import lrgs.rtstat.hosts.LrgsConnectionPanel;
 
 /**
 The MessageBrowser allows the user to display DCP messages on the screen
@@ -87,10 +88,7 @@ public class MessageBrowser extends MenuFrame
     private SearchCriteria searchcrit;
     private SearchCriteriaEditorIF scedit;
 
-    private JComboBox<LrgsConnection> hostField;
-    private JTextField portField = new JTextField(15), userField = new JTextField(15);
-    private PasswordWithShow passwordField = new PasswordWithShow(GuiConstants.DEFAULT_PASSWORD_WITH);
-    private JButton connectButton;
+    private final LrgsConnectionPanel lrgsConnectionPanel = new LrgsConnectionPanel();
     private JTextField scfileField;
     private JButton scSelectButton, scEditButton;
     private JTextField prefixField, suffixField;
@@ -157,7 +155,7 @@ public class MessageBrowser extends MenuFrame
         }
 
 
-        getMyLabelDescriptions();        
+        getMyLabelDescriptions();
         setTitle(labels.getString("MessageBrowser.frameTitle"));
         filechooser = new JFileChooser();
 
@@ -196,92 +194,31 @@ public class MessageBrowser extends MenuFrame
         contpane.add(west, BorderLayout.WEST);
 
         // NorthWest contains Server group
-        JPanel northwest = new JPanel(new GridBagLayout());
+        JPanel northwest = new JPanel(new BorderLayout());
         northwest.setBorder(new TitledBorder(
                 labels.getString("MessageBrowser.serverTitle")));
 
-        northwest.add(new JLabel(
-                labels.getString("MessageBrowser.hostName")),
-            new GridBagConstraints(0, 0, 1, 1, 0.2, 1.0,
-                GridBagConstraints.EAST, GridBagConstraints.NONE,
-                new Insets(2, 5, 2, 5), 0, 0)); 
+        lrgsConnectionPanel.setMinimumSize(new Dimension((int)(lrgsConnectionPanel.getMinimumSize().width*1.5),180));
+        lrgsConnectionPanel.setPreferredSize(lrgsConnectionPanel.getMinimumSize());
 
-        hostField = new JComboBox<>();
-        hostField.setEditable(true);
-        hostField.setModel(new LrgsConnectionComboBoxModel(new File(LddsClient.getLddsConnectionsFile())));
-        hostField.addActionListener(e -> setConnectionFields());
-        northwest.add(hostField,
-            new GridBagConstraints(1, 0, 1, 1, 0.8, 1.0,
-                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-                new Insets(2, 5, 2, 5), 0, 0)); 
+        northwest.add(lrgsConnectionPanel);
 
-        northwest.add(new JLabel(labels.getString("MessageBrowser.port")),
-            new GridBagConstraints(0, 1, 1, 1, 0.2, 1.0,
-                GridBagConstraints.EAST, GridBagConstraints.NONE,
-                new Insets(2, 5, 2, 5), 0, 0)); 
-        northwest.add(portField,
-            new GridBagConstraints(1, 1, 1, 1, 0.8, 1.0,
-                GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
-                new Insets(2, 5, 2, 5), 0, 0)); 
-        portField.setText(GuiApp.getProperty("MessageBrowser.Port"));
-
-        Dimension d = portField.getPreferredSize();
-        hostField.setPreferredSize(d);
-
-        northwest.add(new JLabel(
-                labels.getString("MessageBrowser.userName")),
-            new GridBagConstraints(0, 2, 1, 1, 0.2, 1.0,
-                GridBagConstraints.EAST, GridBagConstraints.NONE,
-                new Insets(2, 5, 2, 5), 0, 0)); 
-        northwest.add(userField,
-            new GridBagConstraints(1, 2, 1, 1, 0.8, 1.0,
-                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-                new Insets(2, 5, 2, 5), 0, 0)); 
-        if(this.userName.length()>0)
-            userField.setText(this.userName);
-        else
-        userField.setText(GuiApp.getProperty("MessageBrowser.User"));
-
-        northwest.add(new JLabel(
-                labels.getString("MessageBrowser.password")),
-            new GridBagConstraints(0, 3, 1, 1, 0.2, 1.0,
-                GridBagConstraints.EAST, GridBagConstraints.NONE,
-                new Insets(2, 5, 2, 5), 0, 0)); 
-        //northwest.add(passwordField = new JTextField(15),
-        northwest.add(passwordField,
-            new GridBagConstraints(1, 3, 1, 1, 0.8, 1.0,
-                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-                new Insets(2, 5, 2, 5), 0, 0)); 
-
-        // Connect button across bottom:
-        connectButton =
-            new SingleClickButton(labels.getString("MessageBrowser.connect"))
-            {
-                public void buttonPressed(AWTEvent event)
-                {
-                    connectButtonPress();
-                }
-            };
-        northwest.add(connectButton, 
-            new GridBagConstraints(0, 4, 2, 1, 0.0, 0.0,
-                GridBagConstraints.CENTER, GridBagConstraints.NONE,
-                new Insets(2, 5, 2, 5), 0, 0)); 
-
+        lrgsConnectionPanel.onConnect(c -> connectButtonPress(c));
         // Finally, add northwest to the west panel.
-        west.add(northwest, 
+        west.add(northwest,
             new GridBagConstraints(0, 0, 1, 1, 0.0, 1.0,
-                GridBagConstraints.NORTH, GridBagConstraints.BOTH,
-                new Insets(2, 5, 2, 5), 0, 0)); 
+                GridBagConstraints.NORTHWEST, GridBagConstraints.BOTH,
+                new Insets(2, 5, 2, 5), 0, 0));
 
 
         // Midwest contains Search Criteria Group.
         JPanel midwest = new JPanel(new BorderLayout());
         midwest.setBorder(new TitledBorder(
                 labels.getString("MessageBrowser.searchCriteria")));
-        west.add(midwest, 
+        west.add(midwest,
             new GridBagConstraints(0, 1, 1, 1, 0.0, 0.2,
                 GridBagConstraints.NORTH, GridBagConstraints.BOTH,
-                new Insets(2, 5, 2, 5), 0, 0)); 
+                new Insets(2, 5, 2, 5), 0, 0));
         JPanel p = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         p.add(new JLabel(labels.getString("MessageBrowser.fileName")));
         p.add(scfileField = new JTextField(15));
@@ -343,7 +280,7 @@ public class MessageBrowser extends MenuFrame
         p.add(nextMessageButton,
             new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
-                new Insets(2, 0, 2, 5), 0, 0)); 
+                new Insets(2, 0, 2, 5), 0, 0));
 
         displayAllButton = new JButton(
                 labels.getString("MessageBrowser.displayAll"));
@@ -358,10 +295,10 @@ public class MessageBrowser extends MenuFrame
         p.add(displayAllButton,
             new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
-                new Insets(2, 0, 2, 5), 0, 0)); 
+                new Insets(2, 0, 2, 5), 0, 0));
 
 
-        clearButton = new JButton("    " + 
+        clearButton = new JButton("    " +
                 genericLabels.getString("clear")+ "    ");
         clearButton.addActionListener(
             new ActionListener()
@@ -374,7 +311,7 @@ public class MessageBrowser extends MenuFrame
         p.add(clearButton,
             new GridBagConstraints(2, 0, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
-                new Insets(2, 5, 2, 5), 0, 0)); 
+                new Insets(2, 5, 2, 5), 0, 0));
 
         saveToFileButton =
             new SingleClickButton(
@@ -390,7 +327,7 @@ public class MessageBrowser extends MenuFrame
         p.add(saveToFileButton,
             new GridBagConstraints(3, 0, 1, 1, 1.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
-                new Insets(2, 5, 2, 0), 0, 0)); 
+                new Insets(2, 5, 2, 0), 0, 0));
 
         center.add(p, BorderLayout.SOUTH);
 
@@ -403,21 +340,21 @@ public class MessageBrowser extends MenuFrame
                 labels.getString("MessageBrowser.beforeMsg")),
             new GridBagConstraints(0, 0, 1, 1, 0.2, 1.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
-                new Insets(2, 5, 2, 5), 0, 0)); 
+                new Insets(2, 5, 2, 5), 0, 0));
 
         southwest.add(prefixField = new JTextField(16),
             new GridBagConstraints(1, 0, 1, 1, 0.8, 1.0,
                 GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-                new Insets(2, 5, 2, 5), 0, 0)); 
+                new Insets(2, 5, 2, 5), 0, 0));
         prefixField.setText(GuiApp.getProperty("MessageBrowser.Prefix"));
         southwest.add(new JLabel(labels.getString("MessageBrowser.afterMsg")),
             new GridBagConstraints(0, 1, 1, 1, 0.2, 1.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
-                new Insets(2, 5, 2, 5), 0, 0)); 
+                new Insets(2, 5, 2, 5), 0, 0));
         southwest.add(suffixField = new JTextField(16),
             new GridBagConstraints(1, 1, 1, 1, 0.8, 1.0,
                 GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-                new Insets(2, 5, 2, 5), 0, 0)); 
+                new Insets(2, 5, 2, 5), 0, 0));
         suffixField.setText(GuiApp.getProperty("MessageBrowser.Suffix"));
 
 
@@ -426,14 +363,14 @@ public class MessageBrowser extends MenuFrame
             southwest.add(new JLabel(labels.getString("MessageBrowser.show")),
                 new GridBagConstraints(0, 2, 1, 1, 0.2, 1.0,
                     GridBagConstraints.EAST, GridBagConstraints.NONE,
-                    new Insets(2, 5, 2, 5), 0, 0)); 
+                    new Insets(2, 5, 2, 5), 0, 0));
             showCombo = new JComboBox(showChoices);
             showCombo.setSelectedItem(
                 GuiApp.getProperty("MessageBrowser.Show", "Raw"));
             southwest.add(showCombo,
                 new GridBagConstraints(1, 2, 1, 1, 1.0, 1.0,
                     GridBagConstraints.WEST, GridBagConstraints.NONE,
-                    new Insets(2, 5, 2, 5), 0, 0)); 
+                    new Insets(2, 5, 2, 5), 0, 0));
 
             showCombo.addActionListener(
                 new ActionListener()
@@ -456,7 +393,7 @@ public class MessageBrowser extends MenuFrame
             if (outFmts == null)
             {
                 String[] thisFmt = new String[1];
-                thisFmt[0] = "human-readable"; 
+                thisFmt[0] = "human-readable";
                 outCombo = new JComboBox(thisFmt);
             } else {
 
@@ -484,20 +421,20 @@ public class MessageBrowser extends MenuFrame
                     labels.getString("MessageBrowser.beforeData")),
                 new GridBagConstraints(0, 4, 1, 1, 0.2, 1.0,
                     GridBagConstraints.EAST, GridBagConstraints.NONE,
-                    new Insets(2, 5, 2, 5), 0, 0)); 
+                    new Insets(2, 5, 2, 5), 0, 0));
             southwest.add(beforeDataField = new JTextField(16),
                 new GridBagConstraints(1, 4, 1, 1, 0.8, 1.0,
                     GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-                    new Insets(2, 5, 2, 5), 0, 0)); 
+                    new Insets(2, 5, 2, 5), 0, 0));
 
             southwest.add(new JLabel(labels.getString("MessageBrowser.afterData")),
                 new GridBagConstraints(0, 5, 1, 1, 0.2, 1.0,
                     GridBagConstraints.EAST, GridBagConstraints.NONE,
-                    new Insets(2, 5, 2, 5), 0, 0)); 
+                    new Insets(2, 5, 2, 5), 0, 0));
             southwest.add(afterDataField = new JTextField(16),
                 new GridBagConstraints(1, 5, 1, 1, 0.8, 1.0,
                     GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
-                    new Insets(2, 5, 2, 5), 0, 0)); 
+                    new Insets(2, 5, 2, 5), 0, 0));
         }
 
         wrapCheck = new JCheckBox(
@@ -506,7 +443,7 @@ public class MessageBrowser extends MenuFrame
         southwest.add(wrapCheck,
             new GridBagConstraints(0, (canDecode ? 6 : 2), 2, 1, 1.0, 1.0,
                 GridBagConstraints.CENTER, GridBagConstraints.NONE,
-                new Insets(2, 6, 2, 5), 0, 0)); 
+                new Insets(2, 6, 2, 5), 0, 0));
         wrapLines = wrapCheck.isSelected();
         messageArea.setLineWrap(wrapLines);
         wrapCheck.addItemListener(
@@ -516,15 +453,15 @@ public class MessageBrowser extends MenuFrame
                 {
                     wrapLines = ev.getStateChange() == ItemEvent.SELECTED;
                     messageArea.setLineWrap(wrapLines);
-                    GuiApp.setProperty("MessageBrowser.WrapLongLines", 
+                    GuiApp.setProperty("MessageBrowser.WrapLongLines",
                         wrapLines ? "true" : "false");
                 }
             });
 
-        west.add(southwest, 
+        west.add(southwest,
             new GridBagConstraints(0, 2, 1, 1, 0.0, 1.0,
                 GridBagConstraints.NORTH, GridBagConstraints.BOTH,
-                new Insets(2, 5, 2, 5), 0, 0)); 
+                new Insets(2, 5, 2, 5), 0, 0));
 
         String dir = System.getProperty("user.dir");
         filechooser.setCurrentDirectory(new File(dir));
@@ -559,15 +496,15 @@ public class MessageBrowser extends MenuFrame
         GuiApp.getProperty("MessageBrowser.Port",
             "" + LddsParams.DefaultPort);
         GuiApp.getProperty("MessageBrowser.Timeout", "60");
-        GuiApp.getProperty("MessageBrowser.DefaultSearchCrit", 
+        GuiApp.getProperty("MessageBrowser.DefaultSearchCrit",
             "$DCSTOOL_USERDIR/MessageBrowser.sc");
         String nm = "MessageBrowser.WrapLongLines";
         GuiApp.getProperty(nm, "true");
-        EditPropsAction.registerEditor(nm, 
+        EditPropsAction.registerEditor(nm,
             new JComboBox(new String[] { "true", "false" }));
         nm = "MessageBrowser.showMsgMetaData";
         GuiApp.getProperty(nm, "false");
-        EditPropsAction.registerEditor(nm, 
+        EditPropsAction.registerEditor(nm,
             new JComboBox(new String[] { "true", "false" }));
 
         // Try to initialize DECODES:
@@ -616,7 +553,7 @@ public class MessageBrowser extends MenuFrame
 
             nm = "MessageBrowser.EnableEquations";
             GuiApp.getProperty(nm, "true");
-            EditPropsAction.registerEditor(nm, 
+            EditPropsAction.registerEditor(nm,
                 new JComboBox(new String[] { "true", "false" }));
 
             nm = "MessageBrowser.Show";
@@ -735,7 +672,7 @@ public class MessageBrowser extends MenuFrame
       Uses current info from the hostname, port, user, and password fields
       to open the DDS connection and send the inital "Hello" message.
     */
-    public void connectButtonPress()
+    public void connectButtonPress(LrgsConnection c)
     {
         statusBar.setText(labels.getString("MessageBrowser.connectingLabel"));
         if (client != null)
@@ -750,33 +687,18 @@ public class MessageBrowser extends MenuFrame
         msgOutputThread = null;
         nextMessageButton.setEnabled(true);
 
-        int port;
-        try
-        {
-            port = Integer.parseInt(portField.getText());
-        }
-        catch(NumberFormatException nfe)
-        {
-            port = LddsParams.DefaultPort;
-        }
+        int port = c.getPort();
 
         String errmsg = null;
-        hostName = (String)hostField.getSelectedItem();
-        String pw = new String(passwordField.getPassword());
-
+        hostName = c.getHostName();
+        String pw = LrgsConnection.decryptPassword(c, LrgsConnectionPanel.pwk);
+        String username = c.getUsername();
         try
         {
             client = new LddsClient(hostName, port);
             client.connect();
 
-            if (pw.length() > 0)
-            {
-                client.sendAuthHello(userField.getText(), pw);
-            }
-            else
-            {
-                client.sendHello(userField.getText());
-            }
+            client.sendAuthHello(username, pw);
 
             msgOutputThread = new DcpMsgOutputThread(this, client,
                 msgDisplayStream, 5, "", "");
@@ -815,11 +737,10 @@ public class MessageBrowser extends MenuFrame
         {
             statusBar.setText(LoadResourceBundle.sprintf(
                     labels.getString("MessageBrowser.connectedToAsUserLabel"),
-                    hostName, port, userField.getText()));
+                    hostName, port, username));
 
             firstAfterConnect = true;
-            //RtStatFrame.updateConnectionList();
-            //RtStatFrame.loadConnectionsField(hostField, connectionList, hostName);
+            lrgsConnectionPanel.addOrUpdateConnection(c);
         }
     }
 
@@ -836,7 +757,7 @@ public class MessageBrowser extends MenuFrame
     }
 
     /**
-      Called when Search Criteria Edit button is pressed. 
+      Called when Search Criteria Edit button is pressed.
       If an SC Edit dialog is already active, just switch to it. Otherwise
       start one on the currently selected criteria.
     */
@@ -851,7 +772,7 @@ public class MessageBrowser extends MenuFrame
         String s = scfileField.getText();
         s = EnvExpander.expand(s, System.getProperties());
 
-        decodes.util.ResourceFactory rf = 
+        decodes.util.ResourceFactory rf =
             decodes.util.ResourceFactory.instance();
         try
         {
@@ -927,13 +848,13 @@ public class MessageBrowser extends MenuFrame
             }
             catch(Exception ioe)
             {
-                if (ioe instanceof FileNotFoundException 
+                if (ioe instanceof FileNotFoundException
                  && curSCName.endsWith("MessageBrowser.sc"))
                 {
-                    try 
+                    try
                     {
-                        f.createNewFile(); 
-                        try 
+                        f.createNewFile();
+                        try
                         {
                             searchcrit = new SearchCriteria(f);
                         }
@@ -981,7 +902,7 @@ public class MessageBrowser extends MenuFrame
     {
         if (client == null)
         {
-            connectButtonPress();
+            connectButtonPress(lrgsConnectionPanel.getCurrentConnection());
             if (client == null) // unsuccessful connect?
             {
                 return;
@@ -997,13 +918,13 @@ public class MessageBrowser extends MenuFrame
         }
         msgOutputThread.prefix = prefixField.getText();
         msgOutputThread.suffix = suffixField.getText();
-        msgOutputThread.timeout = 
+        msgOutputThread.timeout =
             GuiApp.getIntProperty("MessageBrowser.Timeout", 5);
         msgOutputThread.showRaw = showRaw;
         msgOutputThread.doDecode = doDecode;
         msgOutputThread.beforeData = canDecode ? beforeDataField.getText() : null;
         msgOutputThread.afterData = canDecode ? afterDataField.getText() : null;
-        msgOutputThread.showMetaData = 
+        msgOutputThread.showMetaData =
             GuiApp.getBooleanProperty("MessageBrowser.showMsgMetaData", false);
 
         displayPaused = false;
@@ -1018,7 +939,7 @@ public class MessageBrowser extends MenuFrame
     */
     public void sendNetworkLists(SearchCriteria searchcrit)
     {
-        if (searchcrit.NetlistFiles == null 
+        if (searchcrit.NetlistFiles == null
          || searchcrit.NetlistFiles.size() == 0)
         {
             Logger.instance().debug3("No lists to send.");
@@ -1111,16 +1032,8 @@ public class MessageBrowser extends MenuFrame
     */
     public void saveToFileButtonPress()
     {
-        // Get port number
-        int port;
-        try
-        {
-            port = Integer.parseInt(portField.getText());
-        }
-        catch(NumberFormatException nfe)
-        {
-            port = LddsParams.DefaultPort;
-        }
+        final LrgsConnection currentLrgs = lrgsConnectionPanel.getCurrentConnection();
+        final int port = currentLrgs.getPort();
 
         // Make sure current 'searchcrit' object is up-to-date and make
         // a copy for the output thread to use.
@@ -1128,16 +1041,16 @@ public class MessageBrowser extends MenuFrame
         SearchCriteria outputcrit = new SearchCriteria(searchcrit);
 
         MessageOutput output = new MessageOutput(
-            (String)hostField.getSelectedItem(), port, userField.getText(),
+            currentLrgs.getHostName(), port, currentLrgs.getUsername(),
             outputcrit, prefixField.getText(), suffixField.getText(),
             true, doDecode,
             (canDecode ? beforeDataField.getText() : null),
             (canDecode ? afterDataField.getText() : null), showRaw);
         //String s = passwordField.getText().trim();
-        String s = new String(passwordField.getPassword());
+        String s = currentLrgs.getPassword();
         if (s.length() > 0)
         {
-            output.setPassword(s);
+            output.setPassword(LrgsConnection.decryptPassword(currentLrgs, LrgsConnectionPanel.pwk));
         }
 
         output.startup(x+40, y+40);
@@ -1167,7 +1080,7 @@ public class MessageBrowser extends MenuFrame
         return displayPaused;
     }
 
-    /** 
+    /**
     Called when output thread encounters an error. Display it in a dialog.
     @param msg the error message
     */
@@ -1280,7 +1193,7 @@ public class MessageBrowser extends MenuFrame
                 settings.language);
     }
 
-    public static ResourceBundle getLabels() 
+    public static ResourceBundle getLabels()
     {
         if (labels == null)
         {
@@ -1289,7 +1202,7 @@ public class MessageBrowser extends MenuFrame
         return labels;
     }
 
-    public static ResourceBundle getGenericLabels() 
+    public static ResourceBundle getGenericLabels()
     {
         if (genericLabels == null)
         {
@@ -1334,7 +1247,7 @@ public class MessageBrowser extends MenuFrame
     {
         if (client == null)
         {
-            connectButtonPress();
+            connectButtonPress(lrgsConnectionPanel.getCurrentConnection());
             if (client == null) // unsuccessful connect?
             {
                 return;
@@ -1359,13 +1272,13 @@ public class MessageBrowser extends MenuFrame
 
         msgOutputThread.prefix = prefixField.getText();
         msgOutputThread.suffix = suffixField.getText();
-        msgOutputThread.timeout = 
+        msgOutputThread.timeout =
             GuiApp.getIntProperty("MessageBrowser.Timeout", 30);
         msgOutputThread.doDecode = doDecode;
         msgOutputThread.showRaw = showRaw;
         msgOutputThread.beforeData = canDecode ? beforeDataField.getText() : null;
         msgOutputThread.afterData = canDecode ? afterDataField.getText() : null;
-        msgOutputThread.showMetaData = 
+        msgOutputThread.showMetaData =
             GuiApp.getBooleanProperty("MessageBrowser.showMsgMetaData", false);
 
         displayPaused = false;

--- a/src/main/java/lrgs/gui/MessageBrowser.java
+++ b/src/main/java/lrgs/gui/MessageBrowser.java
@@ -62,6 +62,8 @@ import ilex.util.EnvExpander;
 import lrgs.common.*;
 import lrgs.ldds.*;
 import lrgs.rtstat.RtStatFrame;
+import lrgs.rtstat.hosts.LrgsConnection;
+import lrgs.rtstat.hosts.LrgsConnectionComboBoxModel;
 
 /**
 The MessageBrowser allows the user to display DCP messages on the screen
@@ -85,7 +87,7 @@ public class MessageBrowser extends MenuFrame
     private SearchCriteria searchcrit;
     private SearchCriteriaEditorIF scedit;
 
-    private JComboBox hostField;
+    private JComboBox<LrgsConnection> hostField;
     private JTextField portField = new JTextField(15), userField = new JTextField(15);
     private PasswordWithShow passwordField = new PasswordWithShow(GuiConstants.DEFAULT_PASSWORD_WITH);
     private JButton connectButton;
@@ -204,18 +206,10 @@ public class MessageBrowser extends MenuFrame
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
                 new Insets(2, 5, 2, 5), 0, 0)); 
 
-        hostField = new JComboBox();
+        hostField = new JComboBox<>();
         hostField.setEditable(true);
-        hostField.addActionListener(
-            new ActionListener()
-            {
-                public void actionPerformed(ActionEvent ae)
-                {
-                    RtStatFrame.setFieldsFromHostSelection(hostField, connectionList, portField, 
-                        userField, passwordField);
-                }
-            });
-        RtStatFrame.loadConnectionsField(hostField, connectionList, "");
+        hostField.setModel(new LrgsConnectionComboBoxModel(new File(LddsClient.getLddsConnectionsFile())));
+        hostField.addActionListener(e -> setConnectionFields());
         northwest.add(hostField,
             new GridBagConstraints(1, 0, 1, 1, 0.8, 1.0,
                 GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
@@ -824,9 +818,8 @@ public class MessageBrowser extends MenuFrame
                     hostName, port, userField.getText()));
 
             firstAfterConnect = true;
-            RtStatFrame.updateConnectionList(hostName, portField.getText(),
-                userField.getText(), connectionList, pw);
-            RtStatFrame.loadConnectionsField(hostField, connectionList, hostName);
+            //RtStatFrame.updateConnectionList();
+            //RtStatFrame.loadConnectionsField(hostField, connectionList, hostName);
         }
     }
 
@@ -1390,5 +1383,10 @@ public class MessageBrowser extends MenuFrame
         displayingAll = false;
         nextMessageButton.setEnabled(true);
         client.enableMultiMessageMode(false);
+    }
+
+    private void setConnectionFields()
+    {
+        /* TODO: getting moved to the new Panel. */
     }
 }

--- a/src/main/java/lrgs/gui/MessageBrowser.java
+++ b/src/main/java/lrgs/gui/MessageBrowser.java
@@ -88,7 +88,7 @@ public class MessageBrowser extends MenuFrame
     private SearchCriteria searchcrit;
     private SearchCriteriaEditorIF scedit;
 
-    private final LrgsConnectionPanel lrgsConnectionPanel = new LrgsConnectionPanel();
+    private final LrgsConnectionPanel lrgsConnectionPanel = new LrgsConnectionPanel(false);
     private JTextField scfileField;
     private JButton scSelectButton, scEditButton;
     private JTextField prefixField, suffixField;
@@ -675,7 +675,7 @@ public class MessageBrowser extends MenuFrame
       Uses current info from the hostname, port, user, and password fields
       to open the DDS connection and send the inital "Hello" message.
     */
-    public void connectButtonPress(LrgsConnection c)
+    public boolean connectButtonPress(LrgsConnection c)
     {
         statusBar.setText(labels.getString("MessageBrowser.connectingLabel"));
         if (client != null)
@@ -735,6 +735,7 @@ public class MessageBrowser extends MenuFrame
             client = null;
             statusBar.setText(
                     labels.getString("MessageBrowser.notConnectedLabel"));
+            return false;
         }
         else
         {
@@ -743,7 +744,7 @@ public class MessageBrowser extends MenuFrame
                     hostName, port, username));
 
             firstAfterConnect = true;
-            lrgsConnectionPanel.addOrUpdateConnection(c);
+            return client.isConnected();
         }
     }
 

--- a/src/main/java/lrgs/gui/MessageBrowser.java
+++ b/src/main/java/lrgs/gui/MessageBrowser.java
@@ -198,6 +198,9 @@ public class MessageBrowser extends MenuFrame
         northwest.setBorder(new TitledBorder(
                 labels.getString("MessageBrowser.serverTitle")));
 
+        // The below dimensions were determined by sizing the controls within
+        // the eclipse window builder tool and using those measurements. If anyone
+        // has a better method to get the minimum size, please go for it.
         lrgsConnectionPanel.setMinimumSize(new Dimension(529,140));
         lrgsConnectionPanel.setPreferredSize(lrgsConnectionPanel.getMinimumSize());
 

--- a/src/main/java/lrgs/gui/MessageBrowser.java
+++ b/src/main/java/lrgs/gui/MessageBrowser.java
@@ -198,7 +198,7 @@ public class MessageBrowser extends MenuFrame
         northwest.setBorder(new TitledBorder(
                 labels.getString("MessageBrowser.serverTitle")));
 
-        lrgsConnectionPanel.setMinimumSize(new Dimension((int)(lrgsConnectionPanel.getMinimumSize().width*1.5),180));
+        lrgsConnectionPanel.setMinimumSize(new Dimension(529,140));
         lrgsConnectionPanel.setPreferredSize(lrgsConnectionPanel.getMinimumSize());
 
         northwest.add(lrgsConnectionPanel);

--- a/src/main/java/lrgs/ldds/LddsClient.java
+++ b/src/main/java/lrgs/ldds/LddsClient.java
@@ -1663,13 +1663,6 @@ public class LddsClient extends BasicClient
     public byte[] getStatus()
         throws IOException, ProtocolError, ServerError
     {
-        if (debug != null)
-        {
-            debug.println("getStatus");
-        }
-        Logger.instance().debug2(module +
-            "DDS Connection (" + host + ":" + port + ") getStatus");
-
         // Send request
         LddsMessage msg = new LddsMessage(LddsMessage.IdStatus, "?");
         sendData(msg.getBytes());
@@ -1709,13 +1702,6 @@ public class LddsClient extends BasicClient
         {
             return new String[0];
         }
-
-        if (debug != null)
-        {
-            debug.println("getEvent");
-        }
-        Logger.instance().debug2(module +
-            "DDS Connection (" + host + ":" + port + ") getEvents");
 
         // Send request
         LddsMessage msg = new LddsMessage(LddsMessage.IdEvents, "?");

--- a/src/main/java/lrgs/rtstat/RtStat.java
+++ b/src/main/java/lrgs/rtstat/RtStat.java
@@ -1,6 +1,8 @@
 package lrgs.rtstat;
 
 import ilex.util.LoadResourceBundle;
+import lrgs.rtstat.hosts.LrgsConnection;
+import lrgs.rtstat.hosts.LrgsConnectionPanel;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -42,7 +44,13 @@ public class RtStat
 		if (hostname != null)
 		{
 			final String username = cmdLineArgs.getUserName();
-			
+			final String password = cmdLineArgs.getPassword();
+			final int port = cmdLineArgs.getPort();
+			if (username == null || password == null)
+			{
+				log.error("A Username and Password are now required for LRGS connections."
+						 + " Please set one with -pw <password>.");
+			}
 			Thread delay = new Thread()
 			{
 				public void run()
@@ -59,10 +67,17 @@ public class RtStat
 						{
 							public void run()
 							{
-								frame.setHost(hostname);
 								if (username != null)
-									frame.userField.setText(username.trim());
-								frame.connectButton_actionPerformed(null);
+								{
+									frame.connectButton_actionPerformed(
+										new LrgsConnection(hostname, port,
+															username,
+															LrgsConnection.encryptPassword(
+																password,
+																LrgsConnectionPanel.pwk),
+															null)
+									);
+								}
 							}
 						});
 				}

--- a/src/main/java/lrgs/rtstat/RtStat.java
+++ b/src/main/java/lrgs/rtstat/RtStat.java
@@ -1,5 +1,6 @@
 package lrgs.rtstat;
 
+import ilex.util.AuthException;
 import ilex.util.LoadResourceBundle;
 import lrgs.rtstat.hosts.LrgsConnection;
 import lrgs.rtstat.hosts.LrgsConnectionPanel;
@@ -48,7 +49,7 @@ public class RtStat
 			final int port = cmdLineArgs.getPort();
 			if (username == null || password == null)
 			{
-				log.error("A Username and Password are now required for LRGS connections."
+				throw new AuthException("A Username and Password are now required for LRGS connections."
 						 + " Please set one with -pw <password>.");
 			}
 			Thread delay = new Thread()
@@ -60,7 +61,7 @@ public class RtStat
 						sleep(3000L);
 					} catch (InterruptedException e)
 					{
-					log.error("InterruptedException ",e);
+						log.error("InterruptedException ",e);
 					}
 					SwingUtilities.invokeLater(
 						new Runnable()
@@ -134,12 +135,12 @@ public class RtStat
 		{
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
 			System.out.println("Default local: " + Locale.getDefault().toString());
+			RtStat rtStat = new RtStat(args);
+			rtStat.frame.setVisible(true);
 		}
-		catch (Exception e)
+		catch (Exception ex)
 		{
-			log.error("Error starting RtStat ",e);
+			log.error("Error starting RtStat.", ex);
 		}
-		RtStat rtStat = new RtStat(args);
-		rtStat.frame.setVisible(true);
 	}
 }

--- a/src/main/java/lrgs/rtstat/RtStat.java
+++ b/src/main/java/lrgs/rtstat/RtStat.java
@@ -2,6 +2,7 @@ package lrgs.rtstat;
 
 import ilex.util.LoadResourceBundle;
 
+import java.util.Locale;
 import java.util.ResourceBundle;
 
 import javax.swing.*;
@@ -83,16 +84,17 @@ public class RtStat
 	
 	public static void getMyLabelDescriptions()
 	{
-		DecodesSettings settings = DecodesSettings.instance();
 		//Load the generic properties file - includes labels that are used
 		//in multiple screens
+		Locale locale = Locale.getDefault();
+		LoadResourceBundle.setLocale(locale.getLanguage());
 		genericLabels = LoadResourceBundle.getLabelDescriptions(
 				"decodes/resources/generic",
-				settings.language);
+				locale.getLanguage());
 		//Return the main label descriptions for RStat App
 		labels = LoadResourceBundle.getLabelDescriptions(
 				"decodes/resources/rtstat",
-				settings.language);
+				locale.getLanguage());
 	}
 	
 	public static ResourceBundle getLabels() 
@@ -116,6 +118,7 @@ public class RtStat
 		try
 		{
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+			System.out.println("Default local: " + Locale.getDefault().toString());
 		}
 		catch (Exception e)
 		{

--- a/src/main/java/lrgs/rtstat/RtStatCmdLineArgs.java
+++ b/src/main/java/lrgs/rtstat/RtStatCmdLineArgs.java
@@ -12,6 +12,7 @@ import decodes.util.DecodesSettings;
 
 import ilex.cmdline.*;
 import ilex.util.Logger;
+import lrgs.db.LrgsConstants;
 import ilex.util.EnvExpander;
 
 public class RtStatCmdLineArgs
@@ -25,6 +26,8 @@ public class RtStatCmdLineArgs
 	private StringToken userArg;
 	private StringToken lrgsMonUrlArg;
 	private StringToken logFileArg;
+	private StringToken passwordArg;
+	private IntegerToken portArg;
 
     public RtStatCmdLineArgs()
 	{
@@ -52,6 +55,12 @@ public class RtStatCmdLineArgs
 		logFileArg = new StringToken( "l", "logfile name", 
 			"", TokenOptions.optSwitch, "");
 		addToken(logFileArg);
+		passwordArg = new StringToken("pw", "Password for initial connection",
+			"", TokenOptions.optSwitch, "");
+		addToken(passwordArg);
+		portArg = new IntegerToken("p", "port for the remote LRGS",
+			"", TokenOptions.optSwitch, LrgsConstants.DEFAULT_LRGS_PORT);
+		addToken(portArg);
     }
 
 	/**
@@ -144,6 +153,17 @@ public class RtStatCmdLineArgs
 	{
 		String x = userArg.getValue();
 		return x.length() > 0 ? x : null;
+	}
+
+	public String getPassword()
+	{
+		final String x = passwordArg.getValue();
+		return x.length() > 0 ? x : null;
+	}
+
+	public int getPort()
+	{
+		return portArg.getValue();
 	}
 
 	public String getLrgsMonUrl()

--- a/src/main/java/lrgs/rtstat/RtStatFrame.java
+++ b/src/main/java/lrgs/rtstat/RtStatFrame.java
@@ -52,1119 +52,1119 @@ import ilex.util.LoadResourceBundle;
 Main frame for the LRGS Real-Time Status Application.
 */
 public class RtStatFrame
-	extends TopFrame
-	implements DdsClientIf, HyperlinkListener
+    extends TopFrame
+    implements DdsClientIf, HyperlinkListener
 {
-	private final static org.slf4j.Logger log = LoggerFactory.getLogger(RtStatFrame.class);
-	private static ResourceBundle labels =
-		RtStat.getLabels();
-	private static ResourceBundle genericLabels =
-		RtStat.getGenericLabels();
-	private JPanel contentPane;
-	private JMenuBar jMenuBar1 = new JMenuBar();
-	private JMenu jMenuFile = new JMenu();
-	private JMenuItem fileSetPasswordMenuItem = new JMenuItem();
-	private JMenuItem fileUserAdmin = new JMenuItem();
-	private JMenuItem fileLrgsConfig = new JMenuItem();
-	private JMenuItem jMenuFileExit = new JMenuItem();
-	private JMenuItem fileNetworkLists = new JMenuItem();
-	private JMenu jMenuHelp = new JMenu();
-	private JMenuItem jMenuHelpAbout = new JMenuItem();
-	private BorderLayout borderLayout1 = new BorderLayout();
-	private JPanel topPanel = new JPanel();
-	private JLabel hostLabel = new JLabel();
-	private JComboBox<LrgsConnection> hostCombo = new JComboBox<>();
-	private PasswordWithShow passwordField = new PasswordWithShow(GuiConstants.DEFAULT_PASSWORD_WITH);
-	private JSplitPane jSplitPane1 = new JSplitPane();
-	private RtStatPanel rtStatPanel = new RtStatPanel();
-	private EventsPanel eventsPanel = new EventsPanel(false);
-	private JCheckBox passwordCheck = new JCheckBox();
-	private LrgsConnectionPanel connectionPanel = new LrgsConnectionPanel();
-
-	/** True if the display is currently paused. */
-	boolean isPaused = false;
-
-	/** The object used to communicate with the server. */
-	private LddsClient client;
-
-	/** The background polling thread. */
-	RtStatFrameThread myThread;
-
-	/** The currently selected host name. */
-	private String connectedHostName = "";
-
-	private int dividerLoc;
-	private int splitPaneHeight;
-
-	/** the currently connected host -- null if not connected. */
-	String host;
-	int port;
-	String user;
-	String passwd;
-
-	/** Dialog for editing users. */
-	private UserListDialog userListDialog = null;
-
-	private LrgsConfigDialog lrgsConfigDialog = null;
-	private LrgsConfig lrgsConfig;  //  @jve:decl-index=0:
-	private DdsRecvSettings ddsSettings;  //  @jve:decl-index=0:
-	private DrgsInputSettings drgsSettings;
-	private NetlistMaintenanceDialog netlistDlg;
-	private DrgsInputSettings networkDcpSettings;
-	private NetworkDcpStatusFrame networkDcpStatusFrame = null;
-
-	/** Constructor. */
-	public RtStatFrame(int scanPeriod, String iconFile, String headerFile)
-	{
-		exitOnClose = true;
-		try
-		{
-			jbInit();
-		}
-		catch (Exception e)
-		{
-			log.error("RtStatFrame: ",e);
-		}
-		isPaused = false;
-		client = null;
-		passwordCheck.setSelected(false);
-		passwordField.setEnabled(false);
-		myThread = new RtStatFrameThread(this, scanPeriod,iconFile,headerFile);
-		myThread.start();
-		Dimension d = java.awt.Toolkit.getDefaultToolkit().getScreenSize();
-		d.width = 800;
-		d.height -= 60;
-		setSize(d);
-		dividerLoc = d.height - 80 - 160;
-		splitPaneHeight = 0;
-		jSplitPane1.setDividerLocation(dividerLoc);
-		jSplitPane1.addComponentListener(
-			new ComponentAdapter()
-			{
-				public void componentResized(ComponentEvent e)
-				{
-					if (splitPaneHeight == 0)
-					{
-						splitPaneHeight = jSplitPane1.getHeight();
-						return;
-					}
-					int newHeight = jSplitPane1.getHeight();
-					int newLoc = newHeight - (splitPaneHeight - dividerLoc);
-					jSplitPane1.setDividerLocation(newLoc);
-					splitPaneHeight = newHeight;
-					dividerLoc = newLoc;
-				}
-			});
-		eventsPanel.addAncestorListener(
-			new AncestorListener()
-			{
-				public void ancestorAdded(AncestorEvent ev) {}
-				public void ancestorRemoved(AncestorEvent ev) {}
-				public void ancestorMoved(AncestorEvent ev)
-				{
-					dividerLoc = jSplitPane1.getDividerLocation();
-				}
-			});
-
-		//loadConnectionsField(hostCombo, connectionList, connectedHostName);
-		netlistDlg = null;
-		rtStatPanel.htmlPanel.addHyperlinkListener(this);
-
-		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-		final RtStatFrame myframe = this;
-		addWindowListener(
-			new WindowAdapter()
-			{
-				public void windowClosed(WindowEvent e)
-				{
-					if (myframe.getExitOnClose())
-						System.exit(0);
-				}
-			});
-		trackChanges("RtStat");
-	}
-
-	/** Initializes GUI components. */
-	private void jbInit()
-		throws Exception
-	{
-		boolean canConfig = true;
-		ClassLoader cl = Thread.currentThread().getContextClassLoader();
-		try { cl.loadClass("lrgs.ddsrecv.DdsRecvConnectCfg"); }
-		catch(ClassNotFoundException ex) { canConfig = false; }
-
-
-
-		contentPane = (JPanel)this.getContentPane();
-		contentPane.setLayout(borderLayout1);
-		this.setSize(new Dimension(793, 716));
-		this.setTitle(
-				labels.getString("RtStatFrame.frameTitle"));
-		jMenuFile.setText(genericLabels.getString("file"));
-		jMenuFileExit.setText(genericLabels.getString("exit"));
-		jMenuFileExit.addActionListener(
-			new java.awt.event.ActionListener()
-			{
-	    		public void actionPerformed(ActionEvent e)
-	    		{
-					jMenuFileExit_actionPerformed(e);
-				}
-			});
-		fileSetPasswordMenuItem.setText(
-				labels.getString("RtStatFrame.setPassword"));
-		fileSetPasswordMenuItem.addActionListener(
-			new java.awt.event.ActionListener()
-			{
-	    		public void actionPerformed(ActionEvent e)
-	    		{
-					fileSetPasswordMenuItem_actionPerformed();
-				}
-			});
-		fileUserAdmin.setText(
-			labels.getString("RtStatFrame.userAdministration"));
-		fileUserAdmin.addActionListener(
-			new java.awt.event.ActionListener()
-			{
-	    		public void actionPerformed(ActionEvent e)
-	    		{
-					fileUserAdmin_actionPerformed();
-				}
-			});
-
-
-		if (canConfig)
-		{
-			fileLrgsConfig.setText(
-					labels.getString("RtStatFrame.LRGSConfiguration"));
-			fileLrgsConfig.addActionListener(
-				new java.awt.event.ActionListener()
-				{
-		    		public void actionPerformed(ActionEvent e)
-		    		{
-						fileLrgsConfig_actionPerformed();
-					}
-				});
-
-			fileNetworkLists.setText(
-					labels.getString("RtStatFrame.networkLists"));
-			fileNetworkLists.addActionListener(
-				new java.awt.event.ActionListener()
-				{
-		    		public void actionPerformed(ActionEvent e)
-		    		{
-						fileNetworkLists_actionPerformed();
-					}
-				});
-		}
-
-		jMenuHelp.setText(
-				genericLabels.getString("help"));
-		jMenuHelpAbout.setText(
-				genericLabels.getString("about"));
-		jMenuHelpAbout.addActionListener(
-			new java.awt.event.ActionListener()
-			{
-	    		public void actionPerformed(ActionEvent e)
-	    		{
-					jMenuHelpAbout_actionPerformed(e);
-				}
-			});
-
-		hostLabel.setText(
-				labels.getString("RtStatFrame.host"));
-		topPanel.setLayout(new BorderLayout());
-
-		connectionPanel.onPause(c -> pauseButton_actionPerformed(c));
-
-		jSplitPane1.setOrientation(JSplitPane.VERTICAL_SPLIT);
-		eventsPanel.setMaximumSize(new Dimension(32767, 150));
-		eventsPanel.setMinimumSize(new Dimension(10, 120));
-		eventsPanel.setPreferredSize(new Dimension(10, 120));
-		jMenuFile.add(fileSetPasswordMenuItem);
-		jMenuFile.add(fileUserAdmin);
-		if (canConfig)
-		{
-			jMenuFile.add(fileLrgsConfig);
-			jMenuFile.add(fileNetworkLists);
-		}
-		jMenuFile.addSeparator();
-		jMenuFile.add(jMenuFileExit);
-		jMenuHelp.add(jMenuHelpAbout);
-		jMenuBar1.add(jMenuFile);
-		jMenuBar1.add(jMenuHelp);
-		contentPane.add(topPanel, BorderLayout.NORTH);
-		topPanel.add(connectionPanel);
-		connectionPanel.onConnect(c -> connectButton_actionPerformed(c));
-		contentPane.add(jSplitPane1, BorderLayout.CENTER);
-		jSplitPane1.add(rtStatPanel, JSplitPane.TOP);
-		jSplitPane1.add(eventsPanel, JSplitPane.BOTTOM);
-		this.setJMenuBar(jMenuBar1);
-	}
-
-	//File | Exit action performed
-	private void jMenuFileExit_actionPerformed(ActionEvent e)
-	{
-		dispose();
-		if (exitOnClose)
-		{
-			System.exit(0);
-		}
-	}
-
-	//Help | About action performed
-	private void jMenuHelpAbout_actionPerformed(ActionEvent e)
-	{
-		AboutBox dlg = new AboutBox(this, "LRGS", "Local Readout Ground Station");
-		Dimension dlgSize = dlg.getPreferredSize();
-		Dimension frmSize = getSize();
-		Point loc = getLocation();
-		dlg.setLocation((frmSize.width - dlgSize.width) / 2 + loc.x,
-			(frmSize.height - dlgSize.height) / 2 + loc.y);
-		dlg.setModal(true);
-		dlg.setVisible(true);
-	}
-
-	public boolean connectButton_actionPerformed(LrgsConnection c)
-	{
-		final String thost = c.getHostName();
-		if (thost.length() == 0)
-		{
-			showError(labels.getString("RtStatFrame.hostOrIpEmptyErr"));
-			return false;
-		}
-
-		final int p = c.getPort();
-		if (p <= 0)
-		{
-			showError(labels.getString(	"RtStatFrame.portNumErr"));
-
-		}
-		port = p;
-
-		user = c.getUsername();
-		if (user.length() == 0)
-		{
-			showError(labels.getString("RtStatFrame.userEmptyErr"));
-			return false;
-		}
-
-		passwd = LrgsConnection.decryptPassword(c, LrgsConnectionPanel.pwk);
-
-		if (passwd == null || passwd.length() == 0)
-		{
-			showError(labels.getString("RtStatFrame.passAuthErr"));
-			return false;
-		}
-		SwingUtilities.invokeLater(() -> setTitle(labels.getString("RtStatFrame.frameTitle")));
-
-		host = thost;
-		return doConnect(c);
-	}
-
-	private boolean doConnect(LrgsConnection c)
-	{
-		closeConnection();
-		client = null;
-		final LddsClient tclient = new LddsClient(host, port);
-		final JobDialog connectionJobDialog = new JobDialog(
-			this,
-			labels.getString("RtStatFrame.connectingToInfo") + host+":"+port,
-			true);
-		connectionJobDialog.setCanCancel(true);
-		connectionJobDialog.setTitle(
-			LoadResourceBundle.sprintf(labels.getString("RtStatFrame.connectingInfo"),host, port)
-			);
-		Thread backgroundJob =
-			new Thread()
-			{
-				public void run()
-				{
-					pause(1000L);
-
-					while(host != null && !connectionJobDialog.wasCancelled() && connectionJobDialog.isVisible())
-					{
-						connectionJobDialog.addToProgress(LoadResourceBundle.sprintf(
-								labels.getString("RtStatFrame.connectingInfo"),
-								host, port)
-						);
-						try
-						{
-							tclient.connect();
-						}
-						catch(Exception ex)
-						{
-							connectionJobDialog.addToProgress(
-							labels.getString("RtStatFrame.cannotConnectErr")
-							+ ex);
-							tclient.disconnect();
-							pause(5000L);
-							continue;
-						}
-						try
-						{
-							connectionJobDialog.addToProgress(
-								LoadResourceBundle.sprintf(
-									labels.getString("RtStatFrame.authenticatingUserInfo"),
-									user)
-							);
-							tclient.sendAuthHello(user, passwd);
-							connectionJobDialog.addToProgress(labels.getString(
-									"RtStatFrame.connectionSuccessInfo"));
-							pause(2000L);
-							connectionJobDialog.allDone();
-							return;
-						}
-						catch(ServerError ex)
-						{
-							connectionJobDialog.addToProgress(labels.getString(
-									"RtStatFrame.connectionRejectedErr")
-									+ ex);
-							tclient.disconnect();
-						}
-						catch(ProtocolError ex)
-						{
-							connectionJobDialog.addToProgress(
-							labels.getString("RtStatFrame.protocolErr") + ex);
-							tclient.disconnect();
-						}
-						catch(Exception ex)
-						{
-							connectionJobDialog.addToProgress(labels.getString(
-							  "RtStatFrame.authenticationErr") + ex);
-							tclient.disconnect();
-						}
-						// Pause 5 seconds and try again.
-						pause(5000L);
-					}
-				}
-
-
-			};
-		backgroundJob.start();
-		launch(connectionJobDialog);
-		if (tclient.isConnected())
-		{
-			setTitle(labels.getString("RtStatFrame.frameTitle")+": " + host);
-			client = tclient;
-			displayEvent("Connected to " + host + ":" + port + " as user '" + user + "'");
-			return true;
-		}
-		else
-		{
-			return false;
-		}
-	}
-	private static void pause(long millis)
-	{
-		try
-		{
-			Thread.sleep(millis);
-		} catch(InterruptedException ex)
-		{
-			log.error("Error during pause({})",millis,ex);
-		}
-	}
-	private void closeConnection()
-	{
-		if (client != null)
-		{
-			try
-			{
-			  client.sendGoodbye();
-			} catch(Exception ex)
-			{
-				log.error("Error closing connection",ex);
-			}
-			client.disconnect();
-		}
-	}
-
-	/**
-	 * Called from the RtStatFrameThread, this polls the client for status
-	 * and returns the byte buffer.
-	 * It is in this class so it can be synchronized against connect calls.
-	 * @return the server's status, null if not currently connected or paused.
-	 */
-	public synchronized byte[] getStatus()
-	{
-		if (client == null || isPaused)
-		{
-			return null;
-		}
-		try
-		{
-			return client.getStatus();
-		}
-		catch(final Exception ex)
-		{
-			log.error("Error getting status",ex);
-			client.disconnect();
-			client = null;
-			String msg = "An error occurred in client.getStatus(). ";
-			log.error(msg);
-			rtStatPanel.updateStatus("<h1>"+msg+" "+ex.getMessage()+"</h1>");
-			rtStatPanel.invalidate();
-			return null;
-		}
-	}
-
-	public synchronized ArrayList<DdsUser> getUsers()
-		throws AuthException
-	{
-		if (client == null || isPaused)
-		{
-			throw new AuthException(labels.getString("RtStatFrame.listUsersErr"));
-		}
-		return client.getUsers();
-	}
-
-	public synchronized void modUser(DdsUser ddsUser, String pw)
-		throws AuthException
-	{
-		if (client == null || isPaused)
-		{
-			throw new AuthException(labels.getString("RtStatFrame.listUsersErr"));
-		}
-		client.modUser(ddsUser, pw);
-	}
-
-	public void rmUser(String userName)
-		throws AuthException
-	{
-		if (client == null || isPaused)
-		{
-			throw new AuthException(labels.getString("RtStatFrame.listUsersErr"));
-		}
-		client.rmUser(userName);
-	}
-
-	/**
-	 * Called from the RtStatFrameThread, this polls the client for events
-	 * and returns the array.
-	 * It is in this class so it can be synchronized against connect calls.
-	 * @return the server's events, null if not currently connected or paused.
-	 */
-	public synchronized String[] getEvents()
-	{
-		if (client == null || isPaused)
-		{
-			return null;
-		}
-		try
-		{
-			return client.getEvents();
-		}
-		catch(final Exception ex)
-		{
-			client.disconnect();
-			client = null;
-			SwingUtilities.invokeLater(
-				new Runnable()
-				{
-					public void run()
-					{
-						doConnect(null);
-					}
-				});
-			return null;
-		}
-	}
-
-	/**
-	 * Sends the new LrgsConfiguration to the server.
-	 */
-	public synchronized void applyLrgsConfig(LrgsConfig lrgsConfig)
-		throws AuthException
-	{
-		// Convert lrgsConfig to properties-set byte array.
-		Properties props = new Properties();
-		PropertiesUtil.storeInProps(lrgsConfig, props, null);
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		try{
-			props.store(baos, "LRGS Configuration Modified on "+new Date());
-		}
-		catch(IOException ex)
-		{
-			throw new AuthException(labels.getString("RtStatFrame.constructConfigArrayErr" +ex));
-		}
-		byte cfgData[] = baos.toByteArray();
-		client.installConfig("lrgs", cfgData);
-	}
-
-	/**
-	 * Sends the new DdsRecvSettings to the server.
-	 */
-	public synchronized void applyDdsRecvSettings(DdsRecvSettings settings)
-		throws AuthException
-	{
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		try
-		{
-			settings.storeToXml(baos);
-		}
-		catch(IOException ex)
-		{
-			throw new AuthException(
-				labels.getString("RtStatFrame.constructddsConfigArrayErr") + ex.getLocalizedMessage(),
-				ex
-			);
-		}
-		byte cfgData[] = baos.toByteArray();
-		client.installConfig("ddsrecv", cfgData);
-	}
-
-	/**
-	 * Sends the new DrgsInputSettings to the server.
-	 */
-	public synchronized void applyDrgsInputSettings(DrgsInputSettings settings)
-		throws AuthException
-	{
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		try
-		{
-			settings.storeToXml(baos);
-		}
-		catch(IOException ex)
-		{
-			throw new AuthException(
-				labels.getString("RtStatFrame.constructdrgsConfigArrayErr")	+ ex.getLocalizedMessage(),
-				ex);
-		}
-		byte cfgData[] = baos.toByteArray();
-		client.installConfig("drgs", cfgData);
-	}
-
-	public void applyNetworkDcpSettings(DrgsInputSettings settings)
-		throws AuthException
-	{
-		// There was no networkDCP config prior to version 10.
-		if (client.getServerProtoVersion() < 10)
-		{
-			return;
-		}
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		try
-		{
-			settings.storeToXml(baos);
-		}
-		catch(IOException ex)
-		{
-			throw new AuthException(
-				labels.getString("RtStatFrame.constructdrgsConfigArrayErr")	+ ex.getLocalizedMessage(),
-				ex);
-		}
-		byte cfgData[] = baos.toByteArray();
-		client.installConfig("networkDcp", cfgData);
-	}
-
-	/**
-	 * Retrieve the 3 configurations from the server and store them locally.
-	 */
-	public synchronized void getConfigurations()
-		throws AuthException
-	{
-		lrgsConfig = new LrgsConfig();
-		ddsSettings =  DdsRecvSettings.instance();
-		drgsSettings = new DrgsInputSettings();
-		networkDcpSettings = new DrgsInputSettings();
-		networkDcpSettings.savePollingPeriod = true;
-
-		try
-		{
-			byte[] cfgData = client.getConfig("lrgs");
-			ByteArrayInputStream bais = new ByteArrayInputStream(cfgData);
-			Properties props = new Properties();
-			props.load(bais);
-			PropertiesUtil.loadFromProps(lrgsConfig, props);
-		}
-		catch(Exception ex)
-		{
-			String msg = LoadResourceBundle.sprintf(
-				labels.getString("RtStatFrame.cannotReadLrgsConfErr"),
-				host) + ex;
-			showError(msg);
-			throw new AuthException(msg);
-		}
-
-		try
-		{
-			byte[] cfgData = client.getConfig("ddsrecv");
-			ByteArrayInputStream bais = new ByteArrayInputStream(cfgData);
-			Document doc = DomHelper.readStream("rtstat", bais);
-			ddsSettings.readNetworkLists = false;
-			ddsSettings.setFromDoc(doc, "remote");
-		}
-		catch(Exception ex)
-		{
-			String msg = LoadResourceBundle.sprintf(
-					labels.getString("RtStatFrame.cannotReadDdsConfErr"),
-					host, ex);
-			showError(msg);
-		}
-
-		try
-		{
-			byte[] cfgData = client.getConfig("drgs");
-			ByteArrayInputStream bais = new ByteArrayInputStream(cfgData);
-			Document doc = DomHelper.readStream("rtstat", bais);
-			drgsSettings.setFromDoc(doc, "remote");
-		}
-		catch(Exception ex)
-		{
-			String msg = LoadResourceBundle.sprintf(
-					labels.getString("RtStatFrame.cannotReadDrgsConfErr"),
-					host, ex);
-			showError(msg);
-		}
-
-		try
-		{
-			byte[] cfgData = client.getConfig("networkDcp");
-			ByteArrayInputStream bais = new ByteArrayInputStream(cfgData);
-			Document doc = DomHelper.readStream("rtstat", bais);
-			networkDcpSettings.setFromDoc(doc, "remote");
-		}
-		catch(Exception ex)
-		{
-			String msg = LoadResourceBundle.sprintf(
-					labels.getString("RtStatFrame.cannotReadNetworkDcpConfErr"),
-					host, ex);
-			Logger.instance().warning(msg);
-		}
-	}
-
-
-
-	/**
-	 * @return a list of network lists that exist on the server.
-	 */
-	public synchronized String[] getNetlistList()
-		throws AuthException
-	{
-		try
-		{
-			byte data[] = client.getConfig("netlist-list");
-			StringTokenizer st = new StringTokenizer(new String(data));
-			String ret[] = new String[st.countTokens()];
-			for(int i=0; st.hasMoreTokens(); i++)
-				ret[i] = st.nextToken();
-			return ret;
-		}
-		catch(Exception ex)
-		{
-			String msg = LoadResourceBundle.sprintf(
-				labels.getString("RtStatFrame.cannotGetNlListErr"),
-				host) + ex;
-			showError(msg);
-			throw new AuthException(msg);
-		}
-	}
-	/** from DdsClientIf interface */
-	public String getServerHost()
-	{
-		if (client == null) return "none";
-		return client.getHost();
-	}
-
-	/**
-	 * @return the data in a particular network list.
-	 */
-	public synchronized byte[] getNetlist(String listname)
-		throws AuthException
-	{
-		try
-		{
-			return client.getConfig("netlist:" + listname);
-		}
-		catch(Exception ex)
-		{
-			String msg = LoadResourceBundle.sprintf(
-					labels.getString("RtStatFrame.cannotGetNlErr"),
-					host) + ex;
-			showError(msg);
-			throw new AuthException(msg);
-		}
-	}
-
-	/**
-	 * Install a network list on the server.
-	 */
-	public synchronized void installNetlist(String listname, byte[] data)
-		throws AuthException
-	{
-		client.installConfig("netlist:" + listname, data);
-	}
-
-	/**
-	 * Delte a network list from the server.
-	 */
-	public synchronized void deleteNetlist(String listname)
-		throws AuthException
-	{
-		client.installConfig("netlist-delete:" + listname, null);
-	}
-
-	/**
-	 * @return list of outages from the server.
-	 */
-	public ArrayList<Outage> getOutages()
-		throws AuthException
-	{
-		try
-		{
-			return client.getOutages(null, null);
-		}
-		catch(Exception ex)
-		{
-			throw new AuthException(labels.getString(
-					"RtStatFrame.cannotReadOutagesErr") + ex);
-		}
-	}
-
-	/**
-	 * Assert (or reassert) outages.
-	 * @param outages the outages
-	 */
-	public void assertOutages(ArrayList<Outage> outages)
-		throws AuthException
-	{
-		try
-		{
-			byte data[] = client.getOutageXmlParser().outages2xml(outages);
-			LddsMessage msg = new LddsMessage(LddsMessage.IdAssertOutages, "");
-			msg.MsgData = data;
-			msg.MsgLength = data.length;
-			LddsMessage resp = client.serverExec(msg);
-		}
-		catch(Exception ex)
-		{
-			throw new AuthException(
-				labels.getString("RtStatFrame.assertOutagesErr") + ex.getLocalizedMessage(),
-				ex);
-		}
-	}
-
-	private void pauseButton_actionPerformed(boolean paused)
-	{
-		this.isPaused = paused;
-	}
-
-	/**
-	* Shows an error message in a modal dialog and prints it to stderr.
-	* This is a convenience method.
-	* @param msg the message
-	*/
-	public void showError( String msg )
-	{
-		System.err.println(msg);
-		JOptionPane.showMessageDialog(this,
-			AsciiUtil.wrapString(msg, 60), "Error!", JOptionPane.ERROR_MESSAGE);
-	}
-
-	/**
-	 * Called from within the GUI thread after a new status XML block has been
-	 * received and parsed. The passed string is the formatted HTML to be
-	 * displayed in the window.
-	 * @param htmlstat the status as a block of HTML.
-	 */
-	public void updateStatus(String htmlstat, String networkDcpStatus)
-	{
-		rtStatPanel.updateStatus(htmlstat);
-		NetworkDcpStatusFrame ndsf = networkDcpStatusFrame;
-		if (ndsf != null)
-			ndsf.updateStatus(networkDcpStatus);
-	}
-	public void updateNetworkDcpStatus(String nds)
-	{
-
-	}
-	/** Called from within the GUI thread to display an event. */
-	public void displayEvent(String event)
-	{
-		eventsPanel.addLine(event);
-	}
-
-	/**
-	  Sets the host name programmatically.
-	  Must be called from within the GUI thread.
-	*/
-	public void setHost(String hostname)
-	{
-		int n = hostCombo.getItemCount();
-		for(int i=0; i<n; i++)
-		{
-			LrgsConnection c = (LrgsConnection)hostCombo.getItemAt(i);
-			if (hostname.equalsIgnoreCase(c.getHostName()))
-			{
-				hostCombo.setSelectedIndex(i);
-				return;
-			}
-		}
-		hostCombo.addItem(new LrgsConnection(hostname, 16003, null, null, null));
-		hostCombo.setSelectedIndex(n);
-	}
-
-	public void fileSetPasswordMenuItem_actionPerformed()
-	{
-		if (client == null)
-		{
-			showError("Connect to server before attempting to change password.");
-			return;
-		}
-		if (!client.isAuthenticated())
-		{
-			showError("You must login with the old password before you can change the password.");
-			return;
-		}
-
-		LoginDialog ld = new LoginDialog(this,
-				labels.getString("RtStatFrame.modifyPassTitle"), true);
-		ld.setEditableUsername(false, user);
-		launch(ld);
-		if (ld.isOK())
-		{
-			char pw[] = ld.getPassword();
-			try
-			{
-				DdsUser du = new DdsUser(user);
-				modUser(du, new String(pw));
-			}
-			catch(Exception ex)
-			{
-				String msg = labels.getString("RtStatFrame.changePassErr")+ex;
-				JOptionPane.showMessageDialog(this,
-					AsciiUtil.wrapString(msg, 60), "Error!",
-					JOptionPane.ERROR_MESSAGE);
-			}
-		}
-	}
-
-	public void fileUserAdmin_actionPerformed()
-	{
-		if (client == null || !client.isConnected())
-		{
-			showError("Not connected.");
-			return;
-		}
-
-		if (!client.isAuthenticated())
-		{
-			showError(labels.getString(
-				"RtStatFrame.loginAsAdminErr"));
-			return;
-		}
-
-		if (userListDialog == null)
-		{
-			userListDialog = new UserListDialog(this,
-				LoadResourceBundle.sprintf(
-				labels.getString("RtStatFrame.ddsUserTitle"),host), true);
-			userListDialog.setDdsClientIf(this);
-		}
-		userListDialog.setHost(host);
-
-		// Retrieve user list from server.
-		try
-		{
-			ArrayList<DdsUser> userList = getUsers();
-
-			// Non-administrators can see, and modify certain fields, in their own
-			// user record. Jump directly to UserEditDialog with isAdmin=false.
-			if (userList.size() == 1
-			 && TextUtil.strEqual(client.getUserName(), userList.get(0).userName)
-			 && !userList.get(0).isAdmin())
-			{
-				EditUserDialog editUserDialog = new EditUserDialog(null,
-					labels.getString("UserListDialog.modUserDataTitle"), true, false);
-
-				editUserDialog.set(host, userList.get(0), false);
-				boolean done = false;
-				int tries=0;
-				while(!done && tries++ < 5)
-				{
-					launch(editUserDialog);
-					if (editUserDialog.okPressed())
-					{
-						try
-						{
-							client.modUser(userList.get(0), editUserDialog.getPassword());
-							done = true;
-						}
-						catch(AuthException ex)
-						{
-							JOptionPane.showMessageDialog(this,
-			            		AsciiUtil.wrapString(ex.toString(),60),
-								"Error!", JOptionPane.ERROR_MESSAGE);
-							done = false;
-						}
-					}
-					else
-					{
-						done = true;
-					}
-				}
-			}
-			else
-			{
-				userListDialog.setUsers(userList);
-				launch(userListDialog);
-			}
-		}
-		catch(AuthException ex)
-		{
-			showError(labels.getString("RtStatFrame.noPermissionOnServerErr")
-					+ ex.toString());
-		}
-	}
-
-	private void launch(JDialog dlg)
-	{
-
-		if (SwingUtilities.isEventDispatchThread())
-		{
-			real_launch(dlg);
-		}
-		else
-		{
-			try
-			{
-				SwingUtilities.invokeAndWait(() -> real_launch(dlg));
-			}
-			catch (InvocationTargetException | InterruptedException ex)
-			{
-				log.atError()
-				   .setCause(ex)
-				   .log("Error waiting for dialog to return.");
-			}
-		}
-	}
-
-	private void real_launch(JDialog dlg)
-	{
-		Dimension frameSize = this.getSize();
-		Point frameLoc = this.getLocation();
-		Dimension dlgSize = dlg.getPreferredSize();
-		int xo = (frameSize.width - dlgSize.width) / 2;
-		if (xo < 0)
-		{
-			xo = 0;
-		}
-		int yo = (frameSize.height - dlgSize.height) / 2;
-		if (yo < 0)
-	 	{
-			yo = 0;
-		}
-		dlg.setLocation(frameLoc.x + xo, frameLoc.y + yo);
-		dlg.setVisible(true);
-	}
-
-	public void fileLrgsConfig_actionPerformed()
-	{
-		if (client == null)
-		{
-			showError("Not connected.");
-			return;
-		}
-
-		if (!client.isAuthenticated())
-		{
-			showError(labels.getString(
-				"RtStatFrame.loginAsAdminErr"));
-			return;
-		}
-
-		if (lrgsConfigDialog == null)
-		{
-			lrgsConfigDialog = new LrgsConfigDialog(this,
-				labels.getString(
-				"RtStatFrame.lrgsConfigTitle") + connectedHostName);
-		}
-		else
-		{
-			lrgsConfigDialog.setTitle(labels.getString(
-				"RtStatFrame.lrgsConfigTitle") + connectedHostName);
-		}
-		lrgsConfigDialog.setDdsClientIf(this);
-		lrgsConfigDialog.clear();
-		try
-		{
-			getConfigurations();
-		}
-		catch(AuthException ex)
-		{
-			return;
-		}
-		lrgsConfigDialog.setConfig(lrgsConfig, ddsSettings, drgsSettings,
-			networkDcpSettings);
-		launch(lrgsConfigDialog);
-	}
-
-	private void fileNetworkLists_actionPerformed()
-	{
-		if (client == null || !client.isAuthenticated())
-		{
-			showError(labels.getString(
-				"RtStatFrame.loginAsAdminErr"));
-			return;
-		}
-
-		try
-		{
-			if (netlistDlg == null)
-			{
-				netlistDlg = new NetlistMaintenanceDialog(this);
-			}
-			else if (netlistDlg.isVisible())
-			{
-				netlistDlg.toFront();
-				return;
-			}
-			String nll[] = getNetlistList();
-			netlistDlg.startDialog(this, nll);
-			launch(netlistDlg);
-		}
-		catch(AuthException ex)
-		{
-			showError(labels.getString("RtStatFrame.noPermissionOnServerErr")
-					+ ex.toString());
-		}
-	}
-
-	public void hyperlinkUpdate(HyperlinkEvent hevt)
-	{
-		if (hevt != null)
-		{
-			if (hevt.getEventType() == HyperlinkEvent.EventType.ACTIVATED)
-			{
-				URL url = hevt.getURL();
-				String f = url.getFile();
-				if (f == null)
-				{
-					return;
-				}
-				if (f.contains("showNetworkDcps"))
-				{
-					showNetworkDcps();
-				}
-			}
-		}
-	}
-
-	private void showNetworkDcps()
-	{
-		if (networkDcpStatusFrame == null)
-		{
-			networkDcpStatusFrame = new NetworkDcpStatusFrame(this);
-			networkDcpStatusFrame.setVisible(true);
-		}
-		else
-		{
-			networkDcpStatusFrame.toFront();
-		}
-	}
-
-	public void networkDcpStatusFrameClosed()
-	{
-		networkDcpStatusFrame = null;
-	}
+    private final static org.slf4j.Logger log = LoggerFactory.getLogger(RtStatFrame.class);
+    private static ResourceBundle labels =
+        RtStat.getLabels();
+    private static ResourceBundle genericLabels =
+        RtStat.getGenericLabels();
+    private JPanel contentPane;
+    private JMenuBar jMenuBar1 = new JMenuBar();
+    private JMenu jMenuFile = new JMenu();
+    private JMenuItem fileSetPasswordMenuItem = new JMenuItem();
+    private JMenuItem fileUserAdmin = new JMenuItem();
+    private JMenuItem fileLrgsConfig = new JMenuItem();
+    private JMenuItem jMenuFileExit = new JMenuItem();
+    private JMenuItem fileNetworkLists = new JMenuItem();
+    private JMenu jMenuHelp = new JMenu();
+    private JMenuItem jMenuHelpAbout = new JMenuItem();
+    private BorderLayout borderLayout1 = new BorderLayout();
+    private JPanel topPanel = new JPanel();
+    private JLabel hostLabel = new JLabel();
+    private JComboBox<LrgsConnection> hostCombo = new JComboBox<>();
+    private PasswordWithShow passwordField = new PasswordWithShow(GuiConstants.DEFAULT_PASSWORD_WITH);
+    private JSplitPane jSplitPane1 = new JSplitPane();
+    private RtStatPanel rtStatPanel = new RtStatPanel();
+    private EventsPanel eventsPanel = new EventsPanel(false);
+    private JCheckBox passwordCheck = new JCheckBox();
+    private LrgsConnectionPanel connectionPanel = new LrgsConnectionPanel();
+
+    /** True if the display is currently paused. */
+    boolean isPaused = false;
+
+    /** The object used to communicate with the server. */
+    private LddsClient client;
+
+    /** The background polling thread. */
+    RtStatFrameThread myThread;
+
+    /** The currently selected host name. */
+    private String connectedHostName = "";
+
+    private int dividerLoc;
+    private int splitPaneHeight;
+
+    /** the currently connected host -- null if not connected. */
+    String host;
+    int port;
+    String user;
+    String passwd;
+
+    /** Dialog for editing users. */
+    private UserListDialog userListDialog = null;
+
+    private LrgsConfigDialog lrgsConfigDialog = null;
+    private LrgsConfig lrgsConfig;  //  @jve:decl-index=0:
+    private DdsRecvSettings ddsSettings;  //  @jve:decl-index=0:
+    private DrgsInputSettings drgsSettings;
+    private NetlistMaintenanceDialog netlistDlg;
+    private DrgsInputSettings networkDcpSettings;
+    private NetworkDcpStatusFrame networkDcpStatusFrame = null;
+
+    /** Constructor. */
+    public RtStatFrame(int scanPeriod, String iconFile, String headerFile)
+    {
+        exitOnClose = true;
+        try
+        {
+            jbInit();
+        }
+        catch (Exception e)
+        {
+            log.error("RtStatFrame: ",e);
+        }
+        isPaused = false;
+        client = null;
+        passwordCheck.setSelected(false);
+        passwordField.setEnabled(false);
+        myThread = new RtStatFrameThread(this, scanPeriod,iconFile,headerFile);
+        myThread.start();
+        Dimension d = java.awt.Toolkit.getDefaultToolkit().getScreenSize();
+        d.width = 800;
+        d.height -= 60;
+        setSize(d);
+        dividerLoc = d.height - 80 - 160;
+        splitPaneHeight = 0;
+        jSplitPane1.setDividerLocation(dividerLoc);
+        jSplitPane1.addComponentListener(
+            new ComponentAdapter()
+            {
+                public void componentResized(ComponentEvent e)
+                {
+                    if (splitPaneHeight == 0)
+                    {
+                        splitPaneHeight = jSplitPane1.getHeight();
+                        return;
+                    }
+                    int newHeight = jSplitPane1.getHeight();
+                    int newLoc = newHeight - (splitPaneHeight - dividerLoc);
+                    jSplitPane1.setDividerLocation(newLoc);
+                    splitPaneHeight = newHeight;
+                    dividerLoc = newLoc;
+                }
+            });
+        eventsPanel.addAncestorListener(
+            new AncestorListener()
+            {
+                public void ancestorAdded(AncestorEvent ev) {}
+                public void ancestorRemoved(AncestorEvent ev) {}
+                public void ancestorMoved(AncestorEvent ev)
+                {
+                    dividerLoc = jSplitPane1.getDividerLocation();
+                }
+            });
+
+        //loadConnectionsField(hostCombo, connectionList, connectedHostName);
+        netlistDlg = null;
+        rtStatPanel.htmlPanel.addHyperlinkListener(this);
+
+        setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        final RtStatFrame myframe = this;
+        addWindowListener(
+            new WindowAdapter()
+            {
+                public void windowClosed(WindowEvent e)
+                {
+                    if (myframe.getExitOnClose())
+                        System.exit(0);
+                }
+            });
+        trackChanges("RtStat");
+    }
+
+    /** Initializes GUI components. */
+    private void jbInit()
+        throws Exception
+    {
+        boolean canConfig = true;
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        try { cl.loadClass("lrgs.ddsrecv.DdsRecvConnectCfg"); }
+        catch(ClassNotFoundException ex) { canConfig = false; }
+
+
+
+        contentPane = (JPanel)this.getContentPane();
+        contentPane.setLayout(borderLayout1);
+        this.setSize(new Dimension(793, 716));
+        this.setTitle(
+                labels.getString("RtStatFrame.frameTitle"));
+        jMenuFile.setText(genericLabels.getString("file"));
+        jMenuFileExit.setText(genericLabels.getString("exit"));
+        jMenuFileExit.addActionListener(
+            new java.awt.event.ActionListener()
+            {
+                public void actionPerformed(ActionEvent e)
+                {
+                    jMenuFileExit_actionPerformed(e);
+                }
+            });
+        fileSetPasswordMenuItem.setText(
+                labels.getString("RtStatFrame.setPassword"));
+        fileSetPasswordMenuItem.addActionListener(
+            new java.awt.event.ActionListener()
+            {
+                public void actionPerformed(ActionEvent e)
+                {
+                    fileSetPasswordMenuItem_actionPerformed();
+                }
+            });
+        fileUserAdmin.setText(
+            labels.getString("RtStatFrame.userAdministration"));
+        fileUserAdmin.addActionListener(
+            new java.awt.event.ActionListener()
+            {
+                public void actionPerformed(ActionEvent e)
+                {
+                    fileUserAdmin_actionPerformed();
+                }
+            });
+
+
+        if (canConfig)
+        {
+            fileLrgsConfig.setText(
+                    labels.getString("RtStatFrame.LRGSConfiguration"));
+            fileLrgsConfig.addActionListener(
+                new java.awt.event.ActionListener()
+                {
+                    public void actionPerformed(ActionEvent e)
+                    {
+                        fileLrgsConfig_actionPerformed();
+                    }
+                });
+
+            fileNetworkLists.setText(
+                    labels.getString("RtStatFrame.networkLists"));
+            fileNetworkLists.addActionListener(
+                new java.awt.event.ActionListener()
+                {
+                    public void actionPerformed(ActionEvent e)
+                    {
+                        fileNetworkLists_actionPerformed();
+                    }
+                });
+        }
+
+        jMenuHelp.setText(
+                genericLabels.getString("help"));
+        jMenuHelpAbout.setText(
+                genericLabels.getString("about"));
+        jMenuHelpAbout.addActionListener(
+            new java.awt.event.ActionListener()
+            {
+                public void actionPerformed(ActionEvent e)
+                {
+                    jMenuHelpAbout_actionPerformed(e);
+                }
+            });
+
+        hostLabel.setText(
+                labels.getString("RtStatFrame.host"));
+        topPanel.setLayout(new BorderLayout());
+
+        connectionPanel.onPause(c -> pauseButton_actionPerformed(c));
+
+        jSplitPane1.setOrientation(JSplitPane.VERTICAL_SPLIT);
+        eventsPanel.setMaximumSize(new Dimension(32767, 150));
+        eventsPanel.setMinimumSize(new Dimension(10, 120));
+        eventsPanel.setPreferredSize(new Dimension(10, 120));
+        jMenuFile.add(fileSetPasswordMenuItem);
+        jMenuFile.add(fileUserAdmin);
+        if (canConfig)
+        {
+            jMenuFile.add(fileLrgsConfig);
+            jMenuFile.add(fileNetworkLists);
+        }
+        jMenuFile.addSeparator();
+        jMenuFile.add(jMenuFileExit);
+        jMenuHelp.add(jMenuHelpAbout);
+        jMenuBar1.add(jMenuFile);
+        jMenuBar1.add(jMenuHelp);
+        contentPane.add(topPanel, BorderLayout.NORTH);
+        topPanel.add(connectionPanel);
+        connectionPanel.onConnect(c -> connectButton_actionPerformed(c));
+        contentPane.add(jSplitPane1, BorderLayout.CENTER);
+        jSplitPane1.add(rtStatPanel, JSplitPane.TOP);
+        jSplitPane1.add(eventsPanel, JSplitPane.BOTTOM);
+        this.setJMenuBar(jMenuBar1);
+    }
+
+    //File | Exit action performed
+    private void jMenuFileExit_actionPerformed(ActionEvent e)
+    {
+        dispose();
+        if (exitOnClose)
+        {
+            System.exit(0);
+        }
+    }
+
+    //Help | About action performed
+    private void jMenuHelpAbout_actionPerformed(ActionEvent e)
+    {
+        AboutBox dlg = new AboutBox(this, "LRGS", "Local Readout Ground Station");
+        Dimension dlgSize = dlg.getPreferredSize();
+        Dimension frmSize = getSize();
+        Point loc = getLocation();
+        dlg.setLocation((frmSize.width - dlgSize.width) / 2 + loc.x,
+            (frmSize.height - dlgSize.height) / 2 + loc.y);
+        dlg.setModal(true);
+        dlg.setVisible(true);
+    }
+
+    public boolean connectButton_actionPerformed(LrgsConnection c)
+    {
+        final String thost = c.getHostName();
+        if (thost.length() == 0)
+        {
+            showError(labels.getString("RtStatFrame.hostOrIpEmptyErr"));
+            return false;
+        }
+
+        final int p = c.getPort();
+        if (p <= 0)
+        {
+            showError(labels.getString(    "RtStatFrame.portNumErr"));
+
+        }
+        port = p;
+
+        user = c.getUsername();
+        if (user.length() == 0)
+        {
+            showError(labels.getString("RtStatFrame.userEmptyErr"));
+            return false;
+        }
+
+        passwd = LrgsConnection.decryptPassword(c, LrgsConnectionPanel.pwk);
+
+        if (passwd == null || passwd.length() == 0)
+        {
+            showError(labels.getString("RtStatFrame.passAuthErr"));
+            return false;
+        }
+        SwingUtilities.invokeLater(() -> setTitle(labels.getString("RtStatFrame.frameTitle")));
+
+        host = thost;
+        return doConnect(c);
+    }
+
+    private boolean doConnect(LrgsConnection c)
+    {
+        closeConnection();
+        client = null;
+        final LddsClient tclient = new LddsClient(host, port);
+        final JobDialog connectionJobDialog = new JobDialog(
+            this,
+            labels.getString("RtStatFrame.connectingToInfo") + host+":"+port,
+            true);
+        connectionJobDialog.setCanCancel(true);
+        connectionJobDialog.setTitle(
+            LoadResourceBundle.sprintf(labels.getString("RtStatFrame.connectingInfo"),host, port)
+            );
+        Thread backgroundJob =
+            new Thread()
+            {
+                public void run()
+                {
+                    pause(1000L);
+
+                    while(host != null && !connectionJobDialog.wasCancelled() && connectionJobDialog.isVisible())
+                    {
+                        connectionJobDialog.addToProgress(LoadResourceBundle.sprintf(
+                                labels.getString("RtStatFrame.connectingInfo"),
+                                host, port)
+                        );
+                        try
+                        {
+                            tclient.connect();
+                        }
+                        catch(Exception ex)
+                        {
+                            connectionJobDialog.addToProgress(
+                            labels.getString("RtStatFrame.cannotConnectErr")
+                            + ex);
+                            tclient.disconnect();
+                            pause(5000L);
+                            continue;
+                        }
+                        try
+                        {
+                            connectionJobDialog.addToProgress(
+                                LoadResourceBundle.sprintf(
+                                    labels.getString("RtStatFrame.authenticatingUserInfo"),
+                                    user)
+                            );
+                            tclient.sendAuthHello(user, passwd);
+                            connectionJobDialog.addToProgress(labels.getString(
+                                    "RtStatFrame.connectionSuccessInfo"));
+                            pause(2000L);
+                            connectionJobDialog.allDone();
+                            return;
+                        }
+                        catch(ServerError ex)
+                        {
+                            connectionJobDialog.addToProgress(labels.getString(
+                                    "RtStatFrame.connectionRejectedErr")
+                                    + ex);
+                            tclient.disconnect();
+                        }
+                        catch(ProtocolError ex)
+                        {
+                            connectionJobDialog.addToProgress(
+                            labels.getString("RtStatFrame.protocolErr") + ex);
+                            tclient.disconnect();
+                        }
+                        catch(Exception ex)
+                        {
+                            connectionJobDialog.addToProgress(labels.getString(
+                              "RtStatFrame.authenticationErr") + ex);
+                            tclient.disconnect();
+                        }
+                        // Pause 5 seconds and try again.
+                        pause(5000L);
+                    }
+                }
+
+
+            };
+        backgroundJob.start();
+        launch(connectionJobDialog);
+        if (tclient.isConnected())
+        {
+            setTitle(labels.getString("RtStatFrame.frameTitle")+": " + host);
+            client = tclient;
+            displayEvent("Connected to " + host + ":" + port + " as user '" + user + "'");
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    private static void pause(long millis)
+    {
+        try
+        {
+            Thread.sleep(millis);
+        } catch(InterruptedException ex)
+        {
+            log.error("Error during pause({})",millis,ex);
+        }
+    }
+    private void closeConnection()
+    {
+        if (client != null)
+        {
+            try
+            {
+              client.sendGoodbye();
+            } catch(Exception ex)
+            {
+                log.error("Error closing connection",ex);
+            }
+            client.disconnect();
+        }
+    }
+
+    /**
+     * Called from the RtStatFrameThread, this polls the client for status
+     * and returns the byte buffer.
+     * It is in this class so it can be synchronized against connect calls.
+     * @return the server's status, null if not currently connected or paused.
+     */
+    public synchronized byte[] getStatus()
+    {
+        if (client == null || isPaused)
+        {
+            return null;
+        }
+        try
+        {
+            return client.getStatus();
+        }
+        catch(final Exception ex)
+        {
+            log.error("Error getting status",ex);
+            client.disconnect();
+            client = null;
+            String msg = "An error occurred in client.getStatus(). ";
+            log.error(msg);
+            rtStatPanel.updateStatus("<h1>"+msg+" "+ex.getMessage()+"</h1>");
+            rtStatPanel.invalidate();
+            return null;
+        }
+    }
+
+    public synchronized ArrayList<DdsUser> getUsers()
+        throws AuthException
+    {
+        if (client == null || isPaused)
+        {
+            throw new AuthException(labels.getString("RtStatFrame.listUsersErr"));
+        }
+        return client.getUsers();
+    }
+
+    public synchronized void modUser(DdsUser ddsUser, String pw)
+        throws AuthException
+    {
+        if (client == null || isPaused)
+        {
+            throw new AuthException(labels.getString("RtStatFrame.listUsersErr"));
+        }
+        client.modUser(ddsUser, pw);
+    }
+
+    public void rmUser(String userName)
+        throws AuthException
+    {
+        if (client == null || isPaused)
+        {
+            throw new AuthException(labels.getString("RtStatFrame.listUsersErr"));
+        }
+        client.rmUser(userName);
+    }
+
+    /**
+     * Called from the RtStatFrameThread, this polls the client for events
+     * and returns the array.
+     * It is in this class so it can be synchronized against connect calls.
+     * @return the server's events, null if not currently connected or paused.
+     */
+    public synchronized String[] getEvents()
+    {
+        if (client == null || isPaused)
+        {
+            return null;
+        }
+        try
+        {
+            return client.getEvents();
+        }
+        catch(final Exception ex)
+        {
+            client.disconnect();
+            client = null;
+            SwingUtilities.invokeLater(
+                new Runnable()
+                {
+                    public void run()
+                    {
+                        doConnect(null);
+                    }
+                });
+            return null;
+        }
+    }
+
+    /**
+     * Sends the new LrgsConfiguration to the server.
+     */
+    public synchronized void applyLrgsConfig(LrgsConfig lrgsConfig)
+        throws AuthException
+    {
+        // Convert lrgsConfig to properties-set byte array.
+        Properties props = new Properties();
+        PropertiesUtil.storeInProps(lrgsConfig, props, null);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try{
+            props.store(baos, "LRGS Configuration Modified on "+new Date());
+        }
+        catch(IOException ex)
+        {
+            throw new AuthException(labels.getString("RtStatFrame.constructConfigArrayErr" +ex));
+        }
+        byte cfgData[] = baos.toByteArray();
+        client.installConfig("lrgs", cfgData);
+    }
+
+    /**
+     * Sends the new DdsRecvSettings to the server.
+     */
+    public synchronized void applyDdsRecvSettings(DdsRecvSettings settings)
+        throws AuthException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try
+        {
+            settings.storeToXml(baos);
+        }
+        catch(IOException ex)
+        {
+            throw new AuthException(
+                labels.getString("RtStatFrame.constructddsConfigArrayErr") + ex.getLocalizedMessage(),
+                ex
+            );
+        }
+        byte cfgData[] = baos.toByteArray();
+        client.installConfig("ddsrecv", cfgData);
+    }
+
+    /**
+     * Sends the new DrgsInputSettings to the server.
+     */
+    public synchronized void applyDrgsInputSettings(DrgsInputSettings settings)
+        throws AuthException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try
+        {
+            settings.storeToXml(baos);
+        }
+        catch(IOException ex)
+        {
+            throw new AuthException(
+                labels.getString("RtStatFrame.constructdrgsConfigArrayErr")    + ex.getLocalizedMessage(),
+                ex);
+        }
+        byte cfgData[] = baos.toByteArray();
+        client.installConfig("drgs", cfgData);
+    }
+
+    public void applyNetworkDcpSettings(DrgsInputSettings settings)
+        throws AuthException
+    {
+        // There was no networkDCP config prior to version 10.
+        if (client.getServerProtoVersion() < 10)
+        {
+            return;
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try
+        {
+            settings.storeToXml(baos);
+        }
+        catch(IOException ex)
+        {
+            throw new AuthException(
+                labels.getString("RtStatFrame.constructdrgsConfigArrayErr")    + ex.getLocalizedMessage(),
+                ex);
+        }
+        byte cfgData[] = baos.toByteArray();
+        client.installConfig("networkDcp", cfgData);
+    }
+
+    /**
+     * Retrieve the 3 configurations from the server and store them locally.
+     */
+    public synchronized void getConfigurations()
+        throws AuthException
+    {
+        lrgsConfig = new LrgsConfig();
+        ddsSettings =  DdsRecvSettings.instance();
+        drgsSettings = new DrgsInputSettings();
+        networkDcpSettings = new DrgsInputSettings();
+        networkDcpSettings.savePollingPeriod = true;
+
+        try
+        {
+            byte[] cfgData = client.getConfig("lrgs");
+            ByteArrayInputStream bais = new ByteArrayInputStream(cfgData);
+            Properties props = new Properties();
+            props.load(bais);
+            PropertiesUtil.loadFromProps(lrgsConfig, props);
+        }
+        catch(Exception ex)
+        {
+            String msg = LoadResourceBundle.sprintf(
+                labels.getString("RtStatFrame.cannotReadLrgsConfErr"),
+                host) + ex;
+            showError(msg);
+            throw new AuthException(msg);
+        }
+
+        try
+        {
+            byte[] cfgData = client.getConfig("ddsrecv");
+            ByteArrayInputStream bais = new ByteArrayInputStream(cfgData);
+            Document doc = DomHelper.readStream("rtstat", bais);
+            ddsSettings.readNetworkLists = false;
+            ddsSettings.setFromDoc(doc, "remote");
+        }
+        catch(Exception ex)
+        {
+            String msg = LoadResourceBundle.sprintf(
+                    labels.getString("RtStatFrame.cannotReadDdsConfErr"),
+                    host, ex);
+            showError(msg);
+        }
+
+        try
+        {
+            byte[] cfgData = client.getConfig("drgs");
+            ByteArrayInputStream bais = new ByteArrayInputStream(cfgData);
+            Document doc = DomHelper.readStream("rtstat", bais);
+            drgsSettings.setFromDoc(doc, "remote");
+        }
+        catch(Exception ex)
+        {
+            String msg = LoadResourceBundle.sprintf(
+                    labels.getString("RtStatFrame.cannotReadDrgsConfErr"),
+                    host, ex);
+            showError(msg);
+        }
+
+        try
+        {
+            byte[] cfgData = client.getConfig("networkDcp");
+            ByteArrayInputStream bais = new ByteArrayInputStream(cfgData);
+            Document doc = DomHelper.readStream("rtstat", bais);
+            networkDcpSettings.setFromDoc(doc, "remote");
+        }
+        catch(Exception ex)
+        {
+            String msg = LoadResourceBundle.sprintf(
+                    labels.getString("RtStatFrame.cannotReadNetworkDcpConfErr"),
+                    host, ex);
+            Logger.instance().warning(msg);
+        }
+    }
+
+
+
+    /**
+     * @return a list of network lists that exist on the server.
+     */
+    public synchronized String[] getNetlistList()
+        throws AuthException
+    {
+        try
+        {
+            byte data[] = client.getConfig("netlist-list");
+            StringTokenizer st = new StringTokenizer(new String(data));
+            String ret[] = new String[st.countTokens()];
+            for(int i=0; st.hasMoreTokens(); i++)
+                ret[i] = st.nextToken();
+            return ret;
+        }
+        catch(Exception ex)
+        {
+            String msg = LoadResourceBundle.sprintf(
+                labels.getString("RtStatFrame.cannotGetNlListErr"),
+                host) + ex;
+            showError(msg);
+            throw new AuthException(msg);
+        }
+    }
+    /** from DdsClientIf interface */
+    public String getServerHost()
+    {
+        if (client == null) return "none";
+        return client.getHost();
+    }
+
+    /**
+     * @return the data in a particular network list.
+     */
+    public synchronized byte[] getNetlist(String listname)
+        throws AuthException
+    {
+        try
+        {
+            return client.getConfig("netlist:" + listname);
+        }
+        catch(Exception ex)
+        {
+            String msg = LoadResourceBundle.sprintf(
+                    labels.getString("RtStatFrame.cannotGetNlErr"),
+                    host) + ex;
+            showError(msg);
+            throw new AuthException(msg);
+        }
+    }
+
+    /**
+     * Install a network list on the server.
+     */
+    public synchronized void installNetlist(String listname, byte[] data)
+        throws AuthException
+    {
+        client.installConfig("netlist:" + listname, data);
+    }
+
+    /**
+     * Delte a network list from the server.
+     */
+    public synchronized void deleteNetlist(String listname)
+        throws AuthException
+    {
+        client.installConfig("netlist-delete:" + listname, null);
+    }
+
+    /**
+     * @return list of outages from the server.
+     */
+    public ArrayList<Outage> getOutages()
+        throws AuthException
+    {
+        try
+        {
+            return client.getOutages(null, null);
+        }
+        catch(Exception ex)
+        {
+            throw new AuthException(labels.getString(
+                    "RtStatFrame.cannotReadOutagesErr") + ex);
+        }
+    }
+
+    /**
+     * Assert (or reassert) outages.
+     * @param outages the outages
+     */
+    public void assertOutages(ArrayList<Outage> outages)
+        throws AuthException
+    {
+        try
+        {
+            byte data[] = client.getOutageXmlParser().outages2xml(outages);
+            LddsMessage msg = new LddsMessage(LddsMessage.IdAssertOutages, "");
+            msg.MsgData = data;
+            msg.MsgLength = data.length;
+            LddsMessage resp = client.serverExec(msg);
+        }
+        catch(Exception ex)
+        {
+            throw new AuthException(
+                labels.getString("RtStatFrame.assertOutagesErr") + ex.getLocalizedMessage(),
+                ex);
+        }
+    }
+
+    private void pauseButton_actionPerformed(boolean paused)
+    {
+        this.isPaused = paused;
+    }
+
+    /**
+    * Shows an error message in a modal dialog and prints it to stderr.
+    * This is a convenience method.
+    * @param msg the message
+    */
+    public void showError( String msg )
+    {
+        System.err.println(msg);
+        JOptionPane.showMessageDialog(this,
+            AsciiUtil.wrapString(msg, 60), "Error!", JOptionPane.ERROR_MESSAGE);
+    }
+
+    /**
+     * Called from within the GUI thread after a new status XML block has been
+     * received and parsed. The passed string is the formatted HTML to be
+     * displayed in the window.
+     * @param htmlstat the status as a block of HTML.
+     */
+    public void updateStatus(String htmlstat, String networkDcpStatus)
+    {
+        rtStatPanel.updateStatus(htmlstat);
+        NetworkDcpStatusFrame ndsf = networkDcpStatusFrame;
+        if (ndsf != null)
+            ndsf.updateStatus(networkDcpStatus);
+    }
+    public void updateNetworkDcpStatus(String nds)
+    {
+
+    }
+    /** Called from within the GUI thread to display an event. */
+    public void displayEvent(String event)
+    {
+        eventsPanel.addLine(event);
+    }
+
+    /**
+      Sets the host name programmatically.
+      Must be called from within the GUI thread.
+    */
+    public void setHost(String hostname)
+    {
+        int n = hostCombo.getItemCount();
+        for(int i=0; i<n; i++)
+        {
+            LrgsConnection c = (LrgsConnection)hostCombo.getItemAt(i);
+            if (hostname.equalsIgnoreCase(c.getHostName()))
+            {
+                hostCombo.setSelectedIndex(i);
+                return;
+            }
+        }
+        hostCombo.addItem(new LrgsConnection(hostname, 16003, null, null, null));
+        hostCombo.setSelectedIndex(n);
+    }
+
+    public void fileSetPasswordMenuItem_actionPerformed()
+    {
+        if (client == null)
+        {
+            showError("Connect to server before attempting to change password.");
+            return;
+        }
+        if (!client.isAuthenticated())
+        {
+            showError("You must login with the old password before you can change the password.");
+            return;
+        }
+
+        LoginDialog ld = new LoginDialog(this,
+                labels.getString("RtStatFrame.modifyPassTitle"), true);
+        ld.setEditableUsername(false, user);
+        launch(ld);
+        if (ld.isOK())
+        {
+            char pw[] = ld.getPassword();
+            try
+            {
+                DdsUser du = new DdsUser(user);
+                modUser(du, new String(pw));
+            }
+            catch(Exception ex)
+            {
+                String msg = labels.getString("RtStatFrame.changePassErr")+ex;
+                JOptionPane.showMessageDialog(this,
+                    AsciiUtil.wrapString(msg, 60), "Error!",
+                    JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    public void fileUserAdmin_actionPerformed()
+    {
+        if (client == null || !client.isConnected())
+        {
+            showError("Not connected.");
+            return;
+        }
+
+        if (!client.isAuthenticated())
+        {
+            showError(labels.getString(
+                "RtStatFrame.loginAsAdminErr"));
+            return;
+        }
+
+        if (userListDialog == null)
+        {
+            userListDialog = new UserListDialog(this,
+                LoadResourceBundle.sprintf(
+                labels.getString("RtStatFrame.ddsUserTitle"),host), true);
+            userListDialog.setDdsClientIf(this);
+        }
+        userListDialog.setHost(host);
+
+        // Retrieve user list from server.
+        try
+        {
+            ArrayList<DdsUser> userList = getUsers();
+
+            // Non-administrators can see, and modify certain fields, in their own
+            // user record. Jump directly to UserEditDialog with isAdmin=false.
+            if (userList.size() == 1
+             && TextUtil.strEqual(client.getUserName(), userList.get(0).userName)
+             && !userList.get(0).isAdmin())
+            {
+                EditUserDialog editUserDialog = new EditUserDialog(null,
+                    labels.getString("UserListDialog.modUserDataTitle"), true, false);
+
+                editUserDialog.set(host, userList.get(0), false);
+                boolean done = false;
+                int tries=0;
+                while(!done && tries++ < 5)
+                {
+                    launch(editUserDialog);
+                    if (editUserDialog.okPressed())
+                    {
+                        try
+                        {
+                            client.modUser(userList.get(0), editUserDialog.getPassword());
+                            done = true;
+                        }
+                        catch(AuthException ex)
+                        {
+                            JOptionPane.showMessageDialog(this,
+                                AsciiUtil.wrapString(ex.toString(),60),
+                                "Error!", JOptionPane.ERROR_MESSAGE);
+                            done = false;
+                        }
+                    }
+                    else
+                    {
+                        done = true;
+                    }
+                }
+            }
+            else
+            {
+                userListDialog.setUsers(userList);
+                launch(userListDialog);
+            }
+        }
+        catch(AuthException ex)
+        {
+            showError(labels.getString("RtStatFrame.noPermissionOnServerErr")
+                    + ex.toString());
+        }
+    }
+
+    private void launch(JDialog dlg)
+    {
+
+        if (SwingUtilities.isEventDispatchThread())
+        {
+            real_launch(dlg);
+        }
+        else
+        {
+            try
+            {
+                SwingUtilities.invokeAndWait(() -> real_launch(dlg));
+            }
+            catch (InvocationTargetException | InterruptedException ex)
+            {
+                log.atError()
+                   .setCause(ex)
+                   .log("Error waiting for dialog to return.");
+            }
+        }
+    }
+
+    private void real_launch(JDialog dlg)
+    {
+        Dimension frameSize = this.getSize();
+        Point frameLoc = this.getLocation();
+        Dimension dlgSize = dlg.getPreferredSize();
+        int xo = (frameSize.width - dlgSize.width) / 2;
+        if (xo < 0)
+        {
+            xo = 0;
+        }
+        int yo = (frameSize.height - dlgSize.height) / 2;
+        if (yo < 0)
+         {
+            yo = 0;
+        }
+        dlg.setLocation(frameLoc.x + xo, frameLoc.y + yo);
+        dlg.setVisible(true);
+    }
+
+    public void fileLrgsConfig_actionPerformed()
+    {
+        if (client == null)
+        {
+            showError("Not connected.");
+            return;
+        }
+
+        if (!client.isAuthenticated())
+        {
+            showError(labels.getString(
+                "RtStatFrame.loginAsAdminErr"));
+            return;
+        }
+
+        if (lrgsConfigDialog == null)
+        {
+            lrgsConfigDialog = new LrgsConfigDialog(this,
+                labels.getString(
+                "RtStatFrame.lrgsConfigTitle") + connectedHostName);
+        }
+        else
+        {
+            lrgsConfigDialog.setTitle(labels.getString(
+                "RtStatFrame.lrgsConfigTitle") + connectedHostName);
+        }
+        lrgsConfigDialog.setDdsClientIf(this);
+        lrgsConfigDialog.clear();
+        try
+        {
+            getConfigurations();
+        }
+        catch(AuthException ex)
+        {
+            return;
+        }
+        lrgsConfigDialog.setConfig(lrgsConfig, ddsSettings, drgsSettings,
+            networkDcpSettings);
+        launch(lrgsConfigDialog);
+    }
+
+    private void fileNetworkLists_actionPerformed()
+    {
+        if (client == null || !client.isAuthenticated())
+        {
+            showError(labels.getString(
+                "RtStatFrame.loginAsAdminErr"));
+            return;
+        }
+
+        try
+        {
+            if (netlistDlg == null)
+            {
+                netlistDlg = new NetlistMaintenanceDialog(this);
+            }
+            else if (netlistDlg.isVisible())
+            {
+                netlistDlg.toFront();
+                return;
+            }
+            String nll[] = getNetlistList();
+            netlistDlg.startDialog(this, nll);
+            launch(netlistDlg);
+        }
+        catch(AuthException ex)
+        {
+            showError(labels.getString("RtStatFrame.noPermissionOnServerErr")
+                    + ex.toString());
+        }
+    }
+
+    public void hyperlinkUpdate(HyperlinkEvent hevt)
+    {
+        if (hevt != null)
+        {
+            if (hevt.getEventType() == HyperlinkEvent.EventType.ACTIVATED)
+            {
+                URL url = hevt.getURL();
+                String f = url.getFile();
+                if (f == null)
+                {
+                    return;
+                }
+                if (f.contains("showNetworkDcps"))
+                {
+                    showNetworkDcps();
+                }
+            }
+        }
+    }
+
+    private void showNetworkDcps()
+    {
+        if (networkDcpStatusFrame == null)
+        {
+            networkDcpStatusFrame = new NetworkDcpStatusFrame(this);
+            networkDcpStatusFrame.setVisible(true);
+        }
+        else
+        {
+            networkDcpStatusFrame.toFront();
+        }
+    }
+
+    public void networkDcpStatusFrameClosed()
+    {
+        networkDcpStatusFrame = null;
+    }
 }

--- a/src/main/java/lrgs/rtstat/RtStatFrame.java
+++ b/src/main/java/lrgs/rtstat/RtStatFrame.java
@@ -76,7 +76,7 @@ public class RtStatFrame
 	private BorderLayout borderLayout1 = new BorderLayout();
 	private JPanel topPanel = new JPanel();
 	private JLabel hostLabel = new JLabel();
-	private JComboBox hostCombo = new JComboBox();
+	private JComboBox<String> hostCombo = new JComboBox<>();
 	private JLabel portLabel = new JLabel();
 	private JTextField portField = new JTextField(6);
 	private JLabel userLabel = new JLabel();
@@ -405,7 +405,7 @@ public class RtStatFrame
 		dlg.setLocation((frmSize.width - dlgSize.width) / 2 + loc.x, 
 			(frmSize.height - dlgSize.height) / 2 + loc.y);
 		dlg.setModal(true);
-		dlg.show();
+		dlg.setVisible(true);
 	}
 
 	public synchronized void connectButton_actionPerformed(ActionEvent e)
@@ -996,7 +996,7 @@ public class RtStatFrame
 		eventsPanel.addLine(event);
 	}
 
-	public static void loadConnectionsField(JComboBox hostCombo, Properties connectionList,
+	public static void loadConnectionsField(JComboBox<String> hostCombo, Properties connectionList,
 		String connectedHostName)
 	{
 		String fn = LddsClient.getLddsConnectionsFile();
@@ -1060,7 +1060,8 @@ public class RtStatFrame
 		}
 		Collections.sort(hosts);
 		int selected = -1;
-		//MJM Added: to put a black selection in the start of the list.
+		hostCombo.removeAllItems();
+		//MJM Added: to put a blank selection in the start of the list.
 		hostCombo.addItem("");
 		
 		for(int i = 0; i<hosts.size(); i++)
@@ -1071,14 +1072,14 @@ public class RtStatFrame
 				selected = i;
 		}
 		
-		if (selected == -1 && connectedHostName != null)
+		if (selected == -1 && connectedHostName != null && !connectedHostName.isEmpty())
 		{
 			hostCombo.addItem(connectedHostName);
 			selected = hosts.size();
 		}
 	}
 
-	public static void setFieldsFromHostSelection(JComboBox hostCombo, 
+	public static void setFieldsFromHostSelection(JComboBox<String> hostCombo,
 		Properties connectionList, JTextField portField, JTextField userField,
 		PasswordWithShow passwordField)
 	{
@@ -1176,7 +1177,7 @@ public class RtStatFrame
 		int n = hostCombo.getItemCount();
 		for(int i=0; i<n; i++)
 		{
-			String h = (String)hostCombo.getItemAt(i);
+			String h = hostCombo.getItemAt(i);
 			if (hostname.equalsIgnoreCase(h))
 			{
 				hostCombo.setSelectedIndex(i);

--- a/src/main/java/lrgs/rtstat/RtStatFrame.java
+++ b/src/main/java/lrgs/rtstat/RtStatFrame.java
@@ -347,7 +347,6 @@ public class RtStatFrame
 
 	public void connectButton_actionPerformed(LrgsConnection c)
 	{
-		System.out.println("basic error checking." + c.toString() + ": " +c.toPropertyEntry());
 		final String thost = c.getHostName();
 		if (thost.length() == 0)
 		{
@@ -377,24 +376,19 @@ public class RtStatFrame
 			showError(labels.getString("RtStatFrame.passAuthErr"));
 			return;
 		}
-		System.out.println("Setting title.");
 		SwingUtilities.invokeLater(() -> setTitle(labels.getString("RtStatFrame.frameTitle")));
 
 		host = thost;
-		System.out.println("Connecting.");
 		doConnect(c);
 	}
 
 	private void doConnect(LrgsConnection c)
 	{
-		System.out.println("Closing connection.");
 		closeConnection();
-		client = null;
-		System.out.println("Creating new connection.");
+		client = null;	
 		final LddsClient tclient = new LddsClient(host, port);
 
-		connectionJobDialog.setCanCancel(true);
-		System.out.println("Creating Job thread.");
+		connectionJobDialog.setCanCancel(true);		
 		Thread backgroundJob =
 			new Thread()
 			{
@@ -462,7 +456,6 @@ public class RtStatFrame
 
 			};
 		backgroundJob.setName("LRGS Connection background thread.");
-		System.out.println("Starting job thread.");
 		backgroundJob.start();
 		launch(connectionJobDialog);
 		if (tclient.isConnected())
@@ -1185,7 +1178,6 @@ public class RtStatFrame
 		{
 			networkDcpStatusFrame = new NetworkDcpStatusFrame(this);
 			networkDcpStatusFrame.setVisible(true);
-			//System.out.println("Created networkDcpStatusFrame");
 		}
 		else
 		{

--- a/src/main/java/lrgs/rtstat/RtStatFrame.java
+++ b/src/main/java/lrgs/rtstat/RtStatFrame.java
@@ -282,16 +282,8 @@ public class RtStatFrame
 				labels.getString("RtStatFrame.host"));
 		topPanel.setLayout(new BorderLayout());
 
-		pauseButton.setText(
-				labels.getString("RtStatFrame.pause"));
-		pauseButton.addActionListener(
-			new java.awt.event.ActionListener()
-			{
-	    		public void actionPerformed(ActionEvent e)
-	    		{
-					pauseButton_actionPerformed(e);
-	    		}
-			});
+		connectionPanel.onPause(c -> pauseButton_actionPerformed(c));
+
 		jSplitPane1.setOrientation(JSplitPane.VERTICAL_SPLIT);
 		eventsPanel.setMaximumSize(new Dimension(32767, 150));
 		eventsPanel.setMinimumSize(new Dimension(10, 120));
@@ -860,7 +852,7 @@ public class RtStatFrame
 		}
 	}
 
-	private void pauseButton_actionPerformed(ActionEvent e)
+	private void pauseButton_actionPerformed(LrgsConnection c)
 	{
 		if (!isPaused)
 		{

--- a/src/main/java/lrgs/rtstat/RtStatFrame.java
+++ b/src/main/java/lrgs/rtstat/RtStatFrame.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,9 +63,9 @@ public class RtStatFrame
 	implements DdsClientIf, HyperlinkListener
 {
 	private final static org.slf4j.Logger log = LoggerFactory.getLogger(RtStatFrame.class);
-	private static ResourceBundle labels = 
+	private static ResourceBundle labels =
 		RtStat.getLabels();
-	private static ResourceBundle genericLabels = 
+	private static ResourceBundle genericLabels =
 		RtStat.getGenericLabels();
 	private JPanel contentPane;
 	private JMenuBar jMenuBar1 = new JMenuBar();
@@ -80,20 +81,14 @@ public class RtStatFrame
 	private JPanel topPanel = new JPanel();
 	private JLabel hostLabel = new JLabel();
 	private JComboBox<LrgsConnection> hostCombo = new JComboBox<>();
-	private JLabel portLabel = new JLabel();
-	private JTextField portField = new JTextField(6);
-	private JLabel userLabel = new JLabel();
-	JTextField userField = new JTextField(8);
 	private PasswordWithShow passwordField = new PasswordWithShow(GuiConstants.DEFAULT_PASSWORD_WITH);
-	private JButton connectButton = new JButton();
-	private GridBagLayout gridBagLayout1 = new GridBagLayout();
 	private JButton pauseButton = new JButton();
 	private JSplitPane jSplitPane1 = new JSplitPane();
 	private RtStatPanel rtStatPanel = new RtStatPanel();
 	private EventsPanel eventsPanel = new EventsPanel(false);
 	private JCheckBox passwordCheck = new JCheckBox();
 	private LrgsConnectionPanel connectionPanel = new LrgsConnectionPanel();
-	
+
 	/** True if the display is currently paused. */
 	boolean isPaused = false;
 
@@ -105,9 +100,6 @@ public class RtStatFrame
 
 	/** The currently selected host name. */
 	private String connectedHostName = "";
-
-	/** List of historical DDS connections. */
-	private Properties connectionList = new Properties();
 
 	private int dividerLoc;
 	private int splitPaneHeight;
@@ -128,7 +120,11 @@ public class RtStatFrame
 	private NetlistMaintenanceDialog netlistDlg;
 	private DrgsInputSettings networkDcpSettings;
 	private NetworkDcpStatusFrame networkDcpStatusFrame = null;
-	
+
+	private final JobDialog connectionJobDialog = new JobDialog(
+									this,
+									labels.getString("RtStatFrame.connectingToInfo") + host,
+									true);
 
 	/** Constructor. */
 	public RtStatFrame(int scanPeriod, String iconFile, String headerFile)
@@ -182,12 +178,7 @@ public class RtStatFrame
 					dividerLoc = jSplitPane1.getDividerLocation();
 				}
 			});
-		//loadConnectionsCombo();
-		hostCombo.setEditable(true);
-		File lddsConnectionFile = new File(LddsClient.getLddsConnectionsFile());
-		hostCombo.setModel(new LrgsConnectionComboBoxModel(lddsConnectionFile));
-		hostCombo.addActionListener(this::setFieldsFromHostSelection);
-		
+
 		//loadConnectionsField(hostCombo, connectionList, connectedHostName);
 		netlistDlg = null;
 		rtStatPanel.htmlPanel.addHyperlinkListener(this);
@@ -215,8 +206,8 @@ public class RtStatFrame
 		try { cl.loadClass("lrgs.ddsrecv.DdsRecvConnectCfg"); }
 		catch(ClassNotFoundException ex) { canConfig = false; }
 
-		
-		
+
+
 		contentPane = (JPanel)this.getContentPane();
 		contentPane.setLayout(borderLayout1);
 		this.setSize(new Dimension(793, 716));
@@ -252,7 +243,7 @@ public class RtStatFrame
 					fileUserAdmin_actionPerformed();
 				}
 			});
-		
+
 
 		if (canConfig)
 		{
@@ -266,7 +257,7 @@ public class RtStatFrame
 						fileLrgsConfig_actionPerformed();
 					}
 				});
-	
+
 			fileNetworkLists.setText(
 					labels.getString("RtStatFrame.networkLists"));
 			fileNetworkLists.addActionListener(
@@ -277,8 +268,8 @@ public class RtStatFrame
 						fileNetworkLists_actionPerformed();
 					}
 				});
-		}	
-		
+		}
+
 		jMenuHelp.setText(
 				genericLabels.getString("help"));
 		jMenuHelpAbout.setText(
@@ -295,21 +286,6 @@ public class RtStatFrame
 		hostLabel.setText(
 				labels.getString("RtStatFrame.host"));
 		topPanel.setLayout(new BorderLayout());
-		portLabel.setText(
-				labels.getString("RtStatFrame.port"));
-		portField.setText("16003");
-		userLabel.setText(
-				labels.getString("RtStatFrame.user"));
-		connectButton.setText(
-				labels.getString("RtStatFrame.connectButton"));
-		connectButton.addActionListener(
-			new java.awt.event.ActionListener()
-			{
-	    		public void actionPerformed(ActionEvent e)
-	    		{
-					connectButton_actionPerformed(e);
-	    		}
-			});
 
 		pauseButton.setText(
 				labels.getString("RtStatFrame.pause"));
@@ -325,16 +301,6 @@ public class RtStatFrame
 		eventsPanel.setMaximumSize(new Dimension(32767, 150));
 		eventsPanel.setMinimumSize(new Dimension(10, 120));
 		eventsPanel.setPreferredSize(new Dimension(10, 120));
-		passwordCheck.setText(
-				labels.getString("RtStatFrame.password"));
-		passwordCheck.addActionListener(
-			new java.awt.event.ActionListener()
-			{
-	    		public void actionPerformed(ActionEvent e)
-	    		{
-					passwordCheck_actionPerformed(e);
-	    		}
-			});
 		jMenuFile.add(fileSetPasswordMenuItem);
 		jMenuFile.add(fileUserAdmin);
 		if (canConfig)
@@ -348,38 +314,8 @@ public class RtStatFrame
 		jMenuBar1.add(jMenuFile);
 		jMenuBar1.add(jMenuHelp);
 		contentPane.add(topPanel, BorderLayout.NORTH);
-		topPanel.add(connectionPanel);/*
-		topPanel.add(hostLabel,  new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0
-	        ,GridBagConstraints.WEST, GridBagConstraints.NONE, 
-			new Insets(4, 5, 4, 1), 0, 0));
-		topPanel.add(hostCombo,  new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0
-	        ,GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, 
-			new Insets(4, 0, 4, 6), 0, 0));
-		topPanel.add(portLabel,   new GridBagConstraints(2, 0, 1, 1, 0.0, 0.0
-	        ,GridBagConstraints.EAST, GridBagConstraints.NONE, 
-			new Insets(4, 6, 4, 1), 0, 0));
-		topPanel.add(portField,  new GridBagConstraints(3, 0, 1, 1, 0.0, 0.0
-	        ,GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, 
-			new Insets(4, 0, 4, 6), 0, 0));
-		topPanel.add(userLabel,   new GridBagConstraints(4, 0, 1, 1, 0.0, 0.0
-	        ,GridBagConstraints.EAST, GridBagConstraints.NONE, 
-			new Insets(4, 6, 4, 1), 0, 0));
-		topPanel.add(userField,  new GridBagConstraints(5, 0, 1, 1, 0.5, 0.0
-	        ,GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, 
-			new Insets(4, 0, 4, 6), 0, 0));
-		topPanel.add(passwordCheck,  new GridBagConstraints(6, 0, 1, 1, 0.0, 0.0
-	        ,GridBagConstraints.EAST, GridBagConstraints.NONE, 
-			new Insets(4, 6, 4, 1), 0, 0));
-		topPanel.add(passwordField,  new GridBagConstraints(8, 0, 1, 1, 0.5, 0.0
-	        ,GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, 
-			new Insets(4, 0, 4, 6), 0, 0));
-		topPanel.add(connectButton,  new GridBagConstraints(9, 0, 1, 1, 0.0, 0.0
-	        ,GridBagConstraints.CENTER, GridBagConstraints.NONE, 
-			new Insets(4, 20, 4, 0), 0, 0));
-		topPanel.add(pauseButton,  new GridBagConstraints(10, 0, 1, 1, 0.0, 0.0
-	        ,GridBagConstraints.CENTER, GridBagConstraints.NONE, 
-			new Insets(4, 10, 4, 5), 0, 0));
-		*/
+		topPanel.add(connectionPanel);
+		connectionPanel.onConnect(c -> connectButton_actionPerformed(c));
 		contentPane.add(jSplitPane1, BorderLayout.CENTER);
 		jSplitPane1.add(rtStatPanel, JSplitPane.TOP);
 		jSplitPane1.add(eventsPanel, JSplitPane.BOTTOM);
@@ -403,71 +339,62 @@ public class RtStatFrame
 		Dimension dlgSize = dlg.getPreferredSize();
 		Dimension frmSize = getSize();
 		Point loc = getLocation();
-		dlg.setLocation((frmSize.width - dlgSize.width) / 2 + loc.x, 
+		dlg.setLocation((frmSize.width - dlgSize.width) / 2 + loc.x,
 			(frmSize.height - dlgSize.height) / 2 + loc.y);
 		dlg.setModal(true);
 		dlg.setVisible(true);
 	}
 
-	public synchronized void connectButton_actionPerformed(ActionEvent e)
+	public void connectButton_actionPerformed(LrgsConnection c)
 	{
-		final String thost = ((String)hostCombo.getSelectedItem()).trim();
+		System.out.println("basic error checking." + c.toString() + ": " +c.toPropertyEntry());
+		final String thost = c.getHostName();
 		if (thost.length() == 0)
 		{
 			showError(labels.getString("RtStatFrame.hostOrIpEmptyErr"));
 			return;
 		}
 
-		int p = 16003;
-		String ps = portField.getText().trim();
-		if (ps.length() > 0)
+		final int p = c.getPort();
+		if (p <= 0)
 		{
-			try
-			{
-				p = Integer.parseInt(ps);
-			}
-			catch(NumberFormatException ex)
-			{
-				showError(labels.getString(	"RtStatFrame.portNumErr"));
-				return;
-			}
+			showError(labels.getString(	"RtStatFrame.portNumErr"));
+
 		}
 		port = p;
 
-		user = userField.getText().trim();
+		user = c.getUsername();
 		if (user.length() == 0)
 		{
 			showError(labels.getString("RtStatFrame.userEmptyErr"));
 			return;
 		}
 
-		passwd = null;
-		if (passwordCheck.isSelected())
-		{
-			passwd = new String(passwordField.getPassword()).trim();
-			if (passwd.length() == 0)
-			{
-				showError(labels.getString("RtStatFrame.passAuthErr"));
-				return;
-			}
-		}
+		passwd = LrgsConnection.decryptPassword(c, LrgsConnectionPanel.pwk);
 
-		setTitle(labels.getString("RtStatFrame.frameTitle"));
+		if (passwd == null || passwd.length() == 0)
+		{
+			showError(labels.getString("RtStatFrame.passAuthErr"));
+			return;
+		}
+		System.out.println("Setting title.");
+		SwingUtilities.invokeLater(() -> setTitle(labels.getString("RtStatFrame.frameTitle")));
+
 		host = thost;
-		doConnect();
+		System.out.println("Connecting.");
+		doConnect(c);
 	}
 
-	private void doConnect()
+	private void doConnect(LrgsConnection c)
 	{
+		System.out.println("Closing connection.");
 		closeConnection();
 		client = null;
+		System.out.println("Creating new connection.");
 		final LddsClient tclient = new LddsClient(host, port);
-		final JobDialog dlg = new JobDialog(
-									this, 
-									labels.getString("RtStatFrame.connectingToInfo") + host,
-									true);
-		dlg.setCanCancel(true);
 
+		connectionJobDialog.setCanCancel(true);
+		System.out.println("Creating Job thread.");
 		Thread backgroundJob =
 			new Thread()
 			{
@@ -475,16 +402,19 @@ public class RtStatFrame
 				{
 					pause(1000L);
 
-					while(host != null && !dlg.wasCancelled()
-						&& dlg.isVisible())
+					while(host != null && !connectionJobDialog.wasCancelled() && connectionJobDialog.isVisible())
 					{
-						dlg.addToProgress(LoadResourceBundle.sprintf(
+						connectionJobDialog.addToProgress(LoadResourceBundle.sprintf(
 								labels.getString("RtStatFrame.connectingInfo"),
-							host, port));
-						try { tclient.connect(); }
+								host, port)
+						);
+						try
+						{
+							tclient.connect();
+						}
 						catch(Exception ex)
 						{
-							dlg.addToProgress(
+							connectionJobDialog.addToProgress(
 							labels.getString("RtStatFrame.cannotConnectErr")
 							+ ex);
 							tclient.disconnect();
@@ -493,44 +423,34 @@ public class RtStatFrame
 						}
 						try
 						{
-							if (passwd == null)
-							{
-								dlg.addToProgress(LoadResourceBundle.sprintf(
-								labels.getString("RtStatFrame.sendingUserInfo"),
-								user));
-								tclient.sendHello(user);
-							}
-							else
-							{
-								dlg.addToProgress(
+							connectionJobDialog.addToProgress(
 								LoadResourceBundle.sprintf(
-								labels.getString(
-								"RtStatFrame.authenticatingUserInfo"),
-								user));
-								tclient.sendAuthHello(user, passwd);
-							}
-							dlg.addToProgress(labels.getString(
+									labels.getString("RtStatFrame.authenticatingUserInfo"),
+									user)
+							);
+							tclient.sendAuthHello(user, passwd);
+							connectionJobDialog.addToProgress(labels.getString(
 									"RtStatFrame.connectionSuccessInfo"));
 							pause(2000L);
-							dlg.allDone();
+							connectionJobDialog.allDone();
 							return;
 						}
 						catch(ServerError ex)
 						{
-							dlg.addToProgress(labels.getString(
-									"RtStatFrame.connectionRejectedErr") 
+							connectionJobDialog.addToProgress(labels.getString(
+									"RtStatFrame.connectionRejectedErr")
 									+ ex);
 							tclient.disconnect();
 						}
 						catch(ProtocolError ex)
 						{
-							dlg.addToProgress(
+							connectionJobDialog.addToProgress(
 							labels.getString("RtStatFrame.protocolErr") + ex);
 							tclient.disconnect();
 						}
 						catch(Exception ex)
 						{
-							dlg.addToProgress(labels.getString(
+							connectionJobDialog.addToProgress(labels.getString(
 							  "RtStatFrame.authenticationErr") + ex);
 							tclient.disconnect();
 						}
@@ -541,15 +461,17 @@ public class RtStatFrame
 
 
 			};
+		backgroundJob.setName("LRGS Connection background thread.");
+		System.out.println("Starting job thread.");
 		backgroundJob.start();
-		launch(dlg);
+		launch(connectionJobDialog);
 		if (tclient.isConnected())
 		{
 			setTitle(labels.getString("RtStatFrame.frameTitle")+": " + host);
 			client = tclient;
-			updateConnectionList();
-			displayEvent("Connected to " + host + ":"
-				+ port + " as user '" + user + "'");
+			displayEvent("Connected to " + host + ":" + port + " as user '" + user + "'");
+			LrgsConnection newConnection = new LrgsConnection(c, new Date());
+			connectionPanel.addOrUpdateConnection(newConnection);
 		}
 	}
 	private static void pause(long millis)
@@ -661,7 +583,7 @@ public class RtStatFrame
 				{
 					public void run()
 					{
-						doConnect();
+						doConnect(null);
 					}
 				});
 			return null;
@@ -694,7 +616,7 @@ public class RtStatFrame
 	 */
 	public synchronized void applyDdsRecvSettings(DdsRecvSettings settings)
 		throws AuthException
-	{		
+	{
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		try
 		{
@@ -754,7 +676,7 @@ public class RtStatFrame
 		byte cfgData[] = baos.toByteArray();
 		client.installConfig("networkDcp", cfgData);
 	}
-	
+
 	/**
 	 * Retrieve the 3 configurations from the server and store them locally.
 	 */
@@ -777,7 +699,7 @@ public class RtStatFrame
 		}
 		catch(Exception ex)
 		{
-			String msg = LoadResourceBundle.sprintf( 
+			String msg = LoadResourceBundle.sprintf(
 				labels.getString("RtStatFrame.cannotReadLrgsConfErr"),
 				host) + ex;
 			showError(msg);
@@ -794,7 +716,7 @@ public class RtStatFrame
 		}
 		catch(Exception ex)
 		{
-			String msg = LoadResourceBundle.sprintf( 
+			String msg = LoadResourceBundle.sprintf(
 					labels.getString("RtStatFrame.cannotReadDdsConfErr"),
 					host, ex);
 			showError(msg);
@@ -809,12 +731,12 @@ public class RtStatFrame
 		}
 		catch(Exception ex)
 		{
-			String msg = LoadResourceBundle.sprintf( 
+			String msg = LoadResourceBundle.sprintf(
 					labels.getString("RtStatFrame.cannotReadDrgsConfErr"),
-					host, ex); 
+					host, ex);
 			showError(msg);
 		}
-		
+
 		try
 		{
 			byte[] cfgData = client.getConfig("networkDcp");
@@ -824,15 +746,15 @@ public class RtStatFrame
 		}
 		catch(Exception ex)
 		{
-			String msg = LoadResourceBundle.sprintf( 
+			String msg = LoadResourceBundle.sprintf(
 					labels.getString("RtStatFrame.cannotReadNetworkDcpConfErr"),
-					host, ex); 
+					host, ex);
 			Logger.instance().warning(msg);
 		}
 	}
 
-	
-	
+
+
 	/**
 	 * @return a list of network lists that exist on the server.
 	 */
@@ -850,7 +772,7 @@ public class RtStatFrame
 		}
 		catch(Exception ex)
 		{
-			String msg = LoadResourceBundle.sprintf( 
+			String msg = LoadResourceBundle.sprintf(
 				labels.getString("RtStatFrame.cannotGetNlListErr"),
 				host) + ex;
 			showError(msg);
@@ -876,7 +798,7 @@ public class RtStatFrame
 		}
 		catch(Exception ex)
 		{
-			String msg = LoadResourceBundle.sprintf( 
+			String msg = LoadResourceBundle.sprintf(
 					labels.getString("RtStatFrame.cannotGetNlErr"),
 					host) + ex;
 			showError(msg);
@@ -988,60 +910,12 @@ public class RtStatFrame
 	}
 	public void updateNetworkDcpStatus(String nds)
 	{
-		
+
 	}
 	/** Called from within the GUI thread to display an event. */
 	public void displayEvent(String event)
 	{
 		eventsPanel.addLine(event);
-	}	
-
-	private  void setFieldsFromHostSelection(ActionEvent event )
-	{
-		
-		LrgsConnection c = (LrgsConnection)hostCombo.getSelectedItem();
-		if (c == LrgsConnection.BLANK)
-		{
-			portField.setText("16003");
-			userField.setText("");
-			passwordField.setText("");
-		}
-		else
-		{
-			portField.setText(""+c.getPort());
-			userField.setText(c.getUsername());
-
-			String pw = c.getPassword();
-			if (pw != null && !pw.isEmpty())
-			{		
-				try
-				{
-					String pwk = "tmp";
-					DesEncrypter de = new DesEncrypter(pwk);
-					String dpw = de.decrypt(pw);
-					passwordField.setText(dpw);
-				}
-				catch (AuthException e)
-				{
-				}
-			}
-			else
-			{
-				passwordField.setText("");
-			}
-		}
-		
-		boolean haveAPassword = passwordField.getPassword().length > 0;
-		passwordCheck.setSelected(haveAPassword);
-		passwordField.setEnabled(haveAPassword);
-	}
-
-	/** 
-	  Updates the connection list file with a new connection.
-	*/
-	public void updateConnectionList()
-	{
-		
 	}
 
 	/**
@@ -1076,8 +950,8 @@ public class RtStatFrame
 			showError("You must login with the old password before you can change the password.");
 			return;
 		}
-		
-		LoginDialog ld = new LoginDialog(this, 
+
+		LoginDialog ld = new LoginDialog(this,
 				labels.getString("RtStatFrame.modifyPassTitle"), true);
 		ld.setEditableUsername(false, user);
 		launch(ld);
@@ -1087,13 +961,13 @@ public class RtStatFrame
 			try
 			{
 				DdsUser du = new DdsUser(user);
-				modUser(du, new String(pw)); 
+				modUser(du, new String(pw));
 			}
 			catch(Exception ex)
 			{
 				String msg = labels.getString("RtStatFrame.changePassErr")+ex;
 				JOptionPane.showMessageDialog(this,
-					AsciiUtil.wrapString(msg, 60), "Error!", 
+					AsciiUtil.wrapString(msg, 60), "Error!",
 					JOptionPane.ERROR_MESSAGE);
 			}
 		}
@@ -1106,7 +980,7 @@ public class RtStatFrame
 			showError("Not connected.");
 			return;
 		}
-		
+
 		if (!client.isAuthenticated())
 		{
 			showError(labels.getString(
@@ -1127,14 +1001,14 @@ public class RtStatFrame
 		try
 		{
 			ArrayList<DdsUser> userList = getUsers();
-			
+
 			// Non-administrators can see, and modify certain fields, in their own
 			// user record. Jump directly to UserEditDialog with isAdmin=false.
-			if (userList.size() == 1 
+			if (userList.size() == 1
 			 && TextUtil.strEqual(client.getUserName(), userList.get(0).userName)
 			 && !userList.get(0).isAdmin())
 			{
-				EditUserDialog editUserDialog = new EditUserDialog(null, 
+				EditUserDialog editUserDialog = new EditUserDialog(null,
 					labels.getString("UserListDialog.modUserDataTitle"), true, false);
 
 				editUserDialog.set(host, userList.get(0), false);
@@ -1145,7 +1019,7 @@ public class RtStatFrame
 					launch(editUserDialog);
 					if (editUserDialog.okPressed())
 					{
-						try 
+						try
 						{
 							client.modUser(userList.get(0), editUserDialog.getPassword());
 							done = true;
@@ -1192,9 +1066,25 @@ public class RtStatFrame
 	 	{
 			yo = 0;
 		}
-		
+
 		dlg.setLocation(frameLoc.x + xo, frameLoc.y + yo);
-		dlg.setVisible(true);
+		if (SwingUtilities.isEventDispatchThread())
+		{
+			dlg.setVisible(true);
+		}
+		else
+		{
+			try
+			{
+				SwingUtilities.invokeAndWait(() -> dlg.setVisible(true));
+			}
+			catch (InvocationTargetException | InterruptedException ex)
+			{
+				log.atError()
+				   .setCause(ex)
+				   .log("Error waiting for dialog to return.");
+			}
+		}
 	}
 
 	public void fileLrgsConfig_actionPerformed()
@@ -1202,7 +1092,7 @@ public class RtStatFrame
 		if (client == null)
 		{
 			showError("Not connected.");
-			return;			
+			return;
 		}
 
 		if (!client.isAuthenticated())
@@ -1229,14 +1119,14 @@ public class RtStatFrame
 		{
 			getConfigurations();
 		}
-		catch(AuthException ex) 
+		catch(AuthException ex)
 		{
 			return;
 		}
 		lrgsConfigDialog.setConfig(lrgsConfig, ddsSettings, drgsSettings,
 			networkDcpSettings);
 		launch(lrgsConfigDialog);
-	}	
+	}
 
 	private void fileNetworkLists_actionPerformed()
 	{
@@ -1288,7 +1178,7 @@ public class RtStatFrame
 			}
 		}
 	}
-	
+
 	private void showNetworkDcps()
 	{
 		if (networkDcpStatusFrame == null)
@@ -1302,7 +1192,7 @@ public class RtStatFrame
 			networkDcpStatusFrame.toFront();
 		}
 	}
-	
+
 	public void networkDcpStatusFrameClosed()
 	{
 		networkDcpStatusFrame = null;

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnection.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnection.java
@@ -1,0 +1,96 @@
+package lrgs.rtstat.hosts;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * Keep the information about a connection to an LRGS for the ComboBox model.
+ */
+public class LrgsConnection
+{
+    public static LrgsConnection BLANK = new LrgsConnection("", -1, "", "", null);
+
+    final String hostName;
+    final int port;
+    final String username;
+    final String password;
+    final Date lastUsed;
+
+
+    public LrgsConnection(String hostName, int port, String username, String password, Date lastUsed)
+    {
+        this.hostName = hostName;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+        this.lastUsed = lastUsed;
+    }
+
+    public String getHostName()
+    {
+        return hostName;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    public Date getLastUsed()
+    {
+        return lastUsed;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        return Objects.equals(this, other);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(hostName, port, username, password);
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s=%d %s %d %s", hostName, port, username, lastUsed.getTime(), password);
+    }
+
+
+    public static LrgsConnection fromDdsFile(String input)
+    {
+        final String parts[] = input.split("\\s+");
+        final String hostNameAndPort = parts[0];
+        final String username = parts[1];
+        final Long lastUsed = Long.parseLong(parts[2]);
+        final String password = parts[3];
+
+        final String parts2[] = hostNameAndPort.split("=");
+
+        return new LrgsConnection(parts2[0], Integer.parseInt(parts2[1]), 
+                                  username, password, new Date(lastUsed));
+    }
+
+    public static String decryptPassword(LrgsConnection c, String key)
+    {
+        return null;
+    }
+
+    public String encryptPassword(LrgsConnection c, String key)
+    {
+        return null;
+    }
+}

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnection.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnection.java
@@ -3,18 +3,25 @@ package lrgs.rtstat.hosts;
 import java.util.Date;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ilex.util.AuthException;
+import ilex.util.DesEncrypter;
+
 /**
  * Keep the information about a connection to an LRGS for the ComboBox model.
  */
-public class LrgsConnection
+public final class LrgsConnection
 {
-    public static LrgsConnection BLANK = new LrgsConnection("", -1, "", "", null);
+    private static final Logger log = LoggerFactory.getLogger(LrgsConnection.class);
+    public static final LrgsConnection BLANK = new LrgsConnection("", -1, "", "", null);
 
-    final String hostName;
-    final int port;
-    final String username;
-    final String password;
-    final Date lastUsed;
+    private final String hostName;
+    private final int port;
+    private final String username;
+    private final String password;
+    private final Date lastUsed;
 
 
     public LrgsConnection(String hostName, int port, String username, String password, Date lastUsed)
@@ -23,6 +30,15 @@ public class LrgsConnection
         this.port = port;
         this.username = username;
         this.password = password;
+        this.lastUsed = lastUsed;
+    }
+
+    public LrgsConnection(LrgsConnection c, Date lastUsed)
+    {
+        this.hostName = c.hostName;
+        this.port = c.port;
+        this.username = c.username;
+        this.password = c.password;
         this.lastUsed = lastUsed;
     }
 
@@ -54,7 +70,45 @@ public class LrgsConnection
     @Override
     public boolean equals(Object other)
     {
-        return Objects.equals(this, other);
+        if (!(other instanceof LrgsConnection))
+        {
+            return false;
+        }
+        LrgsConnection rhs = (LrgsConnection)other;
+        if (port != rhs.port)
+        {
+            return false;
+        }
+
+        if (lastUsed != null && rhs.lastUsed == null)
+        {
+            return false;
+        }
+        else if (lastUsed == null && rhs.lastUsed != null)
+        {
+            return false;
+        }
+        else if ((lastUsed != null && rhs.lastUsed != null) && !lastUsed.equals(rhs.lastUsed))
+        {
+            return false;
+        }
+
+        if (!hostName.equals(rhs.hostName))
+        {
+            return false;
+        }
+
+        if (!username.equals(rhs.username))
+        {
+            return false;
+        }
+
+        if (!password.equals(rhs.password))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     @Override
@@ -66,31 +120,70 @@ public class LrgsConnection
     @Override
     public String toString()
     {
-        return String.format("%s=%d %s %d %s", hostName, port, username, lastUsed.getTime(), password);
+        return hostName;
+    }
+
+    public String toPropertyEntry()
+    {
+        return String.format("%d %s %d %s",
+                                port, username,
+                                (lastUsed == null ? 0 : lastUsed.getTime()),
+                                password);
     }
 
 
-    public static LrgsConnection fromDdsFile(String input)
+    public static LrgsConnection fromDdsFile(String host, String input)
     {
         final String parts[] = input.split("\\s+");
-        final String hostNameAndPort = parts[0];
+        final int port = Integer.parseInt(parts[0]);
         final String username = parts[1];
         final Long lastUsed = Long.parseLong(parts[2]);
         final String password = parts[3];
 
-        final String parts2[] = hostNameAndPort.split("=");
-
-        return new LrgsConnection(parts2[0], Integer.parseInt(parts2[1]), 
+        return new LrgsConnection(host, port,
                                   username, password, new Date(lastUsed));
     }
 
     public static String decryptPassword(LrgsConnection c, String key)
     {
-        return null;
+        final String encrypted = c.getPassword();
+        if (encrypted == null || encrypted.isEmpty())
+        {
+            return "";
+        }
+        try
+        {
+		    final DesEncrypter de = new DesEncrypter(key);
+		    final String password = de.decrypt(encrypted);
+            return password;
+        }
+        catch (AuthException ex)
+        {
+            log.atTrace()
+               .setCause(ex)
+               .log("Unable to decrypt password from LddsConnection files.");
+            return "";
+        }
     }
 
-    public String encryptPassword(LrgsConnection c, String key)
+    public static String encryptPassword(String password, String key)
     {
-        return null;
+        if (password == null || password.isEmpty())
+        {
+            return "";
+        }
+        try
+        {
+		    final DesEncrypter de = new DesEncrypter(key);
+		    final String passwordEncrypted = de.encrypt(password);
+            return passwordEncrypted;
+        }
+        catch (AuthException ex)
+        {
+            log.atTrace()
+               .setCause(ex)
+               .log("Unable to encrypt password for LddsConnection files.");
+            return "";
+        }
     }
 }

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnection.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnection.java
@@ -153,8 +153,8 @@ public final class LrgsConnection
         }
         try
         {
-		    final DesEncrypter de = new DesEncrypter(key);
-		    final String password = de.decrypt(encrypted);
+            final DesEncrypter de = new DesEncrypter(key);
+            final String password = de.decrypt(encrypted);
             return password;
         }
         catch (AuthException ex)
@@ -174,8 +174,8 @@ public final class LrgsConnection
         }
         try
         {
-		    final DesEncrypter de = new DesEncrypter(key);
-		    final String passwordEncrypted = de.encrypt(password);
+            final DesEncrypter de = new DesEncrypter(key);
+            final String passwordEncrypted = de.encrypt(password);
             return passwordEncrypted;
         }
         catch (AuthException ex)

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionComboBoxModel.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionComboBoxModel.java
@@ -1,0 +1,96 @@
+package lrgs.rtstat.hosts;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import javax.swing.DefaultComboBoxModel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LrgsConnectionComboBoxModel extends DefaultComboBoxModel<LrgsConnection>
+{
+    private static final Logger log = LoggerFactory.getLogger(LrgsConnectionComboBoxModel.class);
+
+    final List<LrgsConnection> hosts = new ArrayList<>();
+    final File lddsConnectionFile;
+
+    public LrgsConnectionComboBoxModel(File lddsConnectionFile)
+    {
+        this.lddsConnectionFile = lddsConnectionFile;
+        hosts.add(LrgsConnection.BLANK);
+        try (FileInputStream fis = new FileInputStream(lddsConnectionFile);
+             BufferedReader br = new BufferedReader(new InputStreamReader(fis)))
+        {
+            String line;
+            while ( (line = br.readLine()) != null)
+            {
+                if (!(line.startsWith("#") || !line.trim().isEmpty()))
+                {
+                    System.out.println(line);
+                    hosts.add(LrgsConnection.fromDdsFile(line));
+                }
+            }
+		}
+		catch(IOException ioe)
+		{
+			log.error("No previously recorded connections");
+		}
+		
+    }
+
+    public void addOrReplaceConnection(LrgsConnection c)
+    {
+        synchronized (hosts)
+        {
+            for (int i = 0; i < hosts.size(); i++)
+            {
+                LrgsConnection host = hosts.get(i);
+                if (host.hostName.equals(c.hostName) && !host.equals(c))
+                {
+                    hosts.set(i, c);
+                    fireContentsChanged(c, i, i);
+                    writeToDisk();
+                    return;
+                }
+            }
+            hosts.add(c);
+            fireIntervalAdded(c, getSize(), getSize());
+            writeToDisk();
+        }
+    }
+
+    private void writeToDisk()
+    {
+        try(FileOutputStream fos = new FileOutputStream(lddsConnectionFile, false);
+            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fos));)
+        {
+            bw.write("#Recent LRGS Connections"+System.lineSeparator());
+            bw.write(String.format("#%s%s", new Date().toString(), System.lineSeparator()));
+            for (LrgsConnection c: hosts)
+            {
+                if (c != LrgsConnection.BLANK)
+                {
+                    bw.write(c.toString());
+                    bw.write(System.lineSeparator());
+                }    
+            }
+        }
+        catch (IOException ex)
+        {
+            log.atError()
+               .setCause(ex)
+               .log("Unable to write LddsConnections to {}", lddsConnectionFile);
+        }
+    }
+}

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
@@ -126,6 +126,10 @@ public class LrgsConnectionPanel extends JPanel
 		panel_4.add(pauseButton);
 
 		controller.setView(this);
+
+
+		int minWidth = passwordField.getMinimumSize().width + lblNewLabel_3.getMinimumSize().width + 50;
+		this.setMinimumSize(new Dimension(minWidth, 40));
 	}
 
 	private void changeConnection()
@@ -164,6 +168,11 @@ public class LrgsConnectionPanel extends JPanel
 	public void setModel(LrgsConnectionComboBoxModel model)
 	{
 		this.hostCombo.setModel(model);
+	}
+
+	public LrgsConnection getCurrentConnection()
+	{
+		return (LrgsConnection)hostCombo.getSelectedItem();
 	}
 
 	public void onConnect(Consumer<LrgsConnection> connectCallback)

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
@@ -1,0 +1,157 @@
+package lrgs.rtstat.hosts;
+
+import javax.swing.JPanel;
+import java.awt.FlowLayout;
+import javax.swing.JComboBox;
+import javax.swing.JTextField;
+import javax.swing.JLabel;
+import javax.swing.SwingConstants;
+
+import decodes.util.DecodesVersion;
+import ilex.util.AuthException;
+import ilex.util.DesEncrypter;
+import lrgs.gui.MessageBrowser;
+import lrgs.rtstat.RtStatFrame;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import javax.swing.JButton;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
+
+public class LrgsConnectionPanel extends JPanel {
+	private static final ResourceBundle labels = ResourceBundle.getBundle("decodes.resources.rtstat", Locale.getDefault()); //$NON-NLS-1$
+	private static String pwk = MessageBrowser.class.toString() + 
+		(""+Math.PI).substring(3, 10) + DecodesVersion.class.toString();
+	private static final long serialVersionUID = 1L;
+	private JComboBox<LrgsConnection> hostCombo;
+	private JTextField portField;
+	private JTextField usernameField;
+	private JTextField passwordField;
+
+	private final LrgsConnectionPanelController controller;
+
+	/**
+	 * Create the panel.
+	 */
+	public LrgsConnectionPanel()
+	{
+		this(new LrgsConnectionPanelController());
+	}
+
+	private LrgsConnectionPanel(LrgsConnectionPanelController controller)
+	{
+		this.controller = controller;
+		setLayout(new FlowLayout(FlowLayout.LEFT, 5, 0));
+		
+		JPanel panel = new JPanel();
+		FlowLayout flowLayout = (FlowLayout) panel.getLayout();
+		flowLayout.setAlignment(FlowLayout.LEFT);
+		add(panel);
+		
+		JLabel lblNewLabel = new JLabel(labels.getString("RtStatFrame.host")); //$NON-NLS-1$
+		lblNewLabel.setHorizontalAlignment(SwingConstants.LEFT);
+		panel.add(lblNewLabel);
+		lblNewLabel.setLabelFor(hostCombo);
+		
+		hostCombo = new JComboBox<>();
+		hostCombo.setName("hostCombo");
+		hostCombo.setMinimumSize(new Dimension(120, 24));
+		hostCombo.setAlignmentX(Component.LEFT_ALIGNMENT);
+		hostCombo.setEditable(true);
+		hostCombo.addActionListener(e -> changeConnection());
+		panel.add(hostCombo);
+		
+		JPanel panel_1 = new JPanel();
+		add(panel_1);
+		
+		JLabel lblNewLabel_1 = new JLabel(labels.getString("RtStatFrame.port")); //$NON-NLS-1$
+		panel_1.add(lblNewLabel_1);
+		lblNewLabel_1.setLabelFor(portField);
+		
+		portField = new JTextField();
+		portField.setMaximumSize(new Dimension(32, 2147483647));
+		panel_1.add(portField);
+		portField.setText("16003");
+		portField.setColumns(10);
+		
+		JPanel panel_2 = new JPanel();
+		add(panel_2);
+		
+		JLabel lblNewLabel_2 = new JLabel(labels.getString("RtStatFrame.user")); //$NON-NLS-1$
+		panel_2.add(lblNewLabel_2);
+		
+		usernameField = new JTextField();
+		lblNewLabel_2.setLabelFor(usernameField);
+		panel_2.add(usernameField);
+		usernameField.setColumns(10);
+		
+		JPanel panel_3 = new JPanel();
+		add(panel_3);
+		
+		JLabel lblNewLabel_3 = new JLabel(labels.getString("RtStatFrame.password")); //$NON-NLS-1$
+		panel_3.add(lblNewLabel_3);
+		lblNewLabel_3.setLabelFor(passwordField);
+		
+		passwordField = new JTextField();
+		panel_3.add(passwordField);
+		passwordField.setColumns(10);
+		
+		JPanel panel_4 = new JPanel();
+		add(panel_4);
+		
+		JButton connectButton = new JButton(labels.getString("RtStatFrame.connectButton")); //$NON-NLS-1$
+		connectButton.addActionListener(e -> controller.connect());		
+		panel_4.add(connectButton);
+		
+		JButton pauseButton = new JButton(labels.getString("RtStatFrame.pause")); //$NON-NLS-1$
+		panel_4.add(pauseButton);
+
+		controller.setView(this);
+	}
+
+	private void changeConnection()
+	{
+		LrgsConnection c = (LrgsConnection)hostCombo.getSelectedItem();
+        if (c == LrgsConnection.BLANK)
+		{
+			portField.setText("16003");
+			usernameField.setText("");
+			passwordField.setText("");
+		}
+		else
+		{
+			portField.setText(""+c.getPort());
+			usernameField.setText(c.getUsername());
+
+			String pw = c.getPassword();
+			if (pw != null && !pw.isEmpty())
+			{		
+				try
+				{
+					DesEncrypter de = new DesEncrypter(pwk);
+					String dpw = de.decrypt(pw);
+					passwordField.setText(dpw);
+				}
+				catch (AuthException e)
+				{
+				}
+			}
+			else
+			{
+				passwordField.setText("");
+			}
+		}
+		controller.changeConnection(c);
+	}
+
+	public void setModel(LrgsConnectionComboBoxModel model)
+	{
+		this.hostCombo.setModel(model);
+		System.out.println(model.getSize());
+	}
+
+}

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
@@ -217,6 +217,11 @@ public final class LrgsConnectionPanel extends JPanel
 		}.execute();
 	}
 
+	private void pause()
+	{
+		this.controller.pause((LrgsConnection)hostCombo.getSelectedItem());
+	}
+
 	public void setModel(LrgsConnectionComboBoxModel model)
 	{
 		this.hostCombo.setModel(model);
@@ -230,6 +235,11 @@ public final class LrgsConnectionPanel extends JPanel
 	public void onConnect(Function<LrgsConnection,Boolean> connectCallback)
 	{
 		this.controller.onConnect(connectCallback);
+	}
+
+	public void onPause(Consumer<LrgsConnection> onPause)
+	{
+		this.controller.onPause(onPause);
 	}
 
 	private LrgsConnection connectionFromFields()

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
@@ -34,258 +34,258 @@ import java.util.function.Function;
 
 public final class LrgsConnectionPanel extends JPanel
 {
-	private static final Logger log = LoggerFactory.getLogger(LrgsConnectionPanel.class);
-	private static final ResourceBundle labels = ResourceBundle.getBundle("decodes.resources.rtstat", Locale.getDefault()); //$NON-NLS-1$
-	public static String pwk = MessageBrowser.class.toString() +
-		(""+Math.PI).substring(3, 10) + DecodesVersion.class.toString();
-	private static final long serialVersionUID = 1L;
-	private JComboBox<LrgsConnection> hostCombo;
-	private JTextField portField;
-	private JTextField usernameField;
-	private JButton pausedButton;
-	private PasswordWithShow passwordField;
-	private boolean paused = false;
+    private static final Logger log = LoggerFactory.getLogger(LrgsConnectionPanel.class);
+    private static final ResourceBundle labels = ResourceBundle.getBundle("decodes.resources.rtstat", Locale.getDefault()); //$NON-NLS-1$
+    public static String pwk = MessageBrowser.class.toString() +
+        (""+Math.PI).substring(3, 10) + DecodesVersion.class.toString();
+    private static final long serialVersionUID = 1L;
+    private JComboBox<LrgsConnection> hostCombo;
+    private JTextField portField;
+    private JTextField usernameField;
+    private JButton pausedButton;
+    private PasswordWithShow passwordField;
+    private boolean paused = false;
 
-	private final LrgsConnectionPanelController controller;
+    private final LrgsConnectionPanelController controller;
 
-	/**
-	 * Create the panel.
-	 */
-	public LrgsConnectionPanel()
-	{
-		this(new LrgsConnectionPanelController(), true);
-	}
+    /**
+     * Create the panel.
+     */
+    public LrgsConnectionPanel()
+    {
+        this(new LrgsConnectionPanelController(), true);
+    }
 
-	public LrgsConnectionPanel(boolean showPause)
-	{
-		this(new LrgsConnectionPanelController(), showPause);
-	}
+    public LrgsConnectionPanel(boolean showPause)
+    {
+        this(new LrgsConnectionPanelController(), showPause);
+    }
 
-	private LrgsConnectionPanel(LrgsConnectionPanelController controller, boolean showPause)
-	{
-		this.controller = controller;
-		setLayout(new FlowLayout(FlowLayout.LEFT, 5, 0));
+    private LrgsConnectionPanel(LrgsConnectionPanelController controller, boolean showPause)
+    {
+        this.controller = controller;
+        setLayout(new FlowLayout(FlowLayout.LEFT, 5, 0));
 
-		JPanel panel = new JPanel();
-		FlowLayout flowLayout = (FlowLayout) panel.getLayout();
-		flowLayout.setAlignment(FlowLayout.LEFT);
-		add(panel);
+        JPanel panel = new JPanel();
+        FlowLayout flowLayout = (FlowLayout) panel.getLayout();
+        flowLayout.setAlignment(FlowLayout.LEFT);
+        add(panel);
 
-		JLabel lblNewLabel = new JLabel(labels.getString("RtStatFrame.host")); //$NON-NLS-1$
-		lblNewLabel.setHorizontalAlignment(SwingConstants.LEFT);
-		panel.add(lblNewLabel);
-		lblNewLabel.setLabelFor(hostCombo);
+        JLabel lblNewLabel = new JLabel(labels.getString("RtStatFrame.host")); //$NON-NLS-1$
+        lblNewLabel.setHorizontalAlignment(SwingConstants.LEFT);
+        panel.add(lblNewLabel);
+        lblNewLabel.setLabelFor(hostCombo);
 
-		hostCombo = new JComboBox<>();
-		hostCombo.setName("hostCombo");
-		hostCombo.setMinimumSize(new Dimension(120, 24));
-		hostCombo.setAlignmentX(Component.LEFT_ALIGNMENT);
-		hostCombo.setEditable(true);
-		hostCombo.addActionListener(e -> changeConnection());
-		hostCombo.setRenderer(new ConnectionRender());
-		panel.add(hostCombo);
+        hostCombo = new JComboBox<>();
+        hostCombo.setName("hostCombo");
+        hostCombo.setMinimumSize(new Dimension(120, 24));
+        hostCombo.setAlignmentX(Component.LEFT_ALIGNMENT);
+        hostCombo.setEditable(true);
+        hostCombo.addActionListener(e -> changeConnection());
+        hostCombo.setRenderer(new ConnectionRender());
+        panel.add(hostCombo);
 
-		JPanel panel_1 = new JPanel();
-		add(panel_1);
+        JPanel panel_1 = new JPanel();
+        add(panel_1);
 
-		JLabel lblNewLabel_1 = new JLabel(labels.getString("RtStatFrame.port")); //$NON-NLS-1$
-		panel_1.add(lblNewLabel_1);
-		lblNewLabel_1.setLabelFor(portField);
+        JLabel lblNewLabel_1 = new JLabel(labels.getString("RtStatFrame.port")); //$NON-NLS-1$
+        panel_1.add(lblNewLabel_1);
+        lblNewLabel_1.setLabelFor(portField);
 
-		portField = new JTextField();
-		portField.setMaximumSize(new Dimension(32, 2147483647));
-		panel_1.add(portField);
-		portField.setText("16003");
-		portField.setColumns(10);
+        portField = new JTextField();
+        portField.setMaximumSize(new Dimension(32, 2147483647));
+        panel_1.add(portField);
+        portField.setText("16003");
+        portField.setColumns(10);
 
-		JPanel panel_2 = new JPanel();
-		add(panel_2);
+        JPanel panel_2 = new JPanel();
+        add(panel_2);
 
-		JLabel lblNewLabel_2 = new JLabel(labels.getString("RtStatFrame.user")); //$NON-NLS-1$
-		panel_2.add(lblNewLabel_2);
+        JLabel lblNewLabel_2 = new JLabel(labels.getString("RtStatFrame.user")); //$NON-NLS-1$
+        panel_2.add(lblNewLabel_2);
 
-		usernameField = new JTextField();
-		lblNewLabel_2.setLabelFor(usernameField);
-		panel_2.add(usernameField);
-		usernameField.setColumns(10);
+        usernameField = new JTextField();
+        lblNewLabel_2.setLabelFor(usernameField);
+        panel_2.add(usernameField);
+        usernameField.setColumns(10);
 
-		JPanel panel_3 = new JPanel();
-		add(panel_3);
+        JPanel panel_3 = new JPanel();
+        add(panel_3);
 
-		JLabel lblNewLabel_3 = new JLabel(labels.getString("RtStatFrame.password")); //$NON-NLS-1$
-		panel_3.add(lblNewLabel_3);
-		lblNewLabel_3.setLabelFor(passwordField);
+        JLabel lblNewLabel_3 = new JLabel(labels.getString("RtStatFrame.password")); //$NON-NLS-1$
+        panel_3.add(lblNewLabel_3);
+        lblNewLabel_3.setLabelFor(passwordField);
 
-		passwordField = new PasswordWithShow(GuiConstants.DEFAULT_PASSWORD_WITH);
-		panel_3.add(passwordField);
+        passwordField = new PasswordWithShow(GuiConstants.DEFAULT_PASSWORD_WITH);
+        panel_3.add(passwordField);
 
-		JPanel panel_4 = new JPanel();
-		add(panel_4);
+        JPanel panel_4 = new JPanel();
+        add(panel_4);
 
-		JButton connectButton = new JButton(labels.getString("RtStatFrame.connectButton")); //$NON-NLS-1$
-		connectButton.addActionListener(e -> connect());
-		panel_4.add(connectButton);
+        JButton connectButton = new JButton(labels.getString("RtStatFrame.connectButton")); //$NON-NLS-1$
+        connectButton.addActionListener(e -> connect());
+        panel_4.add(connectButton);
 
-		pausedButton = new JButton(labels.getString("RtStatFrame.pause")); //$NON-NLS-1$
-		pausedButton.addActionListener(e -> 
-		{
-			paused = !paused;
-			pause(paused);
-		});
-		panel_4.add(pausedButton);
-		pausedButton.setVisible(showPause);
+        pausedButton = new JButton(labels.getString("RtStatFrame.pause")); //$NON-NLS-1$
+        pausedButton.addActionListener(e -> 
+        {
+            paused = !paused;
+            pause(paused);
+        });
+        panel_4.add(pausedButton);
+        pausedButton.setVisible(showPause);
 
-		controller.setView(this);
+        controller.setView(this);
 
 
-		int minWidth = passwordField.getMinimumSize().width + lblNewLabel_3.getMinimumSize().width + 50;
-		this.setMinimumSize(new Dimension(minWidth, 40));
-	}
+        int minWidth = passwordField.getMinimumSize().width + lblNewLabel_3.getMinimumSize().width + 50;
+        this.setMinimumSize(new Dimension(minWidth, 40));
+    }
 
-	private void connect()
-	{
-		paused = false;
-		pause(false);
-		new SwingWorker<LrgsConnection, Void>()
-		{
-			// TODO. This should actually disable the button until the connection is finished.
-			@Override
-			protected LrgsConnection doInBackground() throws Exception
-			{
-				// Always build the connection from the fields, the user may have change a single setting.
-				LrgsConnection c = connectionFromFields();
-				if (controller.connect(c))
-				{
-					return c;
-				}
-				else
-				{
-					return null;
-				}
-			}
+    private void connect()
+    {
+        paused = false;
+        pause(false);
+        new SwingWorker<LrgsConnection, Void>()
+        {
+            // TODO. This should actually disable the button until the connection is finished.
+            @Override
+            protected LrgsConnection doInBackground() throws Exception
+            {
+                // Always build the connection from the fields, the user may have change a single setting.
+                LrgsConnection c = connectionFromFields();
+                if (controller.connect(c))
+                {
+                    return c;
+                }
+                else
+                {
+                    return null;
+                }
+            }
 
-			@Override
-			protected void done()
-			{
-				try
-				{
-					LrgsConnection c = get();
-					if (c != null)
-					{
-						((LrgsConnectionComboBoxModel)hostCombo.getModel())
-							.addOrReplaceConnection(new LrgsConnection(c, new Date()));
-					}
-				}
-				catch (InterruptedException | ExecutionException ex)
-				{
-					log.atError()
-					   .setCause(ex)
-					   .log("Unable to connect to LRGS.");
-					JOptionPane.showMessageDialog(LrgsConnectionPanel.this,
-												  "Unable to connect to LRGS.",
-												  "Error!",
-												  JOptionPane.ERROR_MESSAGE
-												  );
-				}
-			}
+            @Override
+            protected void done()
+            {
+                try
+                {
+                    LrgsConnection c = get();
+                    if (c != null)
+                    {
+                        ((LrgsConnectionComboBoxModel)hostCombo.getModel())
+                            .addOrReplaceConnection(new LrgsConnection(c, new Date()));
+                    }
+                }
+                catch (InterruptedException | ExecutionException ex)
+                {
+                    log.atError()
+                       .setCause(ex)
+                       .log("Unable to connect to LRGS.");
+                    JOptionPane.showMessageDialog(LrgsConnectionPanel.this,
+                                                  "Unable to connect to LRGS.",
+                                                  "Error!",
+                                                  JOptionPane.ERROR_MESSAGE
+                                                  );
+                }
+            }
 
-		}.execute();
+        }.execute();
 
-	}
+    }
 
-	private void changeConnection()
-	{
-		LrgsConnection c = (LrgsConnection)hostCombo.getSelectedItem();
-		if (c == null)
-		{
-			return;
-		}
+    private void changeConnection()
+    {
+        LrgsConnection c = (LrgsConnection)hostCombo.getSelectedItem();
+        if (c == null)
+        {
+            return;
+        }
         else if (c == LrgsConnection.BLANK)
-		{
-			portField.setText("16003");
-			usernameField.setText("");
-			passwordField.setText("");
-		}
-		else
-		{
-			portField.setText(""+c.getPort());
-			usernameField.setText(c.getUsername());
+        {
+            portField.setText("16003");
+            usernameField.setText("");
+            passwordField.setText("");
+        }
+        else
+        {
+            portField.setText(""+c.getPort());
+            usernameField.setText(c.getUsername());
 
-			String pw = LrgsConnection.decryptPassword(c, LrgsConnectionPanel.pwk);
-			passwordField.setText(pw);
-		}
-		new SwingWorker<Void,Void>()
-		{
+            String pw = LrgsConnection.decryptPassword(c, LrgsConnectionPanel.pwk);
+            passwordField.setText(pw);
+        }
+        new SwingWorker<Void,Void>()
+        {
 
-			@Override
-			protected Void doInBackground() throws Exception
-			{
-				controller.changeConnection(c);
-				return null;
-			}
-		}.execute();
-	}
+            @Override
+            protected Void doInBackground() throws Exception
+            {
+                controller.changeConnection(c);
+                return null;
+            }
+        }.execute();
+    }
 
-	private void pause(boolean pause)
-	{
-		if (paused)
-		{
-			pausedButton.setText(labels.getString("RtStatFrame.resume"));
-		}
-		else
-		{
-			pausedButton.setText(labels.getString("RtStatFrame.pause"));
-		}
-		this.controller.pause(paused);
-	}
+    private void pause(boolean pause)
+    {
+        if (paused)
+        {
+            pausedButton.setText(labels.getString("RtStatFrame.resume"));
+        }
+        else
+        {
+            pausedButton.setText(labels.getString("RtStatFrame.pause"));
+        }
+        this.controller.pause(paused);
+    }
 
-	public void setModel(LrgsConnectionComboBoxModel model)
-	{
-		this.hostCombo.setModel(model);
-	}
+    public void setModel(LrgsConnectionComboBoxModel model)
+    {
+        this.hostCombo.setModel(model);
+    }
 
-	public LrgsConnection getCurrentConnection()
-	{
-		return (LrgsConnection)hostCombo.getSelectedItem();
-	}
+    public LrgsConnection getCurrentConnection()
+    {
+        return (LrgsConnection)hostCombo.getSelectedItem();
+    }
 
-	public void onConnect(Function<LrgsConnection,Boolean> connectCallback)
-	{
-		this.controller.onConnect(connectCallback);
-	}
+    public void onConnect(Function<LrgsConnection,Boolean> connectCallback)
+    {
+        this.controller.onConnect(connectCallback);
+    }
 
-	public void onPause(Consumer<Boolean> onPause)
-	{
-		this.controller.onPause(onPause);
-	}
+    public void onPause(Consumer<Boolean> onPause)
+    {
+        this.controller.onPause(onPause);
+    }
 
-	private LrgsConnection connectionFromFields()
-	{
-		final String hostName = hostCombo.getEditor().getItem().toString().trim();
-		final int port = Integer.parseInt(portField.getText());
-		final String username = usernameField.getText();
-		final String password = LrgsConnection.encryptPassword(passwordField.getText(), LrgsConnectionPanel.pwk);
-		return new LrgsConnection(hostName, port, username, password, null);
-	}
+    private LrgsConnection connectionFromFields()
+    {
+        final String hostName = hostCombo.getEditor().getItem().toString().trim();
+        final int port = Integer.parseInt(portField.getText());
+        final String username = usernameField.getText();
+        final String password = LrgsConnection.encryptPassword(passwordField.getText(), LrgsConnectionPanel.pwk);
+        return new LrgsConnection(hostName, port, username, password, null);
+    }
 
-	public static class ConnectionRender extends JLabel implements ListCellRenderer<LrgsConnection>
-	{
+    public static class ConnectionRender extends JLabel implements ListCellRenderer<LrgsConnection>
+    {
 
-		@Override
-		public Component getListCellRendererComponent(JList<? extends LrgsConnection> list, LrgsConnection value,
-				int index, boolean isSelected, boolean cellHasFocus)
-		{
-			if (value == LrgsConnection.BLANK)
-			{
-				setText(" ");
-			}
-			else
-			{
-				setText(String.format("%s:%d (%s)", value.getHostName(), value.getPort(), value.getUsername()));
-			}
+        @Override
+        public Component getListCellRendererComponent(JList<? extends LrgsConnection> list, LrgsConnection value,
+                int index, boolean isSelected, boolean cellHasFocus)
+        {
+            if (value == LrgsConnection.BLANK)
+            {
+                setText(" ");
+            }
+            else
+            {
+                setText(String.format("%s:%d (%s)", value.getHostName(), value.getPort(), value.getUsername()));
+            }
 
-			return this;
-		}
+            return this;
+        }
 
-	}
+    }
 }

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
@@ -6,12 +6,13 @@ import javax.swing.JComboBox;
 import javax.swing.JTextField;
 import javax.swing.JLabel;
 import javax.swing.SwingConstants;
+import javax.swing.SwingWorker;
+
+import org.opendcs.gui.GuiConstants;
+import org.opendcs.gui.PasswordWithShow;
 
 import decodes.util.DecodesVersion;
-import ilex.util.AuthException;
-import ilex.util.DesEncrypter;
 import lrgs.gui.MessageBrowser;
-import lrgs.rtstat.RtStatFrame;
 
 import java.awt.Component;
 import java.awt.Dimension;
@@ -19,18 +20,18 @@ import javax.swing.JButton;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
-import java.awt.event.ActionListener;
-import java.awt.event.ActionEvent;
+import java.util.function.Consumer;
 
-public class LrgsConnectionPanel extends JPanel {
+public class LrgsConnectionPanel extends JPanel
+{
 	private static final ResourceBundle labels = ResourceBundle.getBundle("decodes.resources.rtstat", Locale.getDefault()); //$NON-NLS-1$
-	private static String pwk = MessageBrowser.class.toString() + 
+	public static String pwk = MessageBrowser.class.toString() +
 		(""+Math.PI).substring(3, 10) + DecodesVersion.class.toString();
 	private static final long serialVersionUID = 1L;
 	private JComboBox<LrgsConnection> hostCombo;
 	private JTextField portField;
 	private JTextField usernameField;
-	private JTextField passwordField;
+	private PasswordWithShow passwordField;
 
 	private final LrgsConnectionPanelController controller;
 
@@ -46,17 +47,17 @@ public class LrgsConnectionPanel extends JPanel {
 	{
 		this.controller = controller;
 		setLayout(new FlowLayout(FlowLayout.LEFT, 5, 0));
-		
+
 		JPanel panel = new JPanel();
 		FlowLayout flowLayout = (FlowLayout) panel.getLayout();
 		flowLayout.setAlignment(FlowLayout.LEFT);
 		add(panel);
-		
+
 		JLabel lblNewLabel = new JLabel(labels.getString("RtStatFrame.host")); //$NON-NLS-1$
 		lblNewLabel.setHorizontalAlignment(SwingConstants.LEFT);
 		panel.add(lblNewLabel);
 		lblNewLabel.setLabelFor(hostCombo);
-		
+
 		hostCombo = new JComboBox<>();
 		hostCombo.setName("hostCombo");
 		hostCombo.setMinimumSize(new Dimension(120, 24));
@@ -64,49 +65,63 @@ public class LrgsConnectionPanel extends JPanel {
 		hostCombo.setEditable(true);
 		hostCombo.addActionListener(e -> changeConnection());
 		panel.add(hostCombo);
-		
+
 		JPanel panel_1 = new JPanel();
 		add(panel_1);
-		
+
 		JLabel lblNewLabel_1 = new JLabel(labels.getString("RtStatFrame.port")); //$NON-NLS-1$
 		panel_1.add(lblNewLabel_1);
 		lblNewLabel_1.setLabelFor(portField);
-		
+
 		portField = new JTextField();
 		portField.setMaximumSize(new Dimension(32, 2147483647));
 		panel_1.add(portField);
 		portField.setText("16003");
 		portField.setColumns(10);
-		
+
 		JPanel panel_2 = new JPanel();
 		add(panel_2);
-		
+
 		JLabel lblNewLabel_2 = new JLabel(labels.getString("RtStatFrame.user")); //$NON-NLS-1$
 		panel_2.add(lblNewLabel_2);
-		
+
 		usernameField = new JTextField();
 		lblNewLabel_2.setLabelFor(usernameField);
 		panel_2.add(usernameField);
 		usernameField.setColumns(10);
-		
+
 		JPanel panel_3 = new JPanel();
 		add(panel_3);
-		
+
 		JLabel lblNewLabel_3 = new JLabel(labels.getString("RtStatFrame.password")); //$NON-NLS-1$
 		panel_3.add(lblNewLabel_3);
 		lblNewLabel_3.setLabelFor(passwordField);
-		
-		passwordField = new JTextField();
+
+		passwordField = new PasswordWithShow(GuiConstants.DEFAULT_PASSWORD_WITH);
 		panel_3.add(passwordField);
-		passwordField.setColumns(10);
-		
+
 		JPanel panel_4 = new JPanel();
 		add(panel_4);
-		
+
 		JButton connectButton = new JButton(labels.getString("RtStatFrame.connectButton")); //$NON-NLS-1$
-		connectButton.addActionListener(e -> controller.connect());		
+		connectButton.addActionListener(e ->
+		{
+			new SwingWorker<Void, Void>()
+			{
+				// TODO. This should actually disable the button until the connection is finished.
+				@Override
+				protected Void doInBackground() throws Exception
+				{
+					System.out.println("Calling connect function.");
+					controller.connect();
+					return null;
+				}
+
+			}.execute();
+
+		});
 		panel_4.add(connectButton);
-		
+
 		JButton pauseButton = new JButton(labels.getString("RtStatFrame.pause")); //$NON-NLS-1$
 		panel_4.add(pauseButton);
 
@@ -116,7 +131,11 @@ public class LrgsConnectionPanel extends JPanel {
 	private void changeConnection()
 	{
 		LrgsConnection c = (LrgsConnection)hostCombo.getSelectedItem();
-        if (c == LrgsConnection.BLANK)
+		if (c == null)
+		{
+			return;
+		}
+        else if (c == LrgsConnection.BLANK)
 		{
 			portField.setText("16003");
 			usernameField.setText("");
@@ -127,31 +146,43 @@ public class LrgsConnectionPanel extends JPanel {
 			portField.setText(""+c.getPort());
 			usernameField.setText(c.getUsername());
 
-			String pw = c.getPassword();
-			if (pw != null && !pw.isEmpty())
-			{		
-				try
-				{
-					DesEncrypter de = new DesEncrypter(pwk);
-					String dpw = de.decrypt(pw);
-					passwordField.setText(dpw);
-				}
-				catch (AuthException e)
-				{
-				}
-			}
-			else
-			{
-				passwordField.setText("");
-			}
+			String pw = LrgsConnection.decryptPassword(c, LrgsConnectionPanel.pwk);
+			passwordField.setText(pw);
 		}
-		controller.changeConnection(c);
+		new SwingWorker<Void,Void>()
+		{
+
+			@Override
+			protected Void doInBackground() throws Exception
+			{
+				controller.changeConnection(c);
+				return null;
+			}
+		}.execute();
 	}
 
 	public void setModel(LrgsConnectionComboBoxModel model)
 	{
 		this.hostCombo.setModel(model);
-		System.out.println(model.getSize());
+	}
+
+	public void onConnect(Consumer<LrgsConnection> connectCallback)
+	{
+		this.controller.onConnect(connectCallback);
+	}
+
+	public void addOrUpdateConnection(LrgsConnection newConnection)
+	{
+		((LrgsConnectionComboBoxModel)hostCombo.getModel()).addOrReplaceConnection(newConnection);
+	}
+
+	public LrgsConnection connectionFromFields()
+	{
+		final String hostName = (String)hostCombo.getEditor().getItem();
+		final int port = Integer.parseInt(portField.getText());
+		final String username = usernameField.getText();
+		final String password = LrgsConnection.encryptPassword(passwordField.getText(), LrgsConnectionPanel.pwk);
+		return new LrgsConnection(hostName, port, username, password, null);
 	}
 
 }

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
@@ -112,7 +112,6 @@ public class LrgsConnectionPanel extends JPanel
 				@Override
 				protected Void doInBackground() throws Exception
 				{
-					System.out.println("Calling connect function.");
 					controller.connect();
 					return null;
 				}

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
@@ -42,7 +42,9 @@ public final class LrgsConnectionPanel extends JPanel
 	private JComboBox<LrgsConnection> hostCombo;
 	private JTextField portField;
 	private JTextField usernameField;
+	private JButton pausedButton;
 	private PasswordWithShow passwordField;
+	private boolean paused = false;
 
 	private final LrgsConnectionPanelController controller;
 
@@ -124,9 +126,14 @@ public final class LrgsConnectionPanel extends JPanel
 		connectButton.addActionListener(e -> connect());
 		panel_4.add(connectButton);
 
-		JButton pauseButton = new JButton(labels.getString("RtStatFrame.pause")); //$NON-NLS-1$
-		panel_4.add(pauseButton);
-		pauseButton.setVisible(showPause);
+		pausedButton = new JButton(labels.getString("RtStatFrame.pause")); //$NON-NLS-1$
+		pausedButton.addActionListener(e -> 
+		{
+			paused = !paused;
+			pause(paused);
+		});
+		panel_4.add(pausedButton);
+		pausedButton.setVisible(showPause);
 
 		controller.setView(this);
 
@@ -137,6 +144,8 @@ public final class LrgsConnectionPanel extends JPanel
 
 	private void connect()
 	{
+		paused = false;
+		pause(false);
 		new SwingWorker<LrgsConnection, Void>()
 		{
 			// TODO. This should actually disable the button until the connection is finished.
@@ -145,7 +154,7 @@ public final class LrgsConnectionPanel extends JPanel
 			{
 				// Always build the connection from the fields, the user may have change a single setting.
 				LrgsConnection c = connectionFromFields();
-				if(controller.connect(c))
+				if (controller.connect(c))
 				{
 					return c;
 				}
@@ -217,9 +226,17 @@ public final class LrgsConnectionPanel extends JPanel
 		}.execute();
 	}
 
-	private void pause()
+	private void pause(boolean pause)
 	{
-		this.controller.pause((LrgsConnection)hostCombo.getSelectedItem());
+		if (paused)
+		{
+			pausedButton.setText(labels.getString("RtStatFrame.resume"));
+		}
+		else
+		{
+			pausedButton.setText(labels.getString("RtStatFrame.pause"));
+		}
+		this.controller.pause(paused);
 	}
 
 	public void setModel(LrgsConnectionComboBoxModel model)
@@ -237,7 +254,7 @@ public final class LrgsConnectionPanel extends JPanel
 		this.controller.onConnect(connectCallback);
 	}
 
-	public void onPause(Consumer<LrgsConnection> onPause)
+	public void onPause(Consumer<Boolean> onPause)
 	{
 		this.controller.onPause(onPause);
 	}

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
@@ -9,29 +9,43 @@ import lrgs.ldds.LddsClient;
 public class LrgsConnectionPanelController {
 
     private LrgsConnectionPanel view;
-    private LrgsConnection selectedConnection;
+    private LrgsConnection selectedConnection = LrgsConnection.BLANK;
     private LrgsConnectionComboBoxModel model = new LrgsConnectionComboBoxModel(new File(LddsClient.getLddsConnectionsFile()));
 
     /** Defaults do nothing. */
-    private Consumer<LrgsConnection> connectionCallBack = c -> {};
-    private BiConsumer<LrgsConnection, LrgsConnection> connectionChangedCallback = (old,c) -> {};
+    private Consumer<LrgsConnection> connectionCallBack = c -> {System.out.println("Connecting.");};
+    private BiConsumer<LrgsConnection, LrgsConnection> connectionChangedCallback = (old,c) -> {System.out.println("changing connection.");};
 
     public void setView(LrgsConnectionPanel lrgsConnectionPanel)
     {
         this.view = lrgsConnectionPanel;
         view.setModel(model);
+        model.setSelectedItem(LrgsConnection.BLANK);
     }
 
     public void connect()
     {
-        connectionCallBack.accept(selectedConnection);
+        if (selectedConnection != LrgsConnection.BLANK)
+        {
+            System.out.println("Calling defined connection.");
+            connectionCallBack.accept(selectedConnection);
+        }
+        else
+        {
+            System.out.println("Connection from fields.");
+            connectionCallBack.accept(view.connectionFromFields());
+        }
     }
 
     public void changeConnection(LrgsConnection c)
-    {        
+    {
         LrgsConnection oldConnection = selectedConnection;
         selectedConnection = c;
         connectionChangedCallback.accept(oldConnection, c);
-        model.addOrReplaceConnection(c);
+    }
+
+    public void onConnect(Consumer<LrgsConnection> connectCallback)
+    {
+        this.connectionCallBack = connectCallback;
     }
 }

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
@@ -20,7 +20,7 @@ public class LrgsConnectionPanelController
     /** Defaults do nothing. */
     private Function<LrgsConnection,Boolean> connectionCallBack = c -> {return false;};
     private BiConsumer<LrgsConnection, LrgsConnection> connectionChangedCallback = (old,c) -> {};
-    private Consumer<LrgsConnection> pauseCallBack = c -> {};
+    private Consumer<Boolean> pauseCallBack = c -> {};
 
     public void setView(LrgsConnectionPanel lrgsConnectionPanel)
     {
@@ -46,13 +46,13 @@ public class LrgsConnectionPanelController
         this.connectionCallBack = connectCallback;
     }
 
-    public void onPause(Consumer<LrgsConnection> onPause)
+    public void onPause(Consumer<Boolean> onPause)
     {
         this.pauseCallBack = onPause;
     }
 
-    public void pause(LrgsConnection c)
+    public void pause(boolean paused)
     {
-        this.pauseCallBack.accept(c);
+        this.pauseCallBack.accept(paused);
     }
 }

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
@@ -13,8 +13,8 @@ public class LrgsConnectionPanelController {
     private LrgsConnectionComboBoxModel model = new LrgsConnectionComboBoxModel(new File(LddsClient.getLddsConnectionsFile()));
 
     /** Defaults do nothing. */
-    private Consumer<LrgsConnection> connectionCallBack = c -> {System.out.println("Connecting.");};
-    private BiConsumer<LrgsConnection, LrgsConnection> connectionChangedCallback = (old,c) -> {System.out.println("changing connection.");};
+    private Consumer<LrgsConnection> connectionCallBack = c -> {};
+    private BiConsumer<LrgsConnection, LrgsConnection> connectionChangedCallback = (old,c) -> {};
 
     public void setView(LrgsConnectionPanel lrgsConnectionPanel)
     {
@@ -27,12 +27,10 @@ public class LrgsConnectionPanelController {
     {
         if (selectedConnection != LrgsConnection.BLANK)
         {
-            System.out.println("Calling defined connection.");
             connectionCallBack.accept(selectedConnection);
         }
         else
         {
-            System.out.println("Connection from fields.");
             connectionCallBack.accept(view.connectionFromFields());
         }
     }

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
@@ -1,0 +1,37 @@
+package lrgs.rtstat.hosts;
+
+import java.io.File;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import lrgs.ldds.LddsClient;
+
+public class LrgsConnectionPanelController {
+
+    private LrgsConnectionPanel view;
+    private LrgsConnection selectedConnection;
+    private LrgsConnectionComboBoxModel model = new LrgsConnectionComboBoxModel(new File(LddsClient.getLddsConnectionsFile()));
+
+    /** Defaults do nothing. */
+    private Consumer<LrgsConnection> connectionCallBack = c -> {};
+    private BiConsumer<LrgsConnection, LrgsConnection> connectionChangedCallback = (old,c) -> {};
+
+    public void setView(LrgsConnectionPanel lrgsConnectionPanel)
+    {
+        this.view = lrgsConnectionPanel;
+        view.setModel(model);
+    }
+
+    public void connect()
+    {
+        connectionCallBack.accept(selectedConnection);
+    }
+
+    public void changeConnection(LrgsConnection c)
+    {        
+        LrgsConnection oldConnection = selectedConnection;
+        selectedConnection = c;
+        connectionChangedCallback.accept(oldConnection, c);
+        model.addOrReplaceConnection(c);
+    }
+}

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
@@ -20,6 +20,7 @@ public class LrgsConnectionPanelController
     /** Defaults do nothing. */
     private Function<LrgsConnection,Boolean> connectionCallBack = c -> {return false;};
     private BiConsumer<LrgsConnection, LrgsConnection> connectionChangedCallback = (old,c) -> {};
+    private Consumer<LrgsConnection> pauseCallBack = c -> {};
 
     public void setView(LrgsConnectionPanel lrgsConnectionPanel)
     {
@@ -43,5 +44,15 @@ public class LrgsConnectionPanelController
     public void onConnect(Function<LrgsConnection,Boolean> connectCallback)
     {
         this.connectionCallBack = connectCallback;
+    }
+
+    public void onPause(Consumer<LrgsConnection> onPause)
+    {
+        this.pauseCallBack = onPause;
+    }
+
+    public void pause(LrgsConnection c)
+    {
+        this.pauseCallBack.accept(c);
     }
 }

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
@@ -3,17 +3,22 @@ package lrgs.rtstat.hosts;
 import java.io.File;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import lrgs.ldds.LddsClient;
 
-public class LrgsConnectionPanelController {
-
+public class LrgsConnectionPanelController
+{
+    private static final Logger log = LoggerFactory.getLogger(LrgsConnectionPanelController.class);
     private LrgsConnectionPanel view;
     private LrgsConnection selectedConnection = LrgsConnection.BLANK;
     private LrgsConnectionComboBoxModel model = new LrgsConnectionComboBoxModel(new File(LddsClient.getLddsConnectionsFile()));
 
     /** Defaults do nothing. */
-    private Consumer<LrgsConnection> connectionCallBack = c -> {};
+    private Function<LrgsConnection,Boolean> connectionCallBack = c -> {return false;};
     private BiConsumer<LrgsConnection, LrgsConnection> connectionChangedCallback = (old,c) -> {};
 
     public void setView(LrgsConnectionPanel lrgsConnectionPanel)
@@ -23,16 +28,9 @@ public class LrgsConnectionPanelController {
         model.setSelectedItem(LrgsConnection.BLANK);
     }
 
-    public void connect()
+    public boolean connect(LrgsConnection c)
     {
-        if (selectedConnection != LrgsConnection.BLANK)
-        {
-            connectionCallBack.accept(selectedConnection);
-        }
-        else
-        {
-            connectionCallBack.accept(view.connectionFromFields());
-        }
+        return connectionCallBack.apply(c);
     }
 
     public void changeConnection(LrgsConnection c)
@@ -42,7 +40,7 @@ public class LrgsConnectionPanelController {
         connectionChangedCallback.accept(oldConnection, c);
     }
 
-    public void onConnect(Consumer<LrgsConnection> connectCallback)
+    public void onConnect(Function<LrgsConnection,Boolean> connectCallback)
     {
         this.connectionCallBack = connectCallback;
     }


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #638. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Clear hostCombo list before elements added.

Future work should create an LrgsConnection object and use a proper model. Also it shouldn't need to constantly reload the file every time the connection changes. That's usually small so I'm not worried about it right now but there's room for improvement.

## how you tested the change

Opened RtStat on system with multiple connections, connected, selected other hosts. Saw that combo box contents stayed static.
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
