### PR TITLE
Refactor/241 remove lobobrowser AND fix classpath issues

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -409,24 +409,12 @@ more information about each.
                 <include name="opendcs-annotations.jar"/>
             </fileset>
             <mappedresources enablemultiplemappings="false">
-                <!-- tweak to load at end as LoboBrowser here is including it's own jooq libaries for some reason breaking CWMS use-->
                 <restrict>
                     <path refid="runtime.classpath"/>
                     <type type="file"/>
                 </restrict>
                 <chainedmapper>
                     <flattenmapper/>
-                    <regexpmapper from="^(Cobra-1.0.2.jar|LoboBrowser-1.0.0.jar)" to="zzz\1"/>
-                </chainedmapper>
-            </mappedresources>
-            <mappedresources enablemultiplemappings="false">
-                <restrict>
-                    <path refid="runtime.classpath"/>
-                    <type type="file"/>
-                </restrict>
-                <chainedmapper>
-                    <flattenmapper/>
-                    <regexpmapper from="^(?!Cobra-1.0.2.jar|LoboBrowser-1.0.0.jar)(.*)" to="\1"/>
                 </chainedmapper>
             </mappedresources>
         </copy>
@@ -533,22 +521,7 @@ more information about each.
             <fileset dir="${project.dir}/python"/>
         </copy>
     </target>
-    <!-- same as package, but remove libraries not needed by USACE or USBR -->
-    <target name="nonfed" depends="stage">
-        <delete file="stage/dep/jep-2.4.1.jar"/>
-        <delete file="stage/dep/jython-2.7.2.jar"/>
-        <delete file="stage/dep/xmlparserv2-12.1.0.2.jar"/>
-        <delete file="stage/dep/Cobra.jar"/>
-        <!-- Invokes izpack to build installable package with defaults for CWMS -->
-        <izpack input="${project.dir}/izpack/opendcs-install.xml"
-                output="stage/opendcs-nf-${version}.jar"
-                installerType="standard"
-                basedir="stage"
-                izPackDir="${izpack.dir}">
-            <property name="version" value="${version}"/>
-            <property name="hdb.preselect" value="no"/>
-        </izpack>
-    </target>
+
     <!-- same as nonfed, but includes OpenTSDB and computation files -->
     <target name="opendcs" depends="stage,common.izpack.dependencies">
         <!-- Invokes izpack to build installable package with defaults for CWMS -->

--- a/install/bin/decj
+++ b/install/bin/decj
@@ -40,8 +40,8 @@ fi
 export DCSTOOL_USERDIR
 
 if [ ! -d "$DCSTOOL_USERDIR" ]; then
-    echo "Creating Local User Directory and initial properties in ${DCSTOOL_USERDIR}"
-    echo "The default XML database has been copied to this directory."
+    echo "Creating Local User Directory and initial properties in ${DCSTOOL_USERDIR}" 1>&2
+    echo "The default XML database has been copied to this directory." 1>&2
     mkdir -p $DCSTOOL_USERDIR
     cp $DH/decodes.properties $DCSTOOL_USERDIR/user.properties
     cp -r $DH/edit-db $DCSTOOL_USERDIR/edit-db
@@ -52,7 +52,17 @@ CP=$DH/bin/opendcs.jar:
 
 # If a user-specific 'dep' (dependencies) directory exists, then
 # add all the jars therein to the classpath.
-CP=$CP:$DCSTOOL_USERDIR/*:$DH/dep/*
+if [ -d "$CP_SHARED_JAR_DIR"]; then
+  CP=$CP:$CP_SHARED_JAR_DIR/*
+  echo "The need of this is superseded by using a DCSTOOL_USERDIR for configuration." 1>&2
+  echo "Support for this variable will be moved in a future release. Please update " 1>&2
+  echo "your configuration." 1>&2
+fi
+
+if [ -d "$DCSTOOL_USERDIR/dep" ]; then
+  CP=$CP:$DCSTOOL_USERDIR/dep/*
+fi
+CP=$CP:$DH/dep/*
 
 cmd="java -Xms120m $DECJ_MAXHEAP $DECJ_OPTS -cp $CP -DDCSTOOL_HOME=$DH -DDECODES_INSTALL_DIR=$DH -DDCSTOOL_USERDIR=$DCSTOOL_USERDIR"
 

--- a/install/bin/decj
+++ b/install/bin/decj
@@ -16,7 +16,7 @@ if [ -z "$DCSTOOL_HOME" ]
 then
   DCSTOOL_HOME=$DH
   export DCSTOOL_HOME
-elif [ "$DH" != "$DCSTOOL_HOME" ]
+elif [ "$DH" != "$(realpath ${DCSTOOL_HOME})" ]
 then
   echo "Environment has set a different DCSTOOL_HOME than the location of the application start script."
   echo "Environment $DCSTOOL_HOME"
@@ -50,43 +50,9 @@ fi
 # Build classpath
 CP=$DH/bin/opendcs.jar:
 
-# # For CWMS Installations, add the HEC and RMA Jars.
-# if [ -n "$CWMS_JAR_DIR" -a -d "$CWMS_JAR_DIR" ]
-# then
-#   CP=$CP:$CWMS_JAR_DIR/hec.jar:$CWMS_JAR_DIR/hecData.jar:$CWMS_JAR_DIR/heclib.jar:$CWMS_JAR_DIR/rma.jar:$CWMS_JAR_DIR/lookup.jar
-# fi
-# if [ -n "$CWMS_SYSJAR_DIR" -a -d "$CWMS_SYSJAR_DIR" ]
-# then
-#   CP=$CP:$CWMS_SYSJAR_DIR/jdom.jar:$CWMS_SYSJAR_DIR/jdom-1.0.jar
-# fi
-
-
-if [ ! -z "$CP_SHARED_JAR_DIR" -a -d "$CP_SHARED_JAR_DIR" ]
-then
-  for f in $CP_SHARED_JAR_DIR/*.jar
-  do
-    CP=$CP:$f
-  done
-fi
-
 # If a user-specific 'dep' (dependencies) directory exists, then
 # add all the jars therein to the classpath.
-if [ -d "$DCSTOOL_USERDIR/dep" ]
-then
-  for f in $DCSTOOL_USERDIR/dep/*.jar
-  do
-    CP=$CP:$f
-  done
-fi
-
-# Add the OpenDCS standard 3rd party jars to the classpath
-if [ "$DCSTOOL_USERDIR" != "$DH" ]
-then
- for f in `ls $DH/dep/*.jar | sort`
- do
-   CP=$CP:$f
- done
-fi
+CP=$CP:$DCSTOOL_USERDIR/*:$DH/dep/*
 
 cmd="java -Xms120m $DECJ_MAXHEAP $DECJ_OPTS -cp $CP -DDCSTOOL_HOME=$DH -DDECODES_INSTALL_DIR=$DH -DDCSTOOL_USERDIR=$DCSTOOL_USERDIR"
 

--- a/install/bin/decj.bat
+++ b/install/bin/decj.bat
@@ -7,13 +7,12 @@ pushd "%BIN_PATH%.."
 set "APP_PATH=%CD%"
 popd
 
-set "CLASSPATH=%BIN_PATH%opendcs.jar;%BIN_PATH%hibernate.cfg.xml;%APP_PATH%/dep/*"
-
+set "CLASSPATH=%BIN_PATH%opendcs.jar;%BIN_PATH%hibernate.cfg.xml"
 
 set "CLASSPATH=!CLASSPATH!"
 
 if not defined DCSTOOL_USERDIR (
-  set DCSTOOL_USERDIR="%APPDATA%\.opendcs"
+  set "DCSTOOL_USERDIR=%APPDATA%\.opendcs"
 )
 
 if not exist %DCSTOOL_USERDIR%\ (
@@ -23,9 +22,9 @@ if not exist %DCSTOOL_USERDIR%\ (
   copy %APP_PATH%\decodes.properties %DCSTOOL_USERDIR%\user.properties
   xcopy %APP_PATH%\edit-db %DCSTOOL_USERDIR%\edit-db /E /I
 )
-REM Use short name as the classpath has gotten beyond the windows environment variable support
-if exists %DCSTOOL_USERDIR%/dep/ do (
-  set "CLASSPATH=!CLASSPATH!;%DCSTOOL_USERDIR%/dep"
+
+if exist "%DCSTOOL_USERDIR%/dep\" do (
+  set "CLASSPATH=!CLASSPATH!;%DCSTOOL_USERDIR%/dep/*;%APP_PATH%/dep/*"
   )
 
 java -Xmx240m %DECJ_MAXHEAP% %DECJ_OPTS% -cp "!CLASSPATH!" -DDCSTOOL_HOME="%APP_PATH%" -DDECODES_INSTALL_DIR="%APP_PATH%" -DDCSTOOL_USERDIR="%DCSTOOL_USERDIR%" %*%

--- a/install/bin/decj.bat
+++ b/install/bin/decj.bat
@@ -16,15 +16,24 @@ if not defined DCSTOOL_USERDIR (
 )
 
 if not exist %DCSTOOL_USERDIR%\ (
-  echo "Creating Local User Directory and initial properties in %DCSTOOL_USERDIR%"
-  echo "The default XML database has been copied to this directory."
+  echo "Creating Local User Directory and initial properties in %DCSTOOL_USERDIR%" 1>&2
+  echo "The default XML database has been copied to this directory." 1>&2
   mkdir %DCSTOOL_USERDIR%
   copy %APP_PATH%\decodes.properties %DCSTOOL_USERDIR%\user.properties
   xcopy %APP_PATH%\edit-db %DCSTOOL_USERDIR%\edit-db /E /I
 )
 
+if exist "%CP_SHARED_JAR_DIR" do (
+  set "CLASSPATH=!CLASSPATH!;%CP_SHARED_JAR_DIR/*"
+  echo "The need of this is superseded by using a DCSTOOL_USERDIR for configuration." 1>&2
+  echo "Support for this variable will be moved in a future release. Please update " 1>&2
+  echo "your configuration." 1>&2
+)
+
 if exist "%DCSTOOL_USERDIR%/dep\" do (
-  set "CLASSPATH=!CLASSPATH!;%DCSTOOL_USERDIR%/dep/*;%APP_PATH%/dep/*"
+  set "CLASSPATH=!CLASSPATH!;%DCSTOOL_USERDIR%/dep/*"
   )
+
+set "CLASSPATH=!CLASSPATH!;%APP_PATH%/dep/*"
 
 java -Xmx240m %DECJ_MAXHEAP% %DECJ_OPTS% -cp "!CLASSPATH!" -DDCSTOOL_HOME="%APP_PATH%" -DDECODES_INSTALL_DIR="%APP_PATH%" -DDCSTOOL_USERDIR="%DCSTOOL_USERDIR%" %*%

--- a/install/bin/decj.bat
+++ b/install/bin/decj.bat
@@ -7,17 +7,8 @@ pushd "%BIN_PATH%.."
 set "APP_PATH=%CD%"
 popd
 
-set "CLASSPATH=%BIN_PATH%opendcs.jar;%BIN_PATH%hibernate.cfg.xml;"
+set "CLASSPATH=%BIN_PATH%opendcs.jar;%BIN_PATH%hibernate.cfg.xml;%APP_PATH%/dep/*"
 
-if defined CP_SHARED_JAR_DIR (
- for /R "%CP_SHARED_JAR_DIR%" %%a in (*.jar) do (
-   set "CLASSPATH=!CLASSPATH!;%%sa"
- )
-)
-REM Use short name as the classpath has gotten beyond the windows environment variable support
-for /R "%APP_PATH%/dep" %%a in (*.jar) do (
-  set "CLASSPATH=!CLASSPATH!;%%a"
-  )
 
 set "CLASSPATH=!CLASSPATH!"
 
@@ -33,8 +24,8 @@ if not exist %DCSTOOL_USERDIR%\ (
   xcopy %APP_PATH%\edit-db %DCSTOOL_USERDIR%\edit-db /E /I
 )
 REM Use short name as the classpath has gotten beyond the windows environment variable support
-for /R "%DCSTOOL_USERDIR%/dep" %%a in (*.jar) do (
-  set "CLASSPATH=!CLASSPATH!;%%sa"
+if exists %DCSTOOL_USERDIR%/dep/ do (
+  set "CLASSPATH=!CLASSPATH!;%DCSTOOL_USERDIR%/dep"
   )
 
 java -Xmx240m %DECJ_MAXHEAP% %DECJ_OPTS% -cp "!CLASSPATH!" -DDCSTOOL_HOME="%APP_PATH%" -DDECODES_INSTALL_DIR="%APP_PATH%" -DDCSTOOL_USERDIR="%DCSTOOL_USERDIR%" %*%

--- a/ivy.xml
+++ b/ivy.xml
@@ -38,8 +38,6 @@
         <dependency org="jfree" name="jcommon" rev="1.0.12"/>
         <dependency org="jfree" name="jfreechart" rev="1.0.13"/>
         <dependency org="org.python" name="jython-standalone" rev="2.7.3"/>
-        <dependency org="org.lobobrowser" name="LoboBrowser" rev="1.0.0" conf="runtime_last->default"/>
-        <dependency org="lobobrowser" name="Cobra" rev="1.0.2" conf="runtime_last->default"/>
         <dependency org="org.scijava" name="jep" rev="2.4.1">
             <exclude org="jama" module="jama"/>
         </dependency>

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -26,10 +26,6 @@
         <chain name="default" returnFirst="true" checkmodified="true" changingPattern=".*SNAPSHOT">
             <ibiblio name="central-https" m2compatible="true" root="https://repo1.maven.org/maven2/" usepoms="true"/>
             <ibiblio name="hec" m2compatible="true" root="https://www.hec.usace.army.mil/nexus/repository/maven-public"/>
-            <url name="github" m2compatible="false">
-                <!-- https://github.com/lobobrowser/Cobra/releases/download/1.0.2/Cobra.jar -->
-                <artifact pattern="https://github.com/[organisation]/[module]/releases/download/[revision]/[artifact].[ext]"/>
-            </url>
         </chain>
     </resolvers>
     <module>

--- a/src/main/java/decodes/datasource/WebDirectoryDataSource.java
+++ b/src/main/java/decodes/datasource/WebDirectoryDataSource.java
@@ -43,6 +43,12 @@ import ilex.var.Variable;
  * Provide a directory URL with embedded times in it. Build the URL and list the files
  * contained in the directory. Parse the file names for mediumIDs I'm interested in.
  * File names also contain the message time stamp.
+ * 
+ * https://dd.weather.gc.ca/bulletins/alphanumeric/20240326/CA/CWAO/00/ was used to verify behavior
+ * of this source as best as possible. We suspect the agency has changed the directory structure of 
+ * the data and we are not currently aware of expectation. Please contact the OpenDCS team if you 
+ * need this working and can communicate the current expectations whether it's for the above link
+ * or another source of data following a similar design.
  */
 public class WebDirectoryDataSource extends DataSourceExec
 {


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #241. 
Fixes issue with large classpaths by using wild card class path for the two directories.
Fixes issue with determined vs set DCSTOOL_HOME on POSIX system reporting an a different when there really isn't one.

## Solution

Moved block in WebDirectoryDataSource to use simple regex match to find link, verify that at least for my understanding the behavior is correct (I think the original DataSource folder structure has changed.)
Used wildcard classpaths.
Compared determined "realpath" to determine if environment setup is questionable.

Removed LoboBrowser and Cobra dependencies and references thereto.

## how you tested the change
On windows/linux

Verified applications could run from ant run task, shell/cmd, or double clicking the .bat file in windows.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
