### PR TITLE
Bugfix/database access behavior

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -822,7 +822,13 @@ more information about each.
             <isset property="opendcs.lang"/>
         </condition>
 
-        <property name="decj_opts" value="${debugOpts} ${jfrOpts} ${lang}"/>
+        <condition property="extra_opts"
+                  value="${opendcs.app.decj}"
+                  else="">
+            <isset property="opendcs.app.decj"/>
+        </condition>
+
+        <property name="decj_opts" value="${debugOpts} ${jfrOpts} ${lang} ${extra_opts}"/>
         <echo message="with opts: ${decj_opts}"/>
 
         <exec executable="${stage.dir}/bin/${opendcs.app}" osfamily="unix">
@@ -832,6 +838,7 @@ more information about each.
             <arg value="-l"/><arg value="/dev/stdout"/>
             <arg if:set="opendcs.profile" value="-P"/>
             <arg if:set="opendcs.profile" value="${opendcs.profile}"/>
+            <arg if:set="opendcs.arg" value="${opendcs.arg}"/>
             <env key="DECJ_OPTS" value="${decj_opts}"/>
         </exec>
         <exec executable="${stage.absolute.dir}/bin/${opendcs.app}.bat" osfamily="windows" vmlauncher="false">
@@ -841,6 +848,7 @@ more information about each.
             <arg value="-l"/><arg value="CON:"/>
             <arg if:set="opendcs.profile" value="-P"/>
             <arg if:set="opendcs.profile" value="${opendcs.profile}"/>
+            <arg if:set="opendcs.arg" value="${opendcs.arg}"/>
             <env key="DECJ_OPTS" value="${decj_opts}"/>
         </exec>
     </target>

--- a/src/main/java/decodes/datasource/DataSourceException.java
+++ b/src/main/java/decodes/datasource/DataSourceException.java
@@ -32,5 +32,9 @@ public class DataSourceException extends DecodesException
 	{
 		super(msg);
 	}
-}
 
+	public DataSourceException(String msg, Throwable cause)
+	{
+		super(msg, cause);
+	}
+}

--- a/src/main/java/decodes/datasource/WebAbstractDataSource.java
+++ b/src/main/java/decodes/datasource/WebAbstractDataSource.java
@@ -10,6 +10,8 @@ import java.util.Properties;
 import java.util.TimeZone;
 import java.util.Vector;
 
+import org.slf4j.LoggerFactory;
+
 import ilex.util.EnvExpander;
 import ilex.util.IDateFormat;
 import ilex.util.Logger;
@@ -31,9 +33,9 @@ import decodes.util.PropertySpec;
  * Properties:
  * 	abstractUrl - The URL containing $MEDIUMID or ${MEDIUMID} variable.
  */
-public class WebAbstractDataSource
-	extends DataSourceExec
+public class WebAbstractDataSource extends DataSourceExec
 {
+	private static final org.slf4j.Logger log = LoggerFactory.getLogger(WebAbstractDataSource.class);
 	private String module = "WebAbstractDataSource";
 	
 	// aggregate list of IDs from all network lists.
@@ -182,7 +184,7 @@ public class WebAbstractDataSource
 		catch(InvalidDatabaseException ex) 
 		{
 			log(Logger.E_INFORMATION, module + " " + ex);
-			throw new DataSourceException(module + " " + ex);
+			throw new DataSourceException(module + " " + ex, ex);
 		}
 	}
 	
@@ -217,19 +219,11 @@ public class WebAbstractDataSource
 				currentWebDs.init(myProps, rsSince, rsUntil, null);
 				return currentWebDs.getRawMessage();
 			}
-			catch(DataSourceException ex)
-			{
-				String msg = module + " cannot open '"
-					+ url + "': " + ex;
-				log(Logger.E_WARNING, msg);
-			}
 			catch(Exception ex)
 			{
-				String msg = module + " cannot open '"
-					+ url + "': " + ex;
-				log(Logger.E_WARNING, msg);
-				System.err.println(msg);
-				ex.printStackTrace(System.err);
+				log.atWarn()
+				   .setCause(ex)
+				   .log("Cannot open URL '{}'");
 			}
 		}
 		// No more medium IDs

--- a/src/main/java/decodes/dbeditor/RoutingSpecListPanel.java
+++ b/src/main/java/decodes/dbeditor/RoutingSpecListPanel.java
@@ -5,6 +5,9 @@ package decodes.dbeditor;
 
 import java.awt.*;
 import javax.swing.*;
+
+import org.slf4j.LoggerFactory;
+
 import java.util.ResourceBundle;
 
 import lrgs.gui.DecodesInterface;
@@ -21,6 +24,7 @@ import decodes.db.RoutingSpec;
 @SuppressWarnings("serial")
 public class RoutingSpecListPanel extends JPanel implements ListOpsController
 {
+	private static final org.slf4j.Logger log = LoggerFactory.getLogger(RoutingSpecListPanel.class);
 	static ResourceBundle genericLabels = DbEditorFrame.getGenericLabels();
 	static ResourceBundle dbeditLabels = DbEditorFrame.getDbeditLabels();
 	private ListOpsPanel listOpsPanel = new ListOpsPanel(this);
@@ -190,6 +194,9 @@ public class RoutingSpecListPanel extends JPanel implements ListOpsController
 			try { Database.getDb().getDbIo().deleteRoutingSpec(ob); }
 			catch(DatabaseException e)
 			{
+				log.atError()
+				   .setCause(e)
+				   .log("Unable to delete routing spec.");
 				DbEditorFrame.instance().showError(
 					RoutingSpecListPanel.dbeditLabels.getString("RoutingSpecListPanel.errorDelete")
 					+ e.toString());

--- a/src/main/java/decodes/dbeditor/ScheduleListPanel.java
+++ b/src/main/java/decodes/dbeditor/ScheduleListPanel.java
@@ -352,15 +352,13 @@ class ScheduleEntryTableModel extends AbstractTableModel implements
 
 	void refill() 
 	{
-		ScheduleEntryDAI scheduleEntryDAO = Database.getDb().getDbIo().makeScheduleEntryDAO();
-		if (scheduleEntryDAO == null)
+		try (ScheduleEntryDAI scheduleEntryDAO = Database.getDb().getDbIo().makeScheduleEntryDAO())
 		{
-			Logger.instance().debug1("Cannot write schedule entries. Not supported on this database.");
-			return;
-		}
-
-		try
-		{
+			if (scheduleEntryDAO == null)
+			{
+				Logger.instance().debug1("Cannot write schedule entries. Not supported on this database.");
+				return;
+			}
 			theList.clear();
 			ArrayList<ScheduleEntry> sea = scheduleEntryDAO.listScheduleEntries(null);
 			for(Iterator<ScheduleEntry> seit = sea.iterator(); seit.hasNext(); )
@@ -378,10 +376,6 @@ class ScheduleEntryTableModel extends AbstractTableModel implements
 				LoadResourceBundle.sprintf(
 					dbeditLabels.getString("ScheduleEntryPanel.CannotLoadError"),
 						dbeditLabels.getString("ScheduleEntryPanel.EntityName"), ex));
-		}
-		finally
-		{
-			scheduleEntryDAO.close();
 		}
 	}
 

--- a/src/main/java/opendcs/dao/ScheduleEntryDAO.java
+++ b/src/main/java/opendcs/dao/ScheduleEntryDAO.java
@@ -156,8 +156,8 @@ public class ScheduleEntryDAO extends DaoBase implements ScheduleEntryDAI
 			{
 				try (LoadingAppDAI loadingAppDAO = db.makeLoadingAppDAO())
 				{
+                    loadingAppDAO.inTransactionOf(dao);
 					final ArrayList<CompAppInfo> appInfos = loadingAppDAO.listComputationApps(false);
-					loadingAppDAO.inTransactionOf(dao);
 					dao.doQuery(q.toString(), rs ->
 					{
 						ScheduleEntry se = new ScheduleEntry(DbKey.createDbKey(rs, 1));


### PR DESCRIPTION
## Problem Description

Describe the problem you are trying to solve.

A user testing 7.0.13-RC05 was having their routing scheduler fail within a few minutes. While trying to cleanup my test environment I was able to delete more than 4-5 Routing Specs, the primary cause was in the listScheduledEntries code were it did not correctly put the dao in a transaction before a secondary query to the task.

## Solution

- made it possible to enable the trace setting using the run task
- Cleaned up the delete method for rating spec to use transactions and bind variables
- Moved the inTransctionOf line above the usage of a dao in ScheduledEntryDao

## how you tested the change

Local environment for delete, was able to delete an infinite number and verify with the ConnectionPoolMxBean that connection were not left open.

Waiting on feedback from user who's Routing Scheduler failed quickly, likely tomorrow morning.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
