### PR TITLE
Correct Host combo behavior when switching LRGS in combo box.

### DIFF
--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionComboBoxModel.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionComboBoxModel.java
@@ -1,13 +1,9 @@
 package lrgs.rtstat.hosts;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -110,8 +106,8 @@ public class LrgsConnectionComboBoxModel extends AbstractListModel<LrgsConnectio
                 {
                     hosts.set(i, c);
                     Collections.sort(hosts, sorter);
-                    fireContentsChanged(c, i, i);
                     setSelectedItem(c);
+                    fireContentsChanged(c, 0, hosts.size());
                     writeToDisk();
                     return;
                 }

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanel.java
@@ -17,9 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import decodes.util.DecodesVersion;
-import ilex.util.AsciiUtil;
 import lrgs.gui.MessageBrowser;
-import rma.swing.table.ComboBoxRenderer;
 
 import java.awt.Component;
 import java.awt.Dimension;

--- a/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
+++ b/src/main/java/lrgs/rtstat/hosts/LrgsConnectionPanelController.java
@@ -38,6 +38,7 @@ public class LrgsConnectionPanelController
     {
         LrgsConnection oldConnection = selectedConnection;
         selectedConnection = c;
+        model.setSelectedItem(c);
         connectionChangedCallback.accept(oldConnection, c);
     }
 


### PR DESCRIPTION
## Problem Description



<!-- if you are referencing a specific issue a problem description is not required -->
Host combo was being switched to the wrong LrgsConnection after it successfully connected.

## Solution

Rearranged when certain operations were performed to actually change the active combo.

## how you tested the change

Manually, changed LrgsConnection to different and verify it stayed selected.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
