### PR TITLE
Correct default parameter.

### DIFF
--- a/src/main/java/decodes/gui/PropertiesEditPanel.java
+++ b/src/main/java/decodes/gui/PropertiesEditPanel.java
@@ -225,7 +225,7 @@ public class PropertiesEditPanel extends JPanel
 
     public static PropertiesEditPanel from(Properties properties)
     {
-        return from(properties, false);
+        return from(properties, true);
     }
 
 


### PR DESCRIPTION
## Problem Description
During all the presentations I've realized that when I did #639 I set the incorrect default for canAddDelete to the properties edit panel.

## Solution

Change default back to the original value

## how you tested the change

Manually looked at a few panels were behavior wasn't correct.
There is only one call to creating a PropertiesEditPanel where the add and delete buttons are not available to the user.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
