### PR TITLE
Remove Jdom include, required by cwms-ratings.

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -165,7 +165,6 @@
         <exclude org="javax.media"/>
         <exclude org="com.sun.media"/>
         <exclude org="log4j"/>
-        <exclude org="org.jdom"/>
         <exclude org="org.apache.xmlbeans" module="xmlbeans"/>
 
         <!-- overides to forced updated or specific versions -->


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #717. 

<!-- if you are referencing a specific issue a problem description is not required -->
Unfortunately from the the require libraries is still dependent on this particular jar and version.

## Solution

Remove exclusion

## how you tested the change

Manually tested a cwms ratings with exclusion and got a class not def error, after removal rating ran.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
