### PR TITLE
Exclude build artifacts that aren't used.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,6 @@ Dockerfile
 bin
 .github
 .externalToolBuilders
+**/opendcs-installer*
+**/doc.tar.gz
+**/doc


### PR DESCRIPTION
## Problem Description
Describe the problem you are trying to solve.

Docker images were double the size they should be.

## Solution

Make sure the installer is not included in the image if it was generated before the docker images are created.

## how you tested the change

Manually, made sure the image size changed.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
