### PR TITLE
Preload TsId cache before loading groups. Move group cache fill to tr…

### DIFF
--- a/src/main/java/decodes/tsdb/GroupHelper.java
+++ b/src/main/java/decodes/tsdb/GroupHelper.java
@@ -48,9 +48,11 @@ public abstract class GroupHelper
 	public void evalAll()
 		throws DbIoException
 	{
-		try ( TsGroupDAI tsGroupDAO = tsdb.makeTsGroupDAO(); )
+		try (TimeSeriesDAI tsDao = tsdb.makeTimeSeriesDAO();
+		     TsGroupDAI tsGroupDAO = tsdb.makeTsGroupDAO(); )
 		{
 			ArrayList<TsGroup> allGroups = null;
+			tsDao.reloadTsIdCache();
 			allGroups = tsGroupDAO.getTsGroupList(null);
 			for(TsGroup grp : allGroups)
 				expandTsGroup(grp);

--- a/src/main/java/decodes/tsdb/compedit/ComputationsFilterPanel.java
+++ b/src/main/java/decodes/tsdb/compedit/ComputationsFilterPanel.java
@@ -43,6 +43,7 @@ import javax.swing.*;
 import opendcs.dai.AlgorithmDAI;
 import opendcs.dai.IntervalDAI;
 import opendcs.dai.LoadingAppDAI;
+import opendcs.dai.TimeSeriesDAI;
 import opendcs.dai.TsGroupDAI;
 
 @SuppressWarnings({ "serial", "rawtypes" })
@@ -125,9 +126,12 @@ public class ComputationsFilterPanel extends JPanel
 
 		groupCombo = new JComboBox();
 		groupCombo.addItem("");
-		TsGroupDAI tsGroupDAO = mydb.makeTsGroupDAO();
-		try
+
+		try (TimeSeriesDAI tsDai = mydb.makeTimeSeriesDAO();
+			TsGroupDAI tsGroupDAO = mydb.makeTsGroupDAO();)
 		{
+			// Loading the TsId cache first provides a drastic performance increase
+			tsDai.reloadTsIdCache();
 			groupList = tsGroupDAO.getTsGroupList(null);
 			for(TsGroup grp : groupList)
 				groupCombo.addItem(grp.getGroupId().toString() + " - " + grp.getGroupName());
@@ -136,10 +140,6 @@ public class ComputationsFilterPanel extends JPanel
 		{
 			System.err.println("Error listing groups: " + e1);
 			e1.printStackTrace(System.err);
-		}
-		finally
-		{
-			tsGroupDAO.close();
 		}
 		
 		hideDisabledCheck = new JCheckBox(compLabels.getString("ComputationsFilterPanel.hideDisabled"));

--- a/src/main/java/decodes/tsdb/groupedit/TsGroupListPanel.java
+++ b/src/main/java/decodes/tsdb/groupedit/TsGroupListPanel.java
@@ -40,6 +40,7 @@ package decodes.tsdb.groupedit;
 
 import ilex.util.LoadResourceBundle;
 import ilex.util.Logger;
+import opendcs.dai.TimeSeriesDAI;
 import opendcs.dai.TsGroupDAI;
 
 import java.awt.BorderLayout;
@@ -391,8 +392,10 @@ class TsGroupsSelectTableModel extends AbstractTableModel implements
 		ArrayList<TsGroup> tsGroups = new ArrayList<TsGroup>();
 		if (panel.theTsDb != null)
 		{
-			try(TsGroupDAI groupDAO = panel.theTsDb.makeTsGroupDAO())
+			try(TimeSeriesDAI tsDao = panel.theTsDb.makeTimeSeriesDAO();
+				TsGroupDAI groupDAO = panel.theTsDb.makeTsGroupDAO())
 			{
+				tsDao.reloadTsIdCache();
 				tsGroups = groupDAO.getTsGroupList(null);
 				if (tsGroups == null)
 				{


### PR DESCRIPTION
…ansaction and avoid exception handling in tight loop.

## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
User reported regression in loading CompEdit between .12 and .13. Discovered Group processing was calling into the database in a tight loop for every TimeSeriesID the group would need.

## Solution

Have compedit load the TsId Cache before getting the group list.

## how you tested the change

Manually, loading of a database with large groups went from minutes to near instantaneous.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
