### PR TITLE
Remove Information Element header from Iridium Payload

### DIFF
--- a/src/main/java/lrgs/lrgsmain/LrgsConfig.java
+++ b/src/main/java/lrgs/lrgsmain/LrgsConfig.java
@@ -221,6 +221,9 @@ public class LrgsConfig implements PropertiesOwner
     /** If specified, iridium raw-data will be captured here. */
     public String iridiumCaptureFile = null;
 
+    /** If false, the payload Information Element for the payload will not be shown in the payload itself. */
+    public boolean iridiumIEInPayload = true;
+
     /** Domsat Protocol Converter Host Name */
     public String dpcHost = null;
 


### PR DESCRIPTION
## Problem Description

Currently, Iridium messages parsed by the LRGS keep the Payload Information Element (IE) as the first part of the actual message data. This requires DECODES scripts to skip over this information.
This is metadata information and shouldn't be placed with the message contents. 

Here's an example of such a message:
`ID=xxxxxxxxxxxxxxx,TIME=24284220720,STAT=00,MO=24854,MT=00000,CDR=28956206,LAT=38.6,LON=-121.5,RAD=4 IE:020088 0:Batt 7 #15 13.91 :AT 7 #15 85.7 :RH 7 #15 34 :Stage 7 #15 0.00 :Dewpoint 7 #15 75.84 :YB 14.22 :YN Iridium Test :YD 220705 :SN 2001238`

The problematic part is `IE:020088 `

## Solution

The solution is to remove the information from the message. A configuration option was added (`iridiumIEInPayload`), which defaults to the existing behavior for compatibility. The payload length was also placed in the header portion for preservation (as PLEN).

Here's an example of the above message, but altered with this new behavior:
`ID=xxxxxxxxxxxxxxx,TIME=24284220720,STAT=00,MO=24854,MT=00000,CDR=28956206,LAT=38.6,LON=-121.5,RAD=4,PLEN=136 0:Batt 7 #15 13.91 :AT 7 #15 85.7 :RH 7 #15 34 :Stage 7 #15 0.00 :Dewpoint 7 #15 75.84 :YB 14.22 :YN Iridium Test :YD 220705 :SN 2001238`

## How it was tested

I saved a raw iridium message with the iridiumCaptureFile configuration option.
Then I ran the LRGS and wrote a python script to send that raw message to the LRGS over the Iridium port.
I confirmed that the data remained if the option was not present in the config (preserving prior behavior), and that it was removed if the option was added, and set to false (default is true).

```python
#!python3
import socket
import sys

msg = None

with open(sys.argv[1], 'rb') as f:
  msg = f.read()

with socket.socket( socket.AF_INET, socket.SOCK_STREAM ) as s:
  s.connect( ('127.0.0.1', 10800 ) )
  s.send(msg)
```

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
