### PR TITLE
Bugfix/745 routing spec updates

### DIFF
--- a/src/main/java/decodes/dbeditor/RoutingSpecListPanel.java
+++ b/src/main/java/decodes/dbeditor/RoutingSpecListPanel.java
@@ -165,19 +165,8 @@ public class RoutingSpecListPanel extends JPanel implements ListOpsController
         RoutingSpec newOb = ob.copy();
         newOb.setName(newName);
         newOb.clearId();
-        try
-        {
-            newOb.write();
-        }
-        catch (DatabaseException e)
-        {
-            DbEditorFrame.instance().showError(
-                LoadResourceBundle.sprintf(
-                    genericLabels.getString("cannotSave"), getEntityType()
-                        + " '" + newOb.getName() + "'", e.toString()));
-            return;
-        }
-        rsSelectPanel.addRoutingSpec(newOb);
+        // this previously tried to save to the database initially.
+        // Allow the user to determine if this should be done.
         doOpen(newOb);
     }
 

--- a/src/main/java/decodes/dbeditor/TraceDialog.java
+++ b/src/main/java/decodes/dbeditor/TraceDialog.java
@@ -29,7 +29,7 @@ public class TraceDialog extends JDialog
 	
 	private int maxMessages = 20000;
 	private int numMessages = 0;
-
+	private String closeText = null;
 
 	/**
 	 * Constructor for Dialog parent.
@@ -113,11 +113,24 @@ public class TraceDialog extends JDialog
 	}
 
 	/**
+	 * Text which if seen in addText will automatically close the dialog.
+	 * @param text exact text to check for.
+	 */
+	void setCloseText(String text)
+	{
+		this.closeText = text;
+	}
+
+	/**
 	 * Adds text to the dialog.
 	 * @param text the text.
 	 */
 	public void addText(String text)
 	{
+		if (closeText != null && closeText.equals(text))
+		{
+			this.setVisible(false);
+		}
 		if (numMessages < maxMessages)
 		{
 			SwingUtilities.invokeLater(() ->
@@ -130,7 +143,6 @@ public class TraceDialog extends JDialog
 			});
 			numMessages++;
 		}
-
 	}
 
 	/**

--- a/src/main/java/decodes/dbeditor/routing/RSListTableModel.java
+++ b/src/main/java/decodes/dbeditor/routing/RSListTableModel.java
@@ -117,6 +117,9 @@ public class RSListTableModel extends AbstractTableModel
         RoutingSpec found = theList.find(ob.getName());
         if (found != null)
         {
+            // we very specifically do not call DbIo.deleteRoutingSpec here as we just saved
+            // the updates and we don't need to bother writing them to the database again.
+            // we just need the RoutingSpecList to have the new spec.
             theList.remove(found);
         }
         theList.add(ob);

--- a/src/main/java/decodes/dbeditor/routing/RSListTableModel.java
+++ b/src/main/java/decodes/dbeditor/routing/RSListTableModel.java
@@ -120,6 +120,7 @@ public class RSListTableModel extends AbstractTableModel
             theList.remove(found);
         }
         theList.add(ob);
+        fireTableDataChanged();
     }
 
     public void deleteObject(RoutingSpec ob)

--- a/src/main/java/decodes/dbeditor/routing/RSListTableModel.java
+++ b/src/main/java/decodes/dbeditor/routing/RSListTableModel.java
@@ -112,6 +112,16 @@ public class RSListTableModel extends AbstractTableModel
         fireTableDataChanged();
     }
 
+    public void addOrReplace(RoutingSpec ob)
+    {
+        RoutingSpec found = theList.find(ob.getName());
+        if (found != null)
+        {
+            theList.remove(found);
+        }
+        theList.add(ob);
+    }
+
     public void deleteObject(RoutingSpec ob)
     {
         try

--- a/src/main/java/decodes/sql/PlatformListIO.java
+++ b/src/main/java/decodes/sql/PlatformListIO.java
@@ -909,7 +909,7 @@ public class PlatformListIO extends SqlDbObjIo
             ps.platform.getId(), ps.sensorNumber, ps.getProperties()); }
         catch (DbIoException e)
         {
-            throw new DatabaseException(e.getMessage());
+            throw new DatabaseException(e.getMessage(), e);
         }
         finally
         {

--- a/src/main/java/opendcs/dao/DaoBase.java
+++ b/src/main/java/opendcs/dao/DaoBase.java
@@ -41,6 +41,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -586,7 +587,7 @@ public class DaoBase
      * @param batchSize How many elements of the list to execute for each batch.
      * @throws SQLException
      */
-    public <ValueType> void doModifyBatch(String query, ThrowingFunction<ValueType, Object[] , SQLException> bindingFunction, List<ValueType> values, int batchSize) throws SQLException
+    public <ValueType> void doModifyBatch(String query, ThrowingFunction<ValueType, Object[] , SQLException> bindingFunction, Collection<ValueType> values, int batchSize) throws SQLException
     {
         withStatement(query, (stmt) -> {
             int count = 0;

--- a/src/main/java/opendcs/dao/PropertiesSqlDao.java
+++ b/src/main/java/opendcs/dao/PropertiesSqlDao.java
@@ -146,9 +146,9 @@ public class PropertiesSqlDao extends DaoBase implements PropertiesDAI
         final String q = "insert into " + tableName + " values(?,?,?,?)";
         try
         {
-            doModifyBatch(q, key ->
+            doModifyBatch(q, propertyKey ->
             {
-                return new Object[]{parentKey, key, props.getProperty((String)key)};
+                return new Object[]{parentKey, key2, propertyKey, props.getProperty((String)propertyKey)};
             },
             props.keySet(),
             200);


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #745. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

1. Moved all operations within the appropriate try-catch block
2. Modified function calls in RoutingSpecListIO so ensure the same connection/transaction was used for all operations
3. Added an addOrReplace to TableModel to prevent needless deletion from the database.
4. Migrated propertiesDAO to use bind variables
5. Migrated more of RoutingSpecListIO operations to use bind variables (new handlers to properly wrap connections are at least used.)
6. Changed GUI behavior on commit. A TraceDialog will open, if successful will close automatically, if not it will remain open with the contents of the error.
7. Changed GUI behavior on copy. No longer immediately saves the copy.
8. Changed GUI behavior on save. Database operations now off GUI thread.

## how you tested the change

Manually
1. copied routing spec, saved, closed/repoen dbedit, verified it remained.
2. opened routing spec, modified, saved, closed/reopen dbedit, verified it remained and had changes.
3. opened routing spec, modified with bad data (properties too long), saved, saw errors, closed/repopen dbeidt, verified it remained with original data.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
