### PR TITLE
Devops/setup artifact signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,5 +4,5 @@ ext.osWin = Os.isFamily(Os.FAMILY_WINDOWS)
 
 allprojects {
     group = 'org.opendcs'
-    version = '7.0.14-SNAPSHOT'
+    version = '7.0.14'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,20 @@
+plugins {
+    id "com.palantir.git-version" version "3.1.0"
+}
+
 import org.apache.tools.ant.taskdefs.condition.Os
+
 
 ext.osWin = Os.isFamily(Os.FAMILY_WINDOWS)
 
+def static versionLabel(gitInfo) {
+    def branch = gitInfo.branchName // all branches are snapshots, only tags get released
+    def tag = gitInfo.lastTag
+    // tag is returned as is. Branch may need cleanup
+    return branch == null ? tag : "main.99." + branch.replace("/", "-") + "-SNAPSHOT"
+}
+
 allprojects {
     group = 'org.opendcs'
-    version = '7.0.14'
+    version = versionLabel(versionDetails())
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,6 +11,9 @@ repositories {
 
 dependencies {
     implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.14'
+    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+        implementation 'dev.sigstore:sigstore-gradle-sign-plugin:1.0.0'
+    }
  
 }
 

--- a/buildSrc/src/main/groovy/opendcs.deps-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.deps-conventions.gradle
@@ -25,4 +25,5 @@ repositories {
                 artifact()
             }
     }
+    gradlePluginPortal()
 }

--- a/buildSrc/src/main/groovy/opendcs.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.java-conventions.gradle
@@ -18,7 +18,12 @@ eclipse {
 }
 
 java {
-    toolchain {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
         languageVersion = JavaLanguageVersion.of(8)
     }
 }

--- a/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
@@ -21,11 +21,5 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
                 issuer.set("https://oauth2.sigstore.dev/auth")
             }
         }
-}
-}
-/*
-tasks.withType(SigstoreSignFilesTask).configureEach {
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(11)
     }
-}*/
+}

--- a/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'signing'
+    id 'maven-publish'
+}
+
+
+
+
+signing {
+    useGpgCmd()    
+}

--- a/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
@@ -4,8 +4,28 @@ plugins {
 }
 
 
-
-
 signing {
     useGpgCmd()    
 }
+
+if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+    plugins.apply('dev.sigstore.sign')
+    sigstoreSign {
+        oidcClient {
+            gitHub {
+                audience.set("sigstore")
+            }
+
+            web {
+                clientId.set("sigstore")
+                issuer.set("https://oauth2.sigstore.dev/auth")
+            }
+        }
+}
+}
+/*
+tasks.withType(SigstoreSignFilesTask).configureEach {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}*/

--- a/install/build.gradle
+++ b/install/build.gradle
@@ -1,6 +1,7 @@
 plugins
 {
     id 'opendcs.deps-conventions'
+    id 'opendcs.publishing-conventions'
     id 'distribution'
 }
 
@@ -149,4 +150,10 @@ task runApp(type: Exec) {
                                ).asPath)
 
     workingDir runDir
+}
+
+
+signing {
+    sign distZip
+    sign distTar
 }

--- a/java/annotations/build.gradle
+++ b/java/annotations/build.gradle
@@ -2,8 +2,21 @@ plugins
 {
     id 'opendcs.deps-conventions'
     id 'opendcs.java-conventions'
+    id 'opendcs.publishing-conventions'
     id 'java-library'
 }
 
 // NOTE: this project should not contain any runtime dependencies
 // Build dependencies, such as google autowire are acceptable.
+
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId = 'opendcs-annotations'
+            from components.java
+        }
+
+
+    }
+}

--- a/java/opendcs/src/main/java/lrgs/gui/LrgsBuild.java
+++ b/java/opendcs/src/main/java/lrgs/gui/LrgsBuild.java
@@ -19,8 +19,7 @@ package is built.
 */
 public class LrgsBuild
 {
-	public static final String buildDate = "7.0.13";
-	public static final String rcNum = "13";
+	public static final String buildDate = "7.0.14";
+	public static final String rcNum = "14";
 	public static final String version = "7.0";
 }
-


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Setup artifact signing, using sigstore, and tag based versioning. Additionally setup initial publications

## Solution

Add sigstore plugin to build. This using OpenID connect workflows to verify identity and avoids needing to create gpg keys.
The plugin can use the project identity to sign on behalf the project, or when testing manually you use your own github account.

## how you tested the change

Manually running `publishToMavenLocal` task to trigger signing.
for tag versioning ran `./gradlew -q properties` to see appropriate version is set.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
