### PR TITLE
Remove other branches from this action file.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,10 @@ on:
   pull_request:
     branches:
       - "main"
-      - "7.0"
-      - "8.0"
     types: [opened, synchronize, reopened]
   push:
     branches:
       - "main"
-      - "7.0"
-      - "8.0"
 
 jobs:
   tests:


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
@ktarbet pointed out we shouldn't be building other branches from the same build.yaml. For example 8.0 is minimum java of 11 (soon to be 17) so building would fail for any attempt at java 8.

Additionally, Github actions don't require every build file to be in the default branch.

## Solution

Remove reference to other branches than main from the main build.yaml file.

## how you tested the change

The build behaving is itself the test.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
