### PR TITLE
Chore/create nightly for main

### DIFF
--- a/.github/workflows/nightly-schedule.yml
+++ b/.github/workflows/nightly-schedule.yml
@@ -1,8 +1,7 @@
 name: Nightly Releases
 on:
   schedule:
-    - cron: "0 * * * *"
-  workflow_dispatch:
+    - cron: "0 * * * *"  
 
 
 jobs:
@@ -12,4 +11,3 @@ jobs:
       token: ${{ GITHUB_TOKEN }}
     with:
       branch: "main"
-      tag: "main-nightly"

--- a/.github/workflows/nightly-schedule.yml
+++ b/.github/workflows/nightly-schedule.yml
@@ -1,0 +1,15 @@
+name: Nightly Releases
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+
+jobs:
+  main:
+    uses: ./.github/workflows/nightly.yml
+    secrets:
+      token: ${{ GITHUB_TOKEN }}
+    with:
+      branch: "main"
+      tag: "main-nightly"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,15 +2,20 @@ name: Nightly Release Build
 on:
   workflow_call:
     inputs:
-      tag:
-       type: string
-       required: true
       branch:
        type: string
        required: true
     secrets:
       token:
-       required: true
+       required: false
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: choice
+        required: true
+        description: Which Branch to make the build from
+        options:
+          - main
 
 jobs:
   tests:
@@ -37,22 +42,22 @@ jobs:
           ./gradlew distTar distZip
       - name: create docker images
         run: |
-          ./build_docker.sh ghcr.io/opendcs ${{inputs.tag}}
+          ./build_docker.sh ghcr.io/opendcs ${{inputs.branch}}-nightly
       - name: upload Release
         run: |
           VERSION=`./gradlew properties -q | grep "^version:" | awk '{ print $2}'`
-          gh release upload ${{inputs.tag}} install/build/distributions/${VERSION}.tar#opendcs-${{inputs.tag}}.tar --clobber
-          gh release upload ${{inputs.tag}} install/build/distributions/${VERSION}.zip#opendcs-${{inputs.tag}}.zip --clobber
+          gh release upload ${{inputs.branch}}-nightly install/build/distributions/${VERSION}.tar#opendcs-${{inputs.branch}}-nightly.tar --clobber
+          gh release upload ${{inputs.branch}}-nightly install/build/distributions/${VERSION}.zip#opendcs-${{inputs.branch}}.nightly.zip --clobber
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.token }}
+          password: ${{ secrets.token != null && secrets.token || GITHUB_TOKEN }}
       - name: Push images
         run: |
-          docker push ghcr.io/opendcs/lrgs:${{inputs.tag}}
-          docker push ghcr.io/opendcs/routingscheduler:${{inputs.tag}}
-          docker push ghcr.io/opendcs/compdepends:${{inputs.tag}}
-          docker push ghcr.io/opendcs/compproc:${{inputs.tag}}
+          docker push ghcr.io/opendcs/lrgs:${{inputs.branch}}-nightly
+          docker push ghcr.io/opendcs/routingscheduler:${{inputs.branch}}-nightly
+          docker push ghcr.io/opendcs/compdepends:${{inputs.branch}}-nightly
+          docker push ghcr.io/opendcs/compproc:${{inputs.branch}}-nightly
       

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,16 @@
-name: Nightly Release
+name: Nightly Release Build
 on:
-  schedule:
-    - cron: "0 * * * *"
+  workflow_call:
+    inputs:
+      tag:
+       type: string
+       required: true
+      branch:
+       type: string
+       required: true
+    secrets:
+      token:
+       required: true
 
 jobs:
   tests:
@@ -13,6 +22,8 @@ jobs:
     runs-on: ${{matrix.platform}}
     steps:
       - uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{inputs.branch}}
       - name: Set up JDK
         uses: actions/setup-java@v4.4.0
         with:
@@ -26,22 +37,22 @@ jobs:
           ./gradlew distTar distZip
       - name: create docker images
         run: |
-          ./build_docker.sh ghcr.io/opendcs main-nightly
+          ./build_docker.sh ghcr.io/opendcs ${{inputs.tag}}
       - name: upload Release
         run: |
           VERSION=`./gradlew properties -q | grep "^version:" | awk '{ print $2}'`
-          gh release upload "main-nightly" install/build/distributions/${VERSION}.tar#opendcs-main-nightly.tar --clobber
-          gh release upload "main-nightly" install/build/distributions/${VERSION}.zip#opendcs-main-nightly.zip --clobber
+          gh release upload ${{inputs.tag}} install/build/distributions/${VERSION}.tar#opendcs-${{inputs.tag}}.tar --clobber
+          gh release upload ${{inputs.tag}} install/build/distributions/${VERSION}.zip#opendcs-${{inputs.tag}}.zip --clobber
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.token }}
       - name: Push images
         run: |
-          docker push ghcr.io/opendcs/lrgs:main-nightly
-          docker push ghcr.io/opendcs/routingscheduler:main-nightly
-          docker push ghcr.io/opendcs/compdepends:main-nightly
-          docker push ghcr.io/opendcs/compproc:main-nightly
+          docker push ghcr.io/opendcs/lrgs:${{inputs.tag}}
+          docker push ghcr.io/opendcs/routingscheduler:${{inputs.tag}}
+          docker push ghcr.io/opendcs/compdepends:${{inputs.tag}}
+          docker push ghcr.io/opendcs/compproc:${{inputs.tag}}
       

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,47 @@
+name: Nightly Release
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{matrix.platform}}
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Set up JDK
+        uses: actions/setup-java@v4.4.0
+        with:
+          java-version: ${{matrix.jdk}}
+          distribution: temurin
+      - uses: actions/setup-python@v5.1.0
+        with:
+          python-version: "3.8"
+      - name: Create distributions
+        run: |
+          ./gradlew distTar distZip
+      - name: create docker images
+        run: |
+          ./build_docker.sh ghcr.io/opendcs main-nightly
+      - name: upload Release
+        run: |
+          VERSION=`./gradlew properties -q | grep "^version:" | awk '{ print $2}'`
+          gh release upload "main-nightly" install/build/distributions/${VERSION}.tar#opendcs-main-nightly.tar --clobber
+          gh release upload "main-nightly" install/build/distributions/${VERSION}.zip#opendcs-main-nightly.zip --clobber
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push images
+        run: |
+          docker push ghcr.io/opendcs/lrgs:main-nightly
+          docker push ghcr.io/opendcs/routingscheduler:main-nightly
+          docker push ghcr.io/opendcs/compdepends:main-nightly
+          docker push ghcr.io/opendcs/compproc:main-nightly
+      


### PR DESCRIPTION
## Problem Description

Automate part of distribution process. Instead of manually creating RC builds this will allow anyone concerned with testing to test sooner.

## Solution

Created a scheduled action that calls a reusable workflow.
Workflow can also be called manually

## how you tested the change

Unable to test change outside of Github actions, if the first initial tests are problematic I'll start testing in a fork.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
