### PR TITLE
Allow job to have required permissions.

### DIFF
--- a/.github/workflows/nightly-schedule.yml
+++ b/.github/workflows/nightly-schedule.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   main:
+    permissions:
+      packages: write
+      contents: write
     uses: ./.github/workflows/nightly.yml
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Job call did not provide the required permissions to allow the called action to get the correct permissions.