### PR TITLE
Change comparison to use Long instead of Int.

### DIFF
--- a/java/opendcs/src/main/java/decodes/tsdb/groupedit/TsGroupListPanel.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/groupedit/TsGroupListPanel.java
@@ -696,7 +696,7 @@ class TsGroupsColumnComparator implements Comparator<TsGroup>
 			return 0;
 		}
 		
-		if (col == 0)// sort integers ascending
+		if (col == 0)// sort Longs ascending
 		{
 			try
 			{

--- a/java/opendcs/src/main/java/decodes/tsdb/groupedit/TsGroupListPanel.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/groupedit/TsGroupListPanel.java
@@ -59,6 +59,8 @@ import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.table.AbstractTableModel;
 
+import org.slf4j.LoggerFactory;
+
 import decodes.gui.GuiDialog;
 import decodes.gui.SortingListTable;
 import decodes.gui.SortingListTableModel;
@@ -677,8 +679,9 @@ class TsGroupsSelectColumnizer
 	}
 }
 
-class TsGroupsColumnComparator implements Comparator
+class TsGroupsColumnComparator implements Comparator<TsGroup>
 {
+	private static final org.slf4j.Logger log = LoggerFactory.getLogger(TsGroupsColumnComparator.class);
 	int col;
 
 	TsGroupsColumnComparator(int col)
@@ -686,26 +689,29 @@ class TsGroupsColumnComparator implements Comparator
 		this.col = col;
 	}
 
-	public int compare(Object tsG1, Object tsG2)
+	public int compare(TsGroup tsG1, TsGroup tsG2)
 	{
 		if (tsG1 == tsG2)
+		{
 			return 0;
-		TsGroup g1 = (TsGroup) tsG1;
-		TsGroup g2 = (TsGroup) tsG2;
-		if (col == 0)// sort integers assendingly
+		}
+		
+		if (col == 0)// sort integers ascending
 		{
 			try
 			{
-				int i1 = Integer.parseInt(TsGroupsSelectColumnizer.getColumn(
-						g1, col).trim());
-				int i2 = Integer.parseInt(TsGroupsSelectColumnizer.getColumn(
-						g2, col).trim());
-				return i1 - i2;
-			} catch (Exception ex)
+				long i1 = Long.parseLong(TsGroupsSelectColumnizer.getColumn(tsG1, col).trim());
+				long i2 = Long.parseLong(TsGroupsSelectColumnizer.getColumn(tsG2, col).trim());
+				return Long.compare(i1, i2);
+			}
+			catch (Exception ex)
 			{
+				log.atError().setCause(ex).log("Error parsing column value as long.");
 			}
 		}
-		return TsGroupsSelectColumnizer.getColumn(g1, col).compareToIgnoreCase(
-				TsGroupsSelectColumnizer.getColumn(g2, col));
+		return TsGroupsSelectColumnizer.getColumn(tsG1, col)
+									   .compareToIgnoreCase(
+										  TsGroupsSelectColumnizer.getColumn(tsG2, col)
+									   );
 	}
 }


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #850. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Change use of ints to Long.
Left log message in for future work. This is break down if/when we allow other than numbers for ID fields; but we can account for that when that time comes.

## how you tested the change

Ran group edit before change with dataset that caused `java.lang.IllegalArgumentException: Comparison method violates its general contract!`

Ran group edit after change and saw data load correctly.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
