### PR TITLE
Refactor/rledit dbenum usage

### DIFF
--- a/java/opendcs/src/main/java/decodes/dbeditor/TraceDialog.java
+++ b/java/opendcs/src/main/java/decodes/dbeditor/TraceDialog.java
@@ -116,7 +116,7 @@ public class TraceDialog extends JDialog
 	 * Text which if seen in addText will automatically close the dialog.
 	 * @param text exact text to check for.
 	 */
-	void setCloseText(String text)
+	public void setCloseText(String text)
 	{
 		this.closeText = text;
 	}

--- a/java/opendcs/src/main/java/decodes/rledit/EnumTableModel.java
+++ b/java/opendcs/src/main/java/decodes/rledit/EnumTableModel.java
@@ -81,9 +81,10 @@ public class EnumTableModel extends AbstractTableModel
 	public int getRowCount()
 	{
 		if (currentEnum == null)
+		{
 			return 0;
-		Vector v = (Vector)currentEnum.values();
-		return v.size();
+		}
+		return currentEnum.values().size();
 	}
 
 	/** @return number of enum columns (constant). */
@@ -134,7 +135,7 @@ public class EnumTableModel extends AbstractTableModel
 	{
 		if (currentEnum == null)
 			return null;
-		Vector v = (Vector)currentEnum.values();
+		Vector<?> v = (Vector<EnumValue>)currentEnum.values();
 		if (row >= v.size())
 			return null;
 		return (EnumValue)v.elementAt(row);
@@ -155,12 +156,10 @@ public class EnumTableModel extends AbstractTableModel
 	 * contents of the table.
 	 * @param enumName name of the DECODES enumeration to display
 	 */
-	public void setEnum(String enumName)
+	public void setEnum(DbEnum en)
 	{
-		decodes.db.DbEnum en = Database.getDb().getDbEnum(enumName);
 		if (en == null)
 		{
-			System.err.println("Cannot find enum '" + enumName + "'");
 			return;
 		}
 		currentEnum = en;
@@ -192,10 +191,10 @@ public class EnumTableModel extends AbstractTableModel
 	 */
 	public boolean moveUp(int row)
 	{
-		Vector v = (Vector)currentEnum.values();
+		Vector<EnumValue> v = (Vector<EnumValue>)currentEnum.values();
 		if (row <= 0 || row >= v.size())
 			return false;
-		Object obj = v.elementAt(row);
+		EnumValue obj = v.elementAt(row);
 		v.removeElementAt(row);
 		v.insertElementAt(obj, row-1);
 		fireTableDataChanged();
@@ -208,10 +207,10 @@ public class EnumTableModel extends AbstractTableModel
 	 */
 	public boolean moveDown(int row)
 	{
-		Vector v = (Vector)currentEnum.values();
+		Vector<EnumValue> v = (Vector<EnumValue>)currentEnum.values();
 		if (row < 0 || row >= v.size()-1)
 			return false;
-		Object obj = v.elementAt(row);
+		EnumValue obj = v.elementAt(row);
 		v.removeElementAt(row);
 		v.insertElementAt(obj, row+1);
 		fireTableDataChanged();

--- a/java/opendcs/src/main/java/decodes/rledit/RefListEditor.java
+++ b/java/opendcs/src/main/java/decodes/rledit/RefListEditor.java
@@ -1,6 +1,10 @@
 package decodes.rledit;
 
 import javax.swing.UIManager;
+
+import org.opendcs.database.DatabaseService;
+import org.opendcs.database.api.OpenDcsDatabase;
+
 import java.util.*;
 
 import ilex.gui.WindowUtility;
@@ -18,11 +22,13 @@ public class RefListEditor
     private static ResourceBundle genericLabels = null;
     private static ResourceBundle labels = null;
     boolean packFrame = false;
+    final private OpenDcsDatabase database;
 
     /** Construct the application. */
-    public RefListEditor() 
+    public RefListEditor(OpenDcsDatabase database)
     {
-        RefListFrame frame = new RefListFrame();
+        this.database = database;
+        RefListFrame frame = new RefListFrame(database);
         //Validate frames that have preset sizes
         //Pack frames that have useful preferred size info, e.g. from their layout
         if (packFrame) {
@@ -97,19 +103,10 @@ public class RefListEditor
 
         DecodesSettings settings = DecodesSettings.instance();
         DecodesInterface.setGUI(true);
-
+        OpenDcsDatabase database = DatabaseService.getDatabaseFor("RefListEditor", settings);
+        database.getLegacyDatabase(Database.class).get().initializeForEditing();
         // Construct the database and the interface specified by properties.
         Database db = new decodes.db.Database();
-        
-        Database.setDb(db);
-        DatabaseIO dbio = 
-            DatabaseIO.makeDatabaseIO(settings.editDatabaseTypeCode,
-            settings.editDatabaseLocation);
-        db.setDbIo(dbio);
-        db.enumList.read();
-        db.dataTypeSet.read();
-        db.engineeringUnitList.read();
-        
-        new RefListEditor();
+        new RefListEditor(database);
     }
 }

--- a/java/opendcs/src/main/java/decodes/rledit/RefListEditor.java
+++ b/java/opendcs/src/main/java/decodes/rledit/RefListEditor.java
@@ -105,8 +105,6 @@ public class RefListEditor
         DecodesInterface.setGUI(true);
         OpenDcsDatabase database = DatabaseService.getDatabaseFor("RefListEditor", settings);
         database.getLegacyDatabase(Database.class).get().initializeForEditing();
-        // Construct the database and the interface specified by properties.
-        Database db = new decodes.db.Database();
         new RefListEditor(database);
     }
 }

--- a/java/opendcs/src/main/java/decodes/rledit/RefListFrame.java
+++ b/java/opendcs/src/main/java/decodes/rledit/RefListFrame.java
@@ -9,12 +9,15 @@ import java.awt.event.*;
 import javax.swing.*;
 import javax.swing.border.*;
 
+import org.opendcs.database.api.OpenDcsDatabase;
+
 import java.util.*;
 
 import ilex.util.*;
 import decodes.db.*;
 import decodes.decoder.Season;
 import decodes.gui.SortingListTable;
+import decodes.rledit.panels.EnumerationPanel;
 
 /**
 RefListFrame is the GUI application for Reference List Editor.
@@ -24,1489 +27,1115 @@ units, EU conversions and data type equivalencies.
 @SuppressWarnings("serial")
 public class RefListFrame extends JFrame
 {
-	private static ResourceBundle genericLabels = 
-		RefListEditor.getGenericLabels();
-	private static ResourceBundle labels = RefListEditor.getLabels();
-	private JPanel contentPane;
-	private JMenuBar jMenuBar1 = new JMenuBar();
-	private JMenu jMenuFile = new JMenu();
-	private JMenuItem jMenuFileExit = new JMenuItem();
-	private JMenu jMenuHelp = new JMenu();
-	private JMenuItem jMenuHelpAbout = new JMenuItem();
-	private JLabel statusBar = new JLabel();
-	private BorderLayout borderLayout1 = new BorderLayout();
-	private JTabbedPane rlTabbedPane = new JTabbedPane();
-	private JPanel EnumTab = new JPanel();
-	private JPanel EUTab = new JPanel();
-	private JPanel EuCnvtTab = new JPanel();
-	private JMenuItem mi_saveToDb = new JMenuItem();
-	private JTextArea jTextArea1 = new JTextArea();
-	private BorderLayout borderLayout2 = new BorderLayout();
-	
-	private JPanel jPanel1 = new JPanel();
-	private JScrollPane jScrollPane1 = new JScrollPane();
-	private EnumTableModel enumTableModel = new EnumTableModel();
-	private JTable enumTable = new SortingListTable(enumTableModel,
-		new int[] { 9, 20, 41, 30 });
-	private JButton addEnumValButton = new JButton();
-	private JButton editEnumValButton = new JButton();
-	private JButton deleteEnumValButton = new JButton();
-	private JButton selectEnumValDefaultButton = new JButton();
-	private JButton upEnumValButton = new JButton();
-	private JButton downEnumValButton = new JButton();
-	private JPanel jPanel2 = new JPanel();
-	private FlowLayout flowLayout1 = new FlowLayout();
-	private JLabel jLabel1 = new JLabel();
-	private JComboBox enumComboBox = new JComboBox();
-	private BorderLayout borderLayout3 = new BorderLayout();
-	private JTextArea jTextArea2 = new JTextArea();
-	
-	private JPanel jPanel3 = new JPanel();
-	private JScrollPane jScrollPane2 = new JScrollPane();
-	private EUTableModel euTableModel = new EUTableModel();
-	private JTable euTable = new SortingListTable(euTableModel,
-		new int[] { 20, 30, 25, 25 });
-	private JButton addEUButton = new JButton();
-	private JButton editEUButton = new JButton();
-	private JButton deleteEUButton = new JButton();
-	private JButton undoDeleteEnumValButton = new JButton();
-	private GridBagLayout gridBagLayout1 = new GridBagLayout();
-	private JButton undoDeleteEUButton = new JButton();
-	private GridBagLayout gridBagLayout2 = new GridBagLayout();
-	private BorderLayout borderLayout4 = new BorderLayout();
-	private JTextArea jTextArea3 = new JTextArea();
-	
-	private JPanel jPanel4 = new JPanel();
-	private JScrollPane jScrollPane3 = new JScrollPane();
-	private EUCnvTableModel ucTableModel = new EUCnvTableModel();
-	private JTable ucTable = new SortingListTable(ucTableModel,
-		new int[] {17, 17, 18, 8, 8, 8, 8, 8, 8 });
-	private JButton addEUCnvtButton = new JButton();
-	private JButton editEUCnvtButton = new JButton();
-	private JButton deleteEUCnvtButton = new JButton();
-	private JButton undoDelEuCnvtButton = new JButton();
-	private GridBagLayout gridBagLayout3 = new GridBagLayout();
-	private Border border4;
-	
-	private DTEquivTableModel dteTableModel = new DTEquivTableModel();
-	private JTable dteTable = new SortingListTable(dteTableModel,null);
-	private JButton addDTEButton = new JButton();
-	private JButton editDTEButton = new JButton();
-	private JButton deleteDTEButton = new JButton();
-	private JButton undoDeleteDTEButton = new JButton();
-	private Border border5;
-	
-	private Border border6;
-	private Border border7;
+    private static ResourceBundle genericLabels = RefListEditor.getGenericLabels();
+    private static ResourceBundle labels = RefListEditor.getLabels();
+    private JPanel contentPane;
+    private JMenuBar jMenuBar1 = new JMenuBar();
+    private JMenu jMenuFile = new JMenu();
+    private JMenuItem jMenuFileExit = new JMenuItem();
+    private JMenu jMenuHelp = new JMenu();
+    private JMenuItem jMenuHelpAbout = new JMenuItem();
+    private JLabel statusBar = new JLabel();
+    private BorderLayout borderLayout1 = new BorderLayout();
+    private JTabbedPane rlTabbedPane = new JTabbedPane();
+    private final EnumerationPanel EnumTab;
+    private JPanel EUTab = new JPanel();
+    private JPanel EuCnvtTab = new JPanel();
+    private JMenuItem mi_saveToDb = new JMenuItem();
+    private BorderLayout borderLayout3 = new BorderLayout();
+    private JTextArea jTextArea2 = new JTextArea();
 
-	//================================================
-	private boolean enumsChanged = false;
-	private boolean unitsChanged = false;
-	private boolean convertersChanged = false;
-	private boolean dtsChanged = false;
-	private boolean seasonsChanged = false;
-	private EnumValue deletedEnumValue = null;
-	private EngineeringUnit deletedEU = null;
-	private UnitConverterDb deletedConverter = null;
-	private String []deletedDte = null;
 
-	private SeasonListTableModel seasonListTableModel = new SeasonListTableModel();
-	private SortingListTable seasonsTable = new SortingListTable(seasonListTableModel,
-		SeasonListTableModel.colWidths);
 
-	/**
-	 * No args constructor for JBuilder.
-	 */
-	public RefListFrame()
-	{
-		enableEvents(AWTEvent.WINDOW_EVENT_MASK);
-		try 
-		{
-			jbInit();
-			initControls();
-		}
-		catch(Exception e) {
-			e.printStackTrace();
-		}
+    private JPanel jPanel3 = new JPanel();
+    private JScrollPane jScrollPane2 = new JScrollPane();
+    private EUTableModel euTableModel = new EUTableModel();
+    private JTable euTable = new SortingListTable(euTableModel,
+        new int[] { 20, 30, 25, 25 });
+    private JButton addEUButton = new JButton();
+    private JButton editEUButton = new JButton();
+    private JButton deleteEUButton = new JButton();
 
-		// Default operation is to do nothing when user hits 'X' in upper
-		// right to close the window. We will catch the closing event and
-		// do the same thing as if user had hit File - Exit.
-		setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-		addWindowListener(
-			new WindowAdapter()
-			{
-				public void windowClosing(WindowEvent e)
-				{
-      				jMenuFileExit_actionPerformed(null);
-				}
-			});
-	}
 
-	/**
-	 * Initializes the controls in the frames.
-	 * Calls the init methods in other GUI objects, table models, etc.
-	 */
-	private void initControls()
-	{
-		ArrayList<String> v = new ArrayList<String>();
-		for(Iterator<DbEnum> enumIt = Database.getDb().enumList.iterator();
-			enumIt.hasNext(); )
-		{
-			decodes.db.DbEnum en = enumIt.next();
-			if (en.enumName.equalsIgnoreCase("EquationScope")
-			 || en.enumName.equalsIgnoreCase("DataOrder")
-			 || en.enumName.equalsIgnoreCase("UnitFamily")
-			 || en.enumName.equalsIgnoreCase("LookupAlgorithm")
-			 || en.enumName.equalsIgnoreCase("RecordingMode")
-			 || en.enumName.equalsIgnoreCase("EquipmentType")
-			 || en.enumName.equalsIgnoreCase("Season"))
-				continue;
-			String s = TextUtil.capsExpand(en.enumName);
-			v.add(s);
-		}
-		Collections.sort(v);
-		for(int i=0; i<v.size(); i++)
-			enumComboBox.addItem(v.get(i));
-		enumTable.setRowHeight(20);
-		enumTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-		euTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-		euTable.setRowHeight(20);
-		ucTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-		ucTable.setRowHeight(20);
-		dteTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-		dteTable.setRowHeight(20);
-	}
+    private JButton undoDeleteEUButton = new JButton();
+    private GridBagLayout gridBagLayout2 = new GridBagLayout();
+    private BorderLayout borderLayout4 = new BorderLayout();
+    private JTextArea jTextArea3 = new JTextArea();
 
-	/** Initializes GUI components. */
-	private void jbInit() throws Exception
-	{
-		contentPane = (JPanel) this.getContentPane();
+    private JPanel jPanel4 = new JPanel();
+    private JScrollPane jScrollPane3 = new JScrollPane();
+    private EUCnvTableModel ucTableModel = new EUCnvTableModel();
+    private JTable ucTable = new SortingListTable(ucTableModel,
+        new int[] {17, 17, 18, 8, 8, 8, 8, 8, 8 });
+    private JButton addEUCnvtButton = new JButton();
+    private JButton editEUCnvtButton = new JButton();
+    private JButton deleteEUCnvtButton = new JButton();
+    private JButton undoDelEuCnvtButton = new JButton();
+    private GridBagLayout gridBagLayout3 = new GridBagLayout();
+    private Border border4;
 
-		border4 = BorderFactory.createCompoundBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED,Color.white,Color.white,new Color(124, 124, 124),new Color(178, 178, 178)),BorderFactory.createEmptyBorder(6,6,6,6));
-		border5 = BorderFactory.createCompoundBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED,Color.white,Color.white,new Color(124, 124, 124),new Color(178, 178, 178)),BorderFactory.createEmptyBorder(6,6,6,6));
-	    border6 = BorderFactory.createCompoundBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED,Color.white,Color.white,new Color(124, 124, 124),new Color(178, 178, 178)),BorderFactory.createEmptyBorder(6,6,6,6));
-	    border7 = BorderFactory.createCompoundBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED,Color.white,Color.white,new Color(124, 124, 124),new Color(178, 178, 178)),BorderFactory.createEmptyBorder(6,6,6,6));
-	    contentPane.setLayout(borderLayout1);
-		this.setFont(new java.awt.Font("Serif", 0, 16));
-		this.setSize(new Dimension(800, 536));
-		this.setTitle(labels.getString("RefListFrame.frameTitle"));
-		statusBar.setText(" ");
-		jMenuFile.setText(genericLabels.getString("file"));
-		jMenuFileExit.setText(genericLabels.getString("exit"));
-		jMenuFileExit.addActionListener(new RefListFrame_jMenuFileExit_ActionAdapter(this));
-		jMenuHelp.setText(genericLabels.getString("help"));
-		jMenuHelpAbout.setText(genericLabels.getString("about"));
-		jMenuHelpAbout.addActionListener(new RefListFrame_jMenuHelpAbout_ActionAdapter(this));
-		rlTabbedPane.setTabPlacement(JTabbedPane.TOP);
-		mi_saveToDb.setText(labels.getString("RefListFrame.saveToDB"));
-		mi_saveToDb.addActionListener(new RefListFrame_mi_saveToDb_actionAdapter(this));
-		
-		jTextArea1.setBackground(Color.white);
-		jTextArea1.setFont(new java.awt.Font("Serif", 0, 14));
-		jTextArea1.setBorder(border5);
-		jTextArea1.setEditable(false);
-		jTextArea1.setText(labels.getString("RefListFrame.enumerationsTab"));
-		jTextArea1.setLineWrap(true);
-		jTextArea1.setRows(3);
-		jTextArea1.setWrapStyleWord(true);
-		EnumTab.setLayout(borderLayout2);
-		jPanel1.setLayout(gridBagLayout1);
-		addEnumValButton.setMaximumSize(new Dimension(122, 23));
-		addEnumValButton.setMinimumSize(new Dimension(122, 23));
-		addEnumValButton.setPreferredSize(new Dimension(122, 23));
-		addEnumValButton.setText(genericLabels.getString("add"));
-		addEnumValButton.addActionListener(new RefListFrame_addEnumValButton_actionAdapter(this));
-		editEnumValButton.setMaximumSize(new Dimension(122, 23));
-		editEnumValButton.setMinimumSize(new Dimension(122, 23));
-		editEnumValButton.setPreferredSize(new Dimension(122, 23));
-		editEnumValButton.setText(genericLabels.getString("edit"));
-		editEnumValButton.addActionListener(new RefListFrame_editEnumValButton_actionAdapter(this));
-		deleteEnumValButton.setMaximumSize(new Dimension(122, 23));
-		deleteEnumValButton.setMinimumSize(new Dimension(122, 23));
-		deleteEnumValButton.setPreferredSize(new Dimension(122, 23));
-		deleteEnumValButton.setText(genericLabels.getString("delete"));
-		deleteEnumValButton.addActionListener(new RefListFrame_deleteEnumValButton_actionAdapter(this));
-//		selectEnumValDefaultButton.setMaximumSize(new Dimension(122, 23));
-//		selectEnumValDefaultButton.setMinimumSize(new Dimension(122, 23));
-//		selectEnumValDefaultButton.setPreferredSize(new Dimension(122, 23));
-		selectEnumValDefaultButton.setText(labels.getString("RefListFrame.setDefault"));
-		selectEnumValDefaultButton.addActionListener(new RefListFrame_selectEnumValDefaultButton_actionAdapter(this));
-		upEnumValButton.setMaximumSize(new Dimension(122, 23));
-		upEnumValButton.setMinimumSize(new Dimension(122, 23));
-		upEnumValButton.setPreferredSize(new Dimension(122, 23));
-		upEnumValButton.setText(labels.getString("RefListFrame.moveUp"));
-		upEnumValButton.addActionListener(new RefListFrame_upEnumValButton_actionAdapter(this));
-		downEnumValButton.setMaximumSize(new Dimension(122, 23));
-		downEnumValButton.setMinimumSize(new Dimension(122, 23));
-		downEnumValButton.setPreferredSize(new Dimension(122, 23));
-		downEnumValButton.setText(labels.getString("RefListFrame.moveDown"));
-		downEnumValButton.addActionListener(new RefListFrame_downEnumValButton_actionAdapter(this));
-		jPanel2.setLayout(flowLayout1);
-		jLabel1.setText(labels.getString("RefListFrame.enumeration"));
-		enumComboBox.setMinimumSize(new Dimension(160, 19));
-		enumComboBox.setPreferredSize(new Dimension(160, 19));
-		enumComboBox.addActionListener(new RefListFrame_enumComboBox_actionAdapter(this));
-		
-		EUTab.setLayout(borderLayout3);
-		jTextArea2.setFont(new java.awt.Font("Serif", 0, 14));
-		jTextArea2.setBorder(border6);
-		jTextArea2.setEditable(false);
-		jTextArea2.setText(labels.getString("RefListFrame.engineeringTabDesc"));
-		jTextArea2.setLineWrap(true);
-		jTextArea2.setRows(3);
-		jTextArea2.setWrapStyleWord(true);
-		jPanel3.setLayout(gridBagLayout2);
-		addEUButton.setMaximumSize(new Dimension(122, 23));
-		addEUButton.setMinimumSize(new Dimension(122, 23));
-		addEUButton.setPreferredSize(new Dimension(122, 23));
-		addEUButton.setText(genericLabels.getString("add"));
-		addEUButton.addActionListener(new RefListFrame_addEUButton_actionAdapter(this));
-		editEUButton.setMaximumSize(new Dimension(122, 23));
-		editEUButton.setMinimumSize(new Dimension(122, 23));
-		editEUButton.setPreferredSize(new Dimension(122, 23));
-		editEUButton.setText(genericLabels.getString("edit"));
-		editEUButton.addActionListener(new RefListFrame_editEUButton_actionAdapter(this));
-		deleteEUButton.setMaximumSize(new Dimension(122, 23));
-		deleteEUButton.setMinimumSize(new Dimension(122, 23));
-		deleteEUButton.setPreferredSize(new Dimension(122, 23));
-		deleteEUButton.setText(genericLabels.getString("delete"));
-		deleteEUButton.addActionListener(new RefListFrame_deleteEUButton_actionAdapter(this));
-		undoDeleteEnumValButton.setEnabled(false);
-//		undoDeleteEnumValButton.setMaximumSize(new Dimension(122, 23));
-//		undoDeleteEnumValButton.setMinimumSize(new Dimension(122, 23));
-//		undoDeleteEnumValButton.setPreferredSize(new Dimension(122, 23));
-		undoDeleteEnumValButton.setText(labels.getString("RefListFrame.undoDelete"));
-		undoDeleteEnumValButton.addActionListener(new RefListFrame_undoDeleteEnumValButton_actionAdapter(this));
-		undoDeleteEUButton.setEnabled(false);
-//		undoDeleteEUButton.setMaximumSize(new Dimension(122, 23));
-//		undoDeleteEUButton.setMinimumSize(new Dimension(122, 23));
-//		undoDeleteEUButton.setPreferredSize(new Dimension(122, 23));
-		undoDeleteEUButton.setText(labels.getString("RefListFrame.undoDelete"));
-		undoDeleteEUButton.addActionListener(new RefListFrame_undoDeleteEUButton_actionAdapter(this));
-		
-		EuCnvtTab.setLayout(borderLayout4);
-		jTextArea3.setFont(new java.awt.Font("Serif", 0, 14));
-		jTextArea3.setBorder(border7);
-		jTextArea3.setEditable(false);
-		jTextArea3.setText(labels.getString("RefListFrame.euconversionsDesc"));
-		jTextArea3.setLineWrap(true);
-		jTextArea3.setRows(3);
-		jTextArea3.setWrapStyleWord(true);
-		jPanel4.setLayout(gridBagLayout3);
-		addEUCnvtButton.setMaximumSize(new Dimension(122, 23));
-		addEUCnvtButton.setMinimumSize(new Dimension(122, 23));
-		addEUCnvtButton.setPreferredSize(new Dimension(122, 23));
-		addEUCnvtButton.setText(genericLabels.getString("add"));
-		addEUCnvtButton.addActionListener(new RefListFrame_addEUCnvtButton_actionAdapter(this));
-		editEUCnvtButton.setMaximumSize(new Dimension(122, 23));
-		editEUCnvtButton.setMinimumSize(new Dimension(122, 23));
-		editEUCnvtButton.setPreferredSize(new Dimension(122, 23));
-		editEUCnvtButton.setRequestFocusEnabled(true);
-		editEUCnvtButton.setText(genericLabels.getString("edit"));
-		editEUCnvtButton.addActionListener(new RefListFrame_editEUCnvtButton_actionAdapter(this));
-		deleteEUCnvtButton.setMaximumSize(new Dimension(122, 23));
-		deleteEUCnvtButton.setMinimumSize(new Dimension(122, 23));
-		deleteEUCnvtButton.setPreferredSize(new Dimension(122, 23));
-		deleteEUCnvtButton.setText(genericLabels.getString("delete"));
-		deleteEUCnvtButton.addActionListener(new RefListFrame_deleteEUCnvtButton_actionAdapter(this));
-//		undoDelEuCnvtButton.setMaximumSize(new Dimension(122, 23));
-//		undoDelEuCnvtButton.setMinimumSize(new Dimension(122, 23));
-//		undoDelEuCnvtButton.setPreferredSize(new Dimension(122, 23));
-		undoDelEuCnvtButton.setText(labels.getString("RefListFrame.undoDelete"));
-		undoDelEuCnvtButton.addActionListener(new RefListFrame_undoDelEuCnvtButton_actionAdapter(this));
-		
+    private DTEquivTableModel dteTableModel = new DTEquivTableModel();
+    private JTable dteTable = new SortingListTable(dteTableModel,null);
+    private JButton addDTEButton = new JButton();
+    private JButton editDTEButton = new JButton();
+    private JButton deleteDTEButton = new JButton();
+    private JButton undoDeleteDTEButton = new JButton();
+
+
+    private Border border6;
+    private Border border7;
+
+    //================================================
+
+    private boolean unitsChanged = false;
+    private boolean convertersChanged = false;
+    private boolean dtsChanged = false;
+    private boolean seasonsChanged = false;
+
+    private EngineeringUnit deletedEU = null;
+    private UnitConverterDb deletedConverter = null;
+    private String []deletedDte = null;
+
+    private SeasonListTableModel seasonListTableModel = new SeasonListTableModel();
+    private SortingListTable seasonsTable = new SortingListTable(seasonListTableModel,
+        SeasonListTableModel.colWidths);
+
+    private final OpenDcsDatabase database;
+
+    /**
+     * No args constructor for JBuilder.
+     */
+    public RefListFrame(OpenDcsDatabase database)
+    {
+        this.database = database;
+        this.EnumTab = new EnumerationPanel(database);
+        enableEvents(AWTEvent.WINDOW_EVENT_MASK);
+        try
+        {
+            jbInit();
+            initControls();
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+        }
+
+        // Default operation is to do nothing when user hits 'X' in upper
+        // right to close the window. We will catch the closing event and
+        // do the same thing as if user had hit File - Exit.
+        setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+        addWindowListener(
+            new WindowAdapter()
+            {
+                public void windowClosing(WindowEvent e)
+                {
+                      jMenuFileExit_actionPerformed(null);
+                }
+            });
+    }
+
+    /**
+     * Initializes the controls in the frames.
+     * Calls the init methods in other GUI objects, table models, etc.
+     */
+    private void initControls()
+    {
+
+        euTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        euTable.setRowHeight(20);
+        ucTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        ucTable.setRowHeight(20);
+        dteTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        dteTable.setRowHeight(20);
+    }
+
+    /** Initializes GUI components. */
+    private void jbInit() throws Exception
+    {
+        contentPane = (JPanel) this.getContentPane();
+
+        border4 = BorderFactory.createCompoundBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED,Color.white,Color.white,new Color(124, 124, 124),new Color(178, 178, 178)),BorderFactory.createEmptyBorder(6,6,6,6));
+
+        border6 = BorderFactory.createCompoundBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED,Color.white,Color.white,new Color(124, 124, 124),new Color(178, 178, 178)),BorderFactory.createEmptyBorder(6,6,6,6));
+        border7 = BorderFactory.createCompoundBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED,Color.white,Color.white,new Color(124, 124, 124),new Color(178, 178, 178)),BorderFactory.createEmptyBorder(6,6,6,6));
+        contentPane.setLayout(borderLayout1);
+        this.setFont(new java.awt.Font("Serif", 0, 16));
+        this.setSize(new Dimension(800, 536));
+        this.setTitle(labels.getString("RefListFrame.frameTitle"));
+        statusBar.setText(" ");
+        jMenuFile.setText(genericLabels.getString("file"));
+        jMenuFileExit.setText(genericLabels.getString("exit"));
+        jMenuFileExit.addActionListener(new RefListFrame_jMenuFileExit_ActionAdapter(this));
+        jMenuHelp.setText(genericLabels.getString("help"));
+        jMenuHelpAbout.setText(genericLabels.getString("about"));
+        jMenuHelpAbout.addActionListener(new RefListFrame_jMenuHelpAbout_ActionAdapter(this));
+        rlTabbedPane.setTabPlacement(JTabbedPane.TOP);
+        mi_saveToDb.setText(labels.getString("RefListFrame.saveToDB"));
+        mi_saveToDb.addActionListener(new RefListFrame_mi_saveToDb_actionAdapter(this));
+
+
+        EUTab.setLayout(borderLayout3);
+        jTextArea2.setFont(new java.awt.Font("Serif", 0, 14));
+        jTextArea2.setBorder(border6);
+        jTextArea2.setEditable(false);
+        jTextArea2.setText(labels.getString("RefListFrame.engineeringTabDesc"));
+        jTextArea2.setLineWrap(true);
+        jTextArea2.setRows(3);
+        jTextArea2.setWrapStyleWord(true);
+        jPanel3.setLayout(gridBagLayout2);
+        addEUButton.setMaximumSize(new Dimension(122, 23));
+        addEUButton.setMinimumSize(new Dimension(122, 23));
+        addEUButton.setPreferredSize(new Dimension(122, 23));
+        addEUButton.setText(genericLabels.getString("add"));
+        addEUButton.addActionListener(new RefListFrame_addEUButton_actionAdapter(this));
+        editEUButton.setMaximumSize(new Dimension(122, 23));
+        editEUButton.setMinimumSize(new Dimension(122, 23));
+        editEUButton.setPreferredSize(new Dimension(122, 23));
+        editEUButton.setText(genericLabels.getString("edit"));
+        editEUButton.addActionListener(new RefListFrame_editEUButton_actionAdapter(this));
+        deleteEUButton.setMaximumSize(new Dimension(122, 23));
+        deleteEUButton.setMinimumSize(new Dimension(122, 23));
+        deleteEUButton.setPreferredSize(new Dimension(122, 23));
+        deleteEUButton.setText(genericLabels.getString("delete"));
+        deleteEUButton.addActionListener(new RefListFrame_deleteEUButton_actionAdapter(this));
+
+        undoDeleteEUButton.setEnabled(false);
+//        undoDeleteEUButton.setMaximumSize(new Dimension(122, 23));
+//        undoDeleteEUButton.setMinimumSize(new Dimension(122, 23));
+//        undoDeleteEUButton.setPreferredSize(new Dimension(122, 23));
+        undoDeleteEUButton.setText(labels.getString("RefListFrame.undoDelete"));
+        undoDeleteEUButton.addActionListener(new RefListFrame_undoDeleteEUButton_actionAdapter(this));
+
+        EuCnvtTab.setLayout(borderLayout4);
+        jTextArea3.setFont(new java.awt.Font("Serif", 0, 14));
+        jTextArea3.setBorder(border7);
+        jTextArea3.setEditable(false);
+        jTextArea3.setText(labels.getString("RefListFrame.euconversionsDesc"));
+        jTextArea3.setLineWrap(true);
+        jTextArea3.setRows(3);
+        jTextArea3.setWrapStyleWord(true);
+        jPanel4.setLayout(gridBagLayout3);
+        addEUCnvtButton.setMaximumSize(new Dimension(122, 23));
+        addEUCnvtButton.setMinimumSize(new Dimension(122, 23));
+        addEUCnvtButton.setPreferredSize(new Dimension(122, 23));
+        addEUCnvtButton.setText(genericLabels.getString("add"));
+        addEUCnvtButton.addActionListener(new RefListFrame_addEUCnvtButton_actionAdapter(this));
+        editEUCnvtButton.setMaximumSize(new Dimension(122, 23));
+        editEUCnvtButton.setMinimumSize(new Dimension(122, 23));
+        editEUCnvtButton.setPreferredSize(new Dimension(122, 23));
+        editEUCnvtButton.setRequestFocusEnabled(true);
+        editEUCnvtButton.setText(genericLabels.getString("edit"));
+        editEUCnvtButton.addActionListener(new RefListFrame_editEUCnvtButton_actionAdapter(this));
+        deleteEUCnvtButton.setMaximumSize(new Dimension(122, 23));
+        deleteEUCnvtButton.setMinimumSize(new Dimension(122, 23));
+        deleteEUCnvtButton.setPreferredSize(new Dimension(122, 23));
+        deleteEUCnvtButton.setText(genericLabels.getString("delete"));
+        deleteEUCnvtButton.addActionListener(new RefListFrame_deleteEUCnvtButton_actionAdapter(this));
+//        undoDelEuCnvtButton.setMaximumSize(new Dimension(122, 23));
+//        undoDelEuCnvtButton.setMinimumSize(new Dimension(122, 23));
+//        undoDelEuCnvtButton.setPreferredSize(new Dimension(122, 23));
+        undoDelEuCnvtButton.setText(labels.getString("RefListFrame.undoDelete"));
+        undoDelEuCnvtButton.addActionListener(new RefListFrame_undoDelEuCnvtButton_actionAdapter(this));
 
 
 
 
-		addDTEButton.setMaximumSize(new Dimension(122, 23));
-		addDTEButton.setMinimumSize(new Dimension(122, 23));
-		addDTEButton.setPreferredSize(new Dimension(122, 23));
-		addDTEButton.setText(labels.getString("RefListFrame.addEquiv"));
-		addDTEButton.addActionListener(new RefListFrame_addDTEButton_actionAdapter(this));
-		editDTEButton.setMaximumSize(new Dimension(122, 23));
-		editDTEButton.setMinimumSize(new Dimension(122, 23));
-		editDTEButton.setPreferredSize(new Dimension(122, 23));
-		editDTEButton.setMargin(new Insets(2, 14, 2, 14));
-		editDTEButton.setText(genericLabels.getString("edit"));
-		editDTEButton.addActionListener(new RefListFrame_editDTEButton_actionAdapter(this));
-		deleteDTEButton.setMaximumSize(new Dimension(122, 23));
-		deleteDTEButton.setMinimumSize(new Dimension(122, 23));
-		deleteDTEButton.setPreferredSize(new Dimension(122, 23));
-		deleteDTEButton.setText(labels.getString("RefListFrame.deleteEquiv"));
-		deleteDTEButton.addActionListener(new RefListFrame_deleteDTEButton_actionAdapter(this));
-		undoDeleteDTEButton.setEnabled(false);
-		undoDeleteDTEButton.setText(labels.getString("RefListFrame.undoDelete"));
-		undoDeleteDTEButton.addActionListener(new RefListFrame_undoDeleteDTEButton_actionAdapter(this));
 
-		contentPane.setFont(new java.awt.Font("Dialog", 0, 14));
-	EuCnvtTab.setBorder(BorderFactory.createEmptyBorder());
-	jMenuFile.add(mi_saveToDb);
-		jMenuFile.add(jMenuFileExit);
-		jMenuHelp.add(jMenuHelpAbout);
-		jMenuBar1.add(jMenuFile);
-		jMenuBar1.add(jMenuHelp);
-		this.setJMenuBar(jMenuBar1);
-		contentPane.add(statusBar, BorderLayout.SOUTH);
-		contentPane.add(rlTabbedPane, BorderLayout.CENTER);
-		
-		rlTabbedPane.add(EnumTab,	 labels.getString("RefListFrame.enumTab"));
-		EnumTab.add(jTextArea1, BorderLayout.NORTH);
-		EnumTab.add(jPanel1, BorderLayout.CENTER);
-		jPanel1.add(jScrollPane1,	 new GridBagConstraints(0, 1, 1, 7, 1.0, 1.0
-						,GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(5, 8, 12, 0), 10, -98));
-		jScrollPane1.getViewport().add(enumTable, null);
-		
-		rlTabbedPane.add(EUTab,	labels.getString("RefListFrame.EngUnitsTab"));
-		EUTab.add(jTextArea2, BorderLayout.NORTH);
-		EUTab.add(jPanel3, BorderLayout.CENTER);
-		jPanel3.add(jScrollPane2,	new GridBagConstraints(0, 0, 1, 4, 1.0, 1.0
-						,GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(18, 10, 13, 0), 18, -56));
-		jScrollPane2.getViewport().add(euTable, null);
-		
-		rlTabbedPane.add(EuCnvtTab,	labels.getString("RefListFrame.euConvTab"));
-		EuCnvtTab.add(jTextArea3, BorderLayout.NORTH);
-		EuCnvtTab.add(jPanel4, BorderLayout.CENTER);
-		jPanel4.add(jScrollPane3,	new GridBagConstraints(0, 0, 1, 4, 1.0, 1.0
-						,GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(21, 11, 10, 0), 25, -90));
-		jScrollPane3.getViewport().add(ucTable, null);
-		
-		JPanel dtTab = new JPanel(new BorderLayout());
-		JTextArea dtTabDescArea = new JTextArea();
-		dtTabDescArea.setFont(new java.awt.Font("Serif", 0, 14));
-		dtTabDescArea.setBorder(border4);
-		dtTabDescArea.setEditable(false);
-		dtTabDescArea.setText(labels.getString("RefListFrame.dataTypeEquDesc"));
-		dtTabDescArea.setLineWrap(true);
-		dtTabDescArea.setRows(3);
-		dtTabDescArea.setWrapStyleWord(true);
-		dtTab.add(dtTabDescArea, BorderLayout.NORTH);
-		JPanel dtePanelCenter = new JPanel(new GridBagLayout());
-		JScrollPane dtePanelScrollPane = new JScrollPane();
-		dtePanelScrollPane.getViewport().add(dteTable, null);
-		dtePanelCenter.add(dtePanelScrollPane,	 new GridBagConstraints(0, 0, 1, 4, 1.0, 1.0,
-			GridBagConstraints.CENTER, GridBagConstraints.BOTH, 
-			new Insets(17, 15, 10, 0), 27, -77));
-		dtTab.add(dtePanelCenter, BorderLayout.CENTER);
-		rlTabbedPane.add(dtTab,	labels.getString("RefListFrame.dataTypeEquivTab"));
+        addDTEButton.setMaximumSize(new Dimension(122, 23));
+        addDTEButton.setMinimumSize(new Dimension(122, 23));
+        addDTEButton.setPreferredSize(new Dimension(122, 23));
+        addDTEButton.setText(labels.getString("RefListFrame.addEquiv"));
+        addDTEButton.addActionListener(new RefListFrame_addDTEButton_actionAdapter(this));
+        editDTEButton.setMaximumSize(new Dimension(122, 23));
+        editDTEButton.setMinimumSize(new Dimension(122, 23));
+        editDTEButton.setPreferredSize(new Dimension(122, 23));
+        editDTEButton.setMargin(new Insets(2, 14, 2, 14));
+        editDTEButton.setText(genericLabels.getString("edit"));
+        editDTEButton.addActionListener(new RefListFrame_editDTEButton_actionAdapter(this));
+        deleteDTEButton.setMaximumSize(new Dimension(122, 23));
+        deleteDTEButton.setMinimumSize(new Dimension(122, 23));
+        deleteDTEButton.setPreferredSize(new Dimension(122, 23));
+        deleteDTEButton.setText(labels.getString("RefListFrame.deleteEquiv"));
+        deleteDTEButton.addActionListener(new RefListFrame_deleteDTEButton_actionAdapter(this));
+        undoDeleteDTEButton.setEnabled(false);
+        undoDeleteDTEButton.setText(labels.getString("RefListFrame.undoDelete"));
+        undoDeleteDTEButton.addActionListener(new RefListFrame_undoDeleteDTEButton_actionAdapter(this));
+
+        contentPane.setFont(new java.awt.Font("Dialog", 0, 14));
+    EuCnvtTab.setBorder(BorderFactory.createEmptyBorder());
+    jMenuFile.add(mi_saveToDb);
+        jMenuFile.add(jMenuFileExit);
+        jMenuHelp.add(jMenuHelpAbout);
+        jMenuBar1.add(jMenuFile);
+        jMenuBar1.add(jMenuHelp);
+        this.setJMenuBar(jMenuBar1);
+        contentPane.add(statusBar, BorderLayout.SOUTH);
+        contentPane.add(rlTabbedPane, BorderLayout.CENTER);
+
+        rlTabbedPane.add(EnumTab,     labels.getString("RefListFrame.enumTab"));
 
 
-		// =========== Seasons Tab ==============
-		JPanel seasonsTab = new JPanel(new BorderLayout());
-		JTextArea seasonsTabDescArea = new JTextArea();
-		seasonsTabDescArea.setFont(new java.awt.Font("Serif", 0, 14));
-		seasonsTabDescArea.setBorder(border4);
-		seasonsTabDescArea.setEditable(false);
-		seasonsTabDescArea.setText(labels.getString("SeasonsTab.desc"));
-		seasonsTabDescArea.setLineWrap(true);
-		seasonsTabDescArea.setRows(3);
-		seasonsTabDescArea.setWrapStyleWord(true);
-		seasonsTab.add(seasonsTabDescArea, BorderLayout.NORTH);
-		JPanel seasonsPanelCenter = new JPanel(new GridBagLayout());
-		JScrollPane seasonsPanelScrollPane = new JScrollPane();
-		seasonsPanelScrollPane.getViewport().add(seasonsTable, null);
-		seasonsPanelCenter.add(seasonsPanelScrollPane,
-			new GridBagConstraints(0, 0, 1, 5, 1.0, 1.0,
-				GridBagConstraints.CENTER, GridBagConstraints.BOTH, 
-				new Insets(17, 15, 10, 0), 27, -77));
-		seasonsTab.add(seasonsPanelCenter, BorderLayout.CENTER);
-		JButton addSeasonButton = new JButton(genericLabels.getString("add"));
-		addSeasonButton.addActionListener(
-			new ActionListener()
-			{
-				@Override
-				public void actionPerformed(ActionEvent e)
-				{
-					addSeasonPressed();
-				}
-			});
-		seasonsPanelCenter.add(addSeasonButton,
-			new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
-				GridBagConstraints.SOUTH, GridBagConstraints.HORIZONTAL, 
-				new Insets(10, 5, 5, 5), 0, 0));
-		
-		JButton editSeasonButton = new JButton(genericLabels.getString("edit"));
-		editSeasonButton.addActionListener(
-			new ActionListener()
-			{
-				@Override
-				public void actionPerformed(ActionEvent e)
-				{
-					editSeasonPressed();
-				}
-			});
-		seasonsPanelCenter.add(editSeasonButton,
-			new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0,
-				GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL, 
-				new Insets(5, 5, 5, 5), 0, 0));
-		
-		JButton deleteSeasonButton = new JButton(genericLabels.getString("delete"));
-		deleteSeasonButton.addActionListener(
-			new ActionListener()
-			{
-				@Override
-				public void actionPerformed(ActionEvent e)
-				{
-					deleteSeasonPressed();
-				}
-			});
-		seasonsPanelCenter.add(deleteSeasonButton,
-			new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0,
-				GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL, 
-				new Insets(5, 5, 5, 5), 0, 0));
+        rlTabbedPane.add(EUTab,    labels.getString("RefListFrame.EngUnitsTab"));
+        EUTab.add(jTextArea2, BorderLayout.NORTH);
+        EUTab.add(jPanel3, BorderLayout.CENTER);
+        jPanel3.add(jScrollPane2,    new GridBagConstraints(0, 0, 1, 4, 1.0, 1.0
+                        ,GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(18, 10, 13, 0), 18, -56));
+        jScrollPane2.getViewport().add(euTable, null);
 
-		JButton seasonUpButton = new JButton(labels.getString("RefListFrame.moveUp"));
-		seasonUpButton.addActionListener(
-			new ActionListener()
-			{
-				@Override
-				public void actionPerformed(ActionEvent e)
-				{
-					seasonUpPressed();
-				}
-			});
-		seasonsPanelCenter.add(seasonUpButton,
-			new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0,
-				GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL, 
-				new Insets(5, 5, 5, 5), 0, 0));
+        rlTabbedPane.add(EuCnvtTab,    labels.getString("RefListFrame.euConvTab"));
+        EuCnvtTab.add(jTextArea3, BorderLayout.NORTH);
+        EuCnvtTab.add(jPanel4, BorderLayout.CENTER);
+        jPanel4.add(jScrollPane3,    new GridBagConstraints(0, 0, 1, 4, 1.0, 1.0
+                        ,GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(21, 11, 10, 0), 25, -90));
+        jScrollPane3.getViewport().add(ucTable, null);
 
-		JButton seasonDownButton = new JButton(labels.getString("RefListFrame.moveDown"));
-		seasonDownButton.addActionListener(
-			new ActionListener()
-			{
-				@Override
-				public void actionPerformed(ActionEvent e)
-				{
-					seasonDownPressed();
-				}
-			});
-		seasonsPanelCenter.add(seasonDownButton,
-			new GridBagConstraints(1, 4, 1, 1, 0.0, 0.0,
-				GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL, 
-				new Insets(5, 5, 5, 5), 0, 0));
-		
-		rlTabbedPane.add(seasonsTab, labels.getString("SeasonsTab.tabName"));
-		
-		
-		//====================================
-		jPanel1.add(editEnumValButton,		new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
-		jPanel1.add(deleteEnumValButton,	 new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
-		jPanel1.add(jPanel2,	 new GridBagConstraints(0, 0, 2, 1, 1.0, 0.1
-						,GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL, new Insets(14, 18, 14, 12), 0, 7));
-		
-		jPanel2.add(jLabel1, null);
-		jPanel2.add(enumComboBox, null);
-		
-		jPanel1.add(addEnumValButton,		new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
-		jPanel1.add(downEnumValButton,	 new GridBagConstraints(1, 7, 1, 1, 0.0, 0.0
-						,GridBagConstraints.NORTH, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
-		jPanel1.add(selectEnumValDefaultButton,	 new GridBagConstraints(1, 5, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
-		jPanel1.add(upEnumValButton,	 new GridBagConstraints(1, 6, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
-		jPanel1.add(undoDeleteEnumValButton,	 new GridBagConstraints(1, 4, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
-		
-		jPanel3.add(addEUButton,		new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(15, 20, 5, 20), 0, 0));
-		jPanel3.add(undoDeleteEUButton,	 new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0
-						,GridBagConstraints.NORTH, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
-		jPanel3.add(deleteEUButton,	 new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
-		jPanel3.add(editEUButton,	 new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
-		
-		jPanel4.add(addEUCnvtButton,		new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(15, 16, 5, 12), 0, 0));
-		jPanel4.add(editEUCnvtButton,	 new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 16, 5, 12), 0, 0));
-		jPanel4.add(deleteEUCnvtButton,	 new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0
-						,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 16, 5, 12), 0, 0));
-		jPanel4.add(undoDelEuCnvtButton,	 new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0
-						,GridBagConstraints.NORTH, GridBagConstraints.NONE, new Insets(5, 16, 5, 12), 0, 0));
-		
-		dtePanelCenter.add(addDTEButton, 
-			new GridBagConstraints(1, 0, 1, 1, 0.0, 0.5,
-				GridBagConstraints.SOUTH, GridBagConstraints.NONE, 
-				new Insets(5, 20, 5, 20), 0, 0));
-		dtePanelCenter.add(editDTEButton,
-			new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0,
-				GridBagConstraints.CENTER, GridBagConstraints.NONE, 
-				new Insets(5, 20, 5, 20), 0, 0));
-		dtePanelCenter.add(deleteDTEButton,
-			new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0,
-				GridBagConstraints.CENTER, GridBagConstraints.NONE,
-				new Insets(5, 20, 5, 20), 0, 0));
-		dtePanelCenter.add(undoDeleteDTEButton,
-			new GridBagConstraints(1, 3, 1, 1, 0.0, .5,
-				GridBagConstraints.NORTH, GridBagConstraints.NONE,
-				new Insets(5, 20, 5, 20), 0, 0));
-	}
-
-	protected void seasonDownPressed()
-	{
-		int row = seasonsTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(
-				labels.getString("SeasonsTab.noSelection") + " " + 
-				labels.getString("RefListFrame.moveDown"));
-			return;
-		}
-		if (seasonListTableModel.moveDown(row))
-			seasonsTable.setRowSelectionInterval(row+1, row+1);
-		seasonsChanged = true;
-	}
-
-	protected void seasonUpPressed()
-	{
-		int row = seasonsTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(
-				labels.getString("SeasonsTab.noSelection") + " " + 
-				labels.getString("RefListFrame.moveUp"));
-			return;
-		}
-		if (seasonListTableModel.moveUp(row))
-			seasonsTable.setRowSelectionInterval(row-1, row-1);
-		seasonsChanged = true;
-	}
-
-	protected void deleteSeasonPressed()
-	{
-		Season season = null;
-		int idx = this.seasonsTable.getSelectedRow();
-		if (idx == -1
-		 || (season = (Season)seasonListTableModel.getRowObject(idx)) == null)
-		{
-			showError(
-				labels.getString("SeasonsTab.noSelection") + " " + genericLabels.getString("delete"));
-			return;
-		}
-		int r = JOptionPane.showConfirmDialog(this,
-			"Confirm", labels.getString("SeasonsTab.confirmDelete") + " " + season.getAbbr(),
-			JOptionPane.YES_NO_OPTION);
-		if (r != JOptionPane.YES_OPTION)
-			return;
-		seasonListTableModel.deleteAt(idx);
-		seasonsChanged = true;
-	}
-
-	protected void editSeasonPressed()
-	{
-		Season season = null;
-		int idx = this.seasonsTable.getSelectedRow();
-		if (idx == -1
-		 || (season = (Season)seasonListTableModel.getRowObject(idx)) == null)
-		{
-			showError(
-				labels.getString("SeasonsTab.noSelection") + " " + genericLabels.getString("edit"));
-			return;
-		}
-		SeasonEditDialog dlg = new SeasonEditDialog(this);
-		dlg.fillValues(season);
-		launchDialog(dlg);
-		if (dlg.isOkPressed())
-		{
-			seasonListTableModel.fireTableDataChanged();
-			seasonsChanged = true;
-		}
-	}
-
-	protected void addSeasonPressed()
-	{
-		Season season = new Season();
-		SeasonEditDialog dlg = new SeasonEditDialog(this);
-		dlg.fillValues(season);
-		launchDialog(dlg);
-		if (dlg.isOkPressed())
-		{
-			seasonListTableModel.add(season);
-			seasonsChanged = true;
-		}
-	}
-
-	/** 
-	 * File | Exit action performed.
-	 * @param e ignored
-	 */
-	public void jMenuFileExit_actionPerformed(ActionEvent e) 
-	{
-		if (enumsChanged || unitsChanged || convertersChanged || dtsChanged || seasonsChanged)
-		{
-			int r = JOptionPane.showConfirmDialog(this,
-				labels.getString("RefListFrame.unsavedChangesQues"), 
-				labels.getString("RefListFrame.confirmExit"),
-				JOptionPane.YES_NO_OPTION);
-			if (r != JOptionPane.YES_OPTION)
-				return;
-		}
-		System.exit(0);
-	}
-
-	/**
-	 * Help | About action performed.
-	 * @param e ignored
-	 */
-	public void jMenuHelpAbout_actionPerformed(ActionEvent e) {
-		RefListFrame_AboutBox dlg = new RefListFrame_AboutBox(this);
-		Dimension dlgSize = dlg.getPreferredSize();
-		Dimension frmSize = getSize();
-		java.awt.Point loc = getLocation();
-		dlg.setLocation((frmSize.width - dlgSize.width) / 2 + loc.x, (frmSize.height - dlgSize.height) / 2 + loc.y);
-		dlg.setModal(true);
-		dlg.pack();
-		dlg.setVisible(true);
-//		dlg.show();
-	}
-
-	/**
-	 * Selects an Enumeration to be displayed in the table.
-	 * The table is repopulated and the 'Undo' button is disabled.
-	 * @param e ActionEvent
-	 */
-	void enumComboBox_actionPerformed(ActionEvent e)
-	{
-		// todo: Populate table from selected enum.
-		String s = (String)enumComboBox.getSelectedItem();
-		s = TextUtil.removeAllSpace(s);
-		enumTableModel.setEnum(s);
-		deletedEnumValue = null;
-		deletedEU = null;
-		deletedConverter = null;
-		undoDeleteEnumValButton.setEnabled(false);
-	}
+        JPanel dtTab = new JPanel(new BorderLayout());
+        JTextArea dtTabDescArea = new JTextArea();
+        dtTabDescArea.setFont(new java.awt.Font("Serif", 0, 14));
+        dtTabDescArea.setBorder(border4);
+        dtTabDescArea.setEditable(false);
+        dtTabDescArea.setText(labels.getString("RefListFrame.dataTypeEquDesc"));
+        dtTabDescArea.setLineWrap(true);
+        dtTabDescArea.setRows(3);
+        dtTabDescArea.setWrapStyleWord(true);
+        dtTab.add(dtTabDescArea, BorderLayout.NORTH);
+        JPanel dtePanelCenter = new JPanel(new GridBagLayout());
+        JScrollPane dtePanelScrollPane = new JScrollPane();
+        dtePanelScrollPane.getViewport().add(dteTable, null);
+        dtePanelCenter.add(dtePanelScrollPane,     new GridBagConstraints(0, 0, 1, 4, 1.0, 1.0,
+            GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+            new Insets(17, 15, 10, 0), 27, -77));
+        dtTab.add(dtePanelCenter, BorderLayout.CENTER);
+        rlTabbedPane.add(dtTab,    labels.getString("RefListFrame.dataTypeEquivTab"));
 
 
-	/**
-	 * Displays modal enum value dialog. If OK pressed, results are added
-	 * to table.
-	 * Sets modified flag.
-	 * @param e ActionEvent
-	 */
-	void addEnumValButton_actionPerformed(ActionEvent e)
-	{
-		String s = TextUtil.removeAllSpace(
-			(String)enumComboBox.getSelectedItem());
-		decodes.db.DbEnum en = Database.getDb().getDbEnum(s);
+        // =========== Seasons Tab ==============
+        JPanel seasonsTab = new JPanel(new BorderLayout());
+        JTextArea seasonsTabDescArea = new JTextArea();
+        seasonsTabDescArea.setFont(new java.awt.Font("Serif", 0, 14));
+        seasonsTabDescArea.setBorder(border4);
+        seasonsTabDescArea.setEditable(false);
+        seasonsTabDescArea.setText(labels.getString("SeasonsTab.desc"));
+        seasonsTabDescArea.setLineWrap(true);
+        seasonsTabDescArea.setRows(3);
+        seasonsTabDescArea.setWrapStyleWord(true);
+        seasonsTab.add(seasonsTabDescArea, BorderLayout.NORTH);
+        JPanel seasonsPanelCenter = new JPanel(new GridBagLayout());
+        JScrollPane seasonsPanelScrollPane = new JScrollPane();
+        seasonsPanelScrollPane.getViewport().add(seasonsTable, null);
+        seasonsPanelCenter.add(seasonsPanelScrollPane,
+            new GridBagConstraints(0, 0, 1, 5, 1.0, 1.0,
+                GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                new Insets(17, 15, 10, 0), 27, -77));
+        seasonsTab.add(seasonsPanelCenter, BorderLayout.CENTER);
+        JButton addSeasonButton = new JButton(genericLabels.getString("add"));
+        addSeasonButton.addActionListener(
+            new ActionListener()
+            {
+                @Override
+                public void actionPerformed(ActionEvent e)
+                {
+                    addSeasonPressed();
+                }
+            });
+        seasonsPanelCenter.add(addSeasonButton,
+            new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
+                GridBagConstraints.SOUTH, GridBagConstraints.HORIZONTAL,
+                new Insets(10, 5, 5, 5), 0, 0));
 
-		EnumValueDialog evd = new EnumValueDialog();
-		EnumValue ev = new EnumValue(en, "", "", "", "");
-		evd.fillValues(ev);
-		launchDialog(evd);
-		if (evd.wasChanged())
-		{
-			en.replaceValue(ev.getValue(), ev.getDescription(), ev.getExecClassName(), "");
-			enumTableModel.fireTableDataChanged();
-			enumsChanged = true;
-		}
-	}
+        JButton editSeasonButton = new JButton(genericLabels.getString("edit"));
+        editSeasonButton.addActionListener(
+            new ActionListener()
+            {
+                @Override
+                public void actionPerformed(ActionEvent e)
+                {
+                    editSeasonPressed();
+                }
+            });
+        seasonsPanelCenter.add(editSeasonButton,
+            new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                new Insets(5, 5, 5, 5), 0, 0));
+
+        JButton deleteSeasonButton = new JButton(genericLabels.getString("delete"));
+        deleteSeasonButton.addActionListener(
+            new ActionListener()
+            {
+                @Override
+                public void actionPerformed(ActionEvent e)
+                {
+                    deleteSeasonPressed();
+                }
+            });
+        seasonsPanelCenter.add(deleteSeasonButton,
+            new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                new Insets(5, 5, 5, 5), 0, 0));
+
+        JButton seasonUpButton = new JButton(labels.getString("RefListFrame.moveUp"));
+        seasonUpButton.addActionListener(
+            new ActionListener()
+            {
+                @Override
+                public void actionPerformed(ActionEvent e)
+                {
+                    seasonUpPressed();
+                }
+            });
+        seasonsPanelCenter.add(seasonUpButton,
+            new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                new Insets(5, 5, 5, 5), 0, 0));
+
+        JButton seasonDownButton = new JButton(labels.getString("RefListFrame.moveDown"));
+        seasonDownButton.addActionListener(
+            new ActionListener()
+            {
+                @Override
+                public void actionPerformed(ActionEvent e)
+                {
+                    seasonDownPressed();
+                }
+            });
+        seasonsPanelCenter.add(seasonDownButton,
+            new GridBagConstraints(1, 4, 1, 1, 0.0, 0.0,
+                GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL,
+                new Insets(5, 5, 5, 5), 0, 0));
+
+        rlTabbedPane.add(seasonsTab, labels.getString("SeasonsTab.tabName"));
 
 
-	/**
-	* Displays modal enum-value dialog with selected EV. If OK pressed
-	* the dialog contents are added to the table.
-	* The 'modified' flag is set.
-	* @param e ActionEvent
-	*/
-	void editEnumValButton_actionPerformed(ActionEvent e)
-	{
-		int row = enumTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.enumSelectInfo"));
-			return;
-		}
 
-		String s = TextUtil.removeAllSpace(
-			(String)enumComboBox.getSelectedItem());
-		decodes.db.DbEnum en = Database.getDb().getDbEnum(s);
-		EnumValue ev = enumTableModel.getEnumValueAt(row);
-		EnumValueDialog evd = new EnumValueDialog();
-		evd.fillValues(ev);
-		launchDialog(evd);
-		if (evd.wasChanged())
-		{
-			en.replaceValue(ev.getValue(), ev.getDescription(), ev.getExecClassName(), ev.getEditClassName());
-			enumTableModel.fireTableDataChanged();
-			enumsChanged = true;
-		}
-	}
+        jPanel3.add(addEUButton,        new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0
+                        ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(15, 20, 5, 20), 0, 0));
+        jPanel3.add(undoDeleteEUButton,     new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0
+                        ,GridBagConstraints.NORTH, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
+        jPanel3.add(deleteEUButton,     new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0
+                        ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
+        jPanel3.add(editEUButton,     new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0
+                        ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
 
-	/**
-	 * Deletes the selected enum-value from the table and places it in the
-	 * undo buffer. Enables the Undo Delete button.
-	 * @param e ActionEvent
-	 */
-	void deleteEnumValButton_actionPerformed(ActionEvent e)
-	{
-		int row = enumTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.enumDeleteInfo"));
-			return;
-		}
+        jPanel4.add(addEUCnvtButton,        new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0
+                        ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(15, 16, 5, 12), 0, 0));
+        jPanel4.add(editEUCnvtButton,     new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0
+                        ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 16, 5, 12), 0, 0));
+        jPanel4.add(deleteEUCnvtButton,     new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0
+                        ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 16, 5, 12), 0, 0));
+        jPanel4.add(undoDelEuCnvtButton,     new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0
+                        ,GridBagConstraints.NORTH, GridBagConstraints.NONE, new Insets(5, 16, 5, 12), 0, 0));
 
-		String s = TextUtil.removeAllSpace(
-			(String)enumComboBox.getSelectedItem());
-		decodes.db.DbEnum en = Database.getDb().getDbEnum(s);
-		deletedEnumValue = enumTableModel.getEnumValueAt(row);
-		en.removeValue(deletedEnumValue.getValue());
-		enumTableModel.fireTableDataChanged();
-		undoDeleteEnumValButton.setEnabled(true);
-		enumsChanged = true;
-	}
+        dtePanelCenter.add(addDTEButton,
+            new GridBagConstraints(1, 0, 1, 1, 0.0, 0.5,
+                GridBagConstraints.SOUTH, GridBagConstraints.NONE,
+                new Insets(5, 20, 5, 20), 0, 0));
+        dtePanelCenter.add(editDTEButton,
+            new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                new Insets(5, 20, 5, 20), 0, 0));
+        dtePanelCenter.add(deleteDTEButton,
+            new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                new Insets(5, 20, 5, 20), 0, 0));
+        dtePanelCenter.add(undoDeleteDTEButton,
+            new GridBagConstraints(1, 3, 1, 1, 0.0, .5,
+                GridBagConstraints.NORTH, GridBagConstraints.NONE,
+                new Insets(5, 20, 5, 20), 0, 0));
+    }
 
-	/**
-	 * Adds the deleted enum value back into the table.
-	 * Disables the undo button.
-	 * @param e ActionEvent
-	 */
-	void undoDeleteEnumValButton_actionPerformed(ActionEvent e)
-	{
-		if (deletedEnumValue != null)
-		{
-			String s = TextUtil.removeAllSpace(
-				(String)enumComboBox.getSelectedItem());
-			decodes.db.DbEnum en = Database.getDb().getDbEnum(s);
-			en.replaceValue(deletedEnumValue.getValue(),
-				deletedEnumValue.getDescription(),
-				deletedEnumValue.getExecClassName(), "");
-			deletedEnumValue = null;
-			enumTableModel.fireTableDataChanged();
-		}
-		undoDeleteEnumValButton.setEnabled(false);
-		enumsChanged = true;
-	}
+    protected void seasonDownPressed()
+    {
+        int row = seasonsTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(
+                labels.getString("SeasonsTab.noSelection") + " " +
+                labels.getString("RefListFrame.moveDown"));
+            return;
+        }
+        if (seasonListTableModel.moveDown(row))
+            seasonsTable.setRowSelectionInterval(row+1, row+1);
+        seasonsChanged = true;
+    }
 
-	/**
-	 * Marks the currently selected enumeration value as the 'default' value.
-	 * @param e ActionEvent
-	 */
-	void selectEnumValDefaultButton_actionPerformed(ActionEvent e)
-	{
-		int row = enumTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.enumDefaultInfo"));
-			return;
-		}
+    protected void seasonUpPressed()
+    {
+        int row = seasonsTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(
+                labels.getString("SeasonsTab.noSelection") + " " +
+                labels.getString("RefListFrame.moveUp"));
+            return;
+        }
+        if (seasonListTableModel.moveUp(row))
+            seasonsTable.setRowSelectionInterval(row-1, row-1);
+        seasonsChanged = true;
+    }
 
-		String s = TextUtil.removeAllSpace(
-			(String)enumComboBox.getSelectedItem());
-		decodes.db.DbEnum en = Database.getDb().getDbEnum(s);
-		EnumValue ev = enumTableModel.getEnumValueAt(row);
-		enumTableModel.fireTableDataChanged();
-		en.setDefault(ev.getValue());
-		enumsChanged = true;
-	}
+    protected void deleteSeasonPressed()
+    {
+        Season season = null;
+        int idx = this.seasonsTable.getSelectedRow();
+        if (idx == -1
+         || (season = (Season)seasonListTableModel.getRowObject(idx)) == null)
+        {
+            showError(
+                labels.getString("SeasonsTab.noSelection") + " " + genericLabels.getString("delete"));
+            return;
+        }
+        int r = JOptionPane.showConfirmDialog(this,
+            "Confirm", labels.getString("SeasonsTab.confirmDelete") + " " + season.getAbbr(),
+            JOptionPane.YES_NO_OPTION);
+        if (r != JOptionPane.YES_OPTION)
+            return;
+        seasonListTableModel.deleteAt(idx);
+        seasonsChanged = true;
+    }
 
-	/**
-	 * Moves the currently selected enumeration value up in the table.
-	 * When written to the database, the sort order will be set to the
-	 * currently displayed order. This and the down button allow you to set
-	 * the desired order.
-	 * @param e ActionEvent
-	 */
-	void upEnumValButton_actionPerformed(ActionEvent e)
-	{
-		int row = enumTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.enumMovUpInfo"));
-			return;
-		}
-		if (enumTableModel.moveUp(row))
-			enumTable.setRowSelectionInterval(row-1, row-1);
-		enumsChanged = true;
-	}
+    protected void editSeasonPressed()
+    {
+        Season season = null;
+        int idx = this.seasonsTable.getSelectedRow();
+        if (idx == -1
+         || (season = (Season)seasonListTableModel.getRowObject(idx)) == null)
+        {
+            showError(
+                labels.getString("SeasonsTab.noSelection") + " " + genericLabels.getString("edit"));
+            return;
+        }
+        SeasonEditDialog dlg = new SeasonEditDialog(this);
+        dlg.fillValues(season);
+        launchDialog(dlg);
+        if (dlg.isOkPressed())
+        {
+            seasonListTableModel.fireTableDataChanged();
+            seasonsChanged = true;
+        }
+    }
 
-	/**
-	 * Moves the currently selected enumeration value down in the table.
-	 * When written to the database, the sort order will be set to the
-	 * currently displayed order. This and the up button allow you to set
-	 * the desired order.
-	 * @param e ActionEvent
-	 */
-	void downEnumValButton_actionPerformed(ActionEvent e)
-	{
-		int row = enumTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.enumMovDnInfo"));
-			return;
-		}
-		if (enumTableModel.moveDown(row))
-			enumTable.setRowSelectionInterval(row+1, row+1);
-		enumsChanged = true;
-	}
+    protected void addSeasonPressed()
+    {
+        Season season = new Season();
+        SeasonEditDialog dlg = new SeasonEditDialog(this);
+        dlg.fillValues(season);
+        launchDialog(dlg);
+        if (dlg.isOkPressed())
+        {
+            seasonListTableModel.add(season);
+            seasonsChanged = true;
+        }
+    }
 
-	/**
-	 * Displays modal EU dialog. If OK pressed, results are added to the
-	 * table. Sets modified flag.
-	 * @param e ActionEvent
-	 */
-	void addEUButton_actionPerformed(ActionEvent e)
-	{
-		EUDialog dlg = new EUDialog();
-		launchDialog(dlg);
-		if (dlg.wasChanged())
-		{
-			String abbr = dlg.getAbbr();
-			if (abbr == null || abbr.length() == 0)
-			{
-				showError(labels.getString("RefListFrame.euAbbrErr"));
-				return;
-			}
+    /**
+     * File | Exit action performed.
+     * @param e ignored
+     */
+    public void jMenuFileExit_actionPerformed(ActionEvent e)
+    {
+        if (/*enumsChanged || */ unitsChanged || convertersChanged || dtsChanged || seasonsChanged)
+        {
+            int r = JOptionPane.showConfirmDialog(this,
+                labels.getString("RefListFrame.unsavedChangesQues"),
+                labels.getString("RefListFrame.confirmExit"),
+                JOptionPane.YES_NO_OPTION);
+            if (r != JOptionPane.YES_OPTION)
+                return;
+        }
+        System.exit(0);
+    }
 
-			EngineeringUnit eu = 
-				Database.getDb().engineeringUnitList.getByAbbr(abbr);
-			if (eu != null)
-			{
-				showError(LoadResourceBundle.sprintf(
-						labels.getString("RefListFrame.euAlreadyExistErr"),
-						abbr));
-				return;
-			}
+    /**
+     * Help | About action performed.
+     * @param e ignored
+     */
+    public void jMenuHelpAbout_actionPerformed(ActionEvent e) {
+        RefListFrame_AboutBox dlg = new RefListFrame_AboutBox(this);
+        Dimension dlgSize = dlg.getPreferredSize();
+        Dimension frmSize = getSize();
+        java.awt.Point loc = getLocation();
+        dlg.setLocation((frmSize.width - dlgSize.width) / 2 + loc.x, (frmSize.height - dlgSize.height) / 2 + loc.y);
+        dlg.setModal(true);
+        dlg.pack();
+        dlg.setVisible(true);
+//        dlg.show();
+    }
 
-			eu = EngineeringUnit.getEngineeringUnit(abbr);
-			eu.setName(dlg.getEUName());
-			eu.family = dlg.getFamily();
-			eu.measures = dlg.getMeasures();
-			unitsChanged = true;
-			euTableModel.rebuild();
-			euTableModel.fireTableDataChanged();
-		}
-	}
 
-	/**
-	* Displays model EU dialog with the currently selected EU. If OK pressed,
-	* any modifications are copied back into the object in the table. Sets
-	* modified flag.
-	* @param e ActionEvent
-	*/
-	void editEUButton_actionPerformed(ActionEvent e)
-	{
-		int row = euTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.engEditInfo"));
-			return;
-		}
-		EngineeringUnit eu = (EngineeringUnit)euTableModel.getRowObject(row);
-		String oldAbbr = eu.abbr;
-		EUDialog dlg = new EUDialog();
-		dlg.fillValues(eu);
-		launchDialog(dlg);
-		if (dlg.wasChanged())
-		{
-			EngineeringUnitList eul = Database.getDb().engineeringUnitList;
-			String abbr = dlg.getAbbr();
-			if (abbr == null || abbr.length() == 0)
-			{
-				showError(labels.getString("RefListFrame.euAbbrErr"));
-				return;
-			}
-			if (!oldAbbr.equalsIgnoreCase(abbr))
-			{
-				// Abbr was changed, make sure it doesn't clash with another EU.
-				EngineeringUnit otherEU = eul.getByAbbr(abbr);
-				if (otherEU != null)
-				{
-					showError(LoadResourceBundle.sprintf(
-							labels.getString("RefListFrame.cantChangeAbbr"),
-							abbr));
-					return;
-				}
-			}
+    /**
+     * Displays modal EU dialog. If OK pressed, results are added to the
+     * table. Sets modified flag.
+     * @param e ActionEvent
+     */
+    void addEUButton_actionPerformed(ActionEvent e)
+    {
+        EUDialog dlg = new EUDialog();
+        launchDialog(dlg);
+        if (dlg.wasChanged())
+        {
+            String abbr = dlg.getAbbr();
+            if (abbr == null || abbr.length() == 0)
+            {
+                showError(labels.getString("RefListFrame.euAbbrErr"));
+                return;
+            }
 
-			eul.remove(eu);  // Remove hash entry for old abbr & name.
-			eu.abbr = abbr;
-			eu.setName(dlg.getEUName());
-			eu.family = dlg.getFamily();
-			eu.measures = dlg.getMeasures();
-			eul.add(eu);     // Re-add with correct hash entries.
+            EngineeringUnit eu =
+                Database.getDb().engineeringUnitList.getByAbbr(abbr);
+            if (eu != null)
+            {
+                showError(LoadResourceBundle.sprintf(
+                        labels.getString("RefListFrame.euAlreadyExistErr"),
+                        abbr));
+                return;
+            }
 
-			unitsChanged = true;
-			euTableModel.rebuild();
-			euTableModel.fireTableDataChanged();
-		}
-	}
+            eu = EngineeringUnit.getEngineeringUnit(abbr);
+            eu.setName(dlg.getEUName());
+            eu.family = dlg.getFamily();
+            eu.measures = dlg.getMeasures();
+            unitsChanged = true;
+            euTableModel.rebuild();
+            euTableModel.fireTableDataChanged();
+        }
+    }
 
-	/**
-	 * Deletes the currently selected EU and adds it to the undo buffer.
-	 * Enables the undo-delete button.
-	 * @param e ActionEvent
-	 */
-	void deleteEUButton_actionPerformed(ActionEvent e)
-	{
-		int row = euTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.engDeleteInfo"));
-			return;
-		}
-		deletedEU = (EngineeringUnit)euTableModel.getRowObject(row);
-		Database.getDb().engineeringUnitList.remove(deletedEU);
-		unitsChanged = true;
-		euTableModel.rebuild();
-		euTableModel.fireTableDataChanged();
-		undoDeleteEUButton.setEnabled(true);
-	}
+    /**
+    * Displays model EU dialog with the currently selected EU. If OK pressed,
+    * any modifications are copied back into the object in the table. Sets
+    * modified flag.
+    * @param e ActionEvent
+    */
+    void editEUButton_actionPerformed(ActionEvent e)
+    {
+        int row = euTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.engEditInfo"));
+            return;
+        }
+        EngineeringUnit eu = (EngineeringUnit)euTableModel.getRowObject(row);
+        String oldAbbr = eu.abbr;
+        EUDialog dlg = new EUDialog();
+        dlg.fillValues(eu);
+        launchDialog(dlg);
+        if (dlg.wasChanged())
+        {
+            EngineeringUnitList eul = Database.getDb().engineeringUnitList;
+            String abbr = dlg.getAbbr();
+            if (abbr == null || abbr.length() == 0)
+            {
+                showError(labels.getString("RefListFrame.euAbbrErr"));
+                return;
+            }
+            if (!oldAbbr.equalsIgnoreCase(abbr))
+            {
+                // Abbr was changed, make sure it doesn't clash with another EU.
+                EngineeringUnit otherEU = eul.getByAbbr(abbr);
+                if (otherEU != null)
+                {
+                    showError(LoadResourceBundle.sprintf(
+                            labels.getString("RefListFrame.cantChangeAbbr"),
+                            abbr));
+                    return;
+                }
+            }
 
-	/**
-	 * Re-adds the currently selected EU back into the table.
-	 * Disables the undo-delete button.
-	 * @param e ActionEvent
-	 */
-	void undoDeleteEUButton_actionPerformed(ActionEvent e)
-	{
-		undoDeleteEUButton.setEnabled(false);
-		if (deletedEU == null)
-			return;
-		Database.getDb().engineeringUnitList.add(deletedEU);
-		deletedEU = null;
-		unitsChanged = true;
-		euTableModel.rebuild();
-		euTableModel.fireTableDataChanged();
-	}
+            eul.remove(eu);  // Remove hash entry for old abbr & name.
+            eu.abbr = abbr;
+            eu.setName(dlg.getEUName());
+            eu.family = dlg.getFamily();
+            eu.measures = dlg.getMeasures();
+            eul.add(eu);     // Re-add with correct hash entries.
 
-	/**
-	 * Displays the modal EU Conversion dialog. If OK pressed, the results
-	 * are added to the table as a new conversion.
-	 * @param e ActionEvent
-	 */
-	void addEUCnvtButton_actionPerformed(ActionEvent e)
-	{
-		UnitConverterDb uc = new UnitConverterDb("", "");
-		uc.algorithm = "";
-		EUCnvEditDialog dlg = new EUCnvEditDialog();
-		dlg.fillValues(this, uc);
-		launchDialog(dlg);
-		if (dlg.wasChanged())
-		{
-			UnitConverterSet ucs = Database.getDb().unitConverterSet;
-			ucs.addDbConverter(uc);
-			convertersChanged = true;
-			ucTableModel.rebuild();
-			ucTableModel.fireTableDataChanged();
-		}
-	}
+            unitsChanged = true;
+            euTableModel.rebuild();
+            euTableModel.fireTableDataChanged();
+        }
+    }
 
-	/**
-	 * Displays the model EU Conversion dialog with the selected conversion.
-	 * If OK pressed, the results are added to the table.
-	 * @param e ActionEvent
-	 */
-	void editEUCnvtButton_actionPerformed(ActionEvent e)
-	{
-		int row = ucTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.unitConvEditInfo"));
-			return;
-		}
+    /**
+     * Deletes the currently selected EU and adds it to the undo buffer.
+     * Enables the undo-delete button.
+     * @param e ActionEvent
+     */
+    void deleteEUButton_actionPerformed(ActionEvent e)
+    {
+        int row = euTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.engDeleteInfo"));
+            return;
+        }
+        deletedEU = (EngineeringUnit)euTableModel.getRowObject(row);
+        Database.getDb().engineeringUnitList.remove(deletedEU);
+        unitsChanged = true;
+        euTableModel.rebuild();
+        euTableModel.fireTableDataChanged();
+        undoDeleteEUButton.setEnabled(true);
+    }
 
-		UnitConverterDb uc = (UnitConverterDb)ucTableModel.getRowObject(row);
-		String oldFrom = uc.fromAbbr;
-		String oldTo = uc.toAbbr;
-		EUCnvEditDialog dlg = new EUCnvEditDialog();
-		dlg.fillValues(this, uc);
+    /**
+     * Re-adds the currently selected EU back into the table.
+     * Disables the undo-delete button.
+     * @param e ActionEvent
+     */
+    void undoDeleteEUButton_actionPerformed(ActionEvent e)
+    {
+        undoDeleteEUButton.setEnabled(false);
+        if (deletedEU == null)
+            return;
+        Database.getDb().engineeringUnitList.add(deletedEU);
+        deletedEU = null;
+        unitsChanged = true;
+        euTableModel.rebuild();
+        euTableModel.fireTableDataChanged();
+    }
 
-		launchDialog(dlg);
-		if (dlg.wasChanged())
-		{
-			UnitConverterSet ucs = Database.getDb().unitConverterSet;
+    /**
+     * Displays the modal EU Conversion dialog. If OK pressed, the results
+     * are added to the table as a new conversion.
+     * @param e ActionEvent
+     */
+    void addEUCnvtButton_actionPerformed(ActionEvent e)
+    {
+        UnitConverterDb uc = new UnitConverterDb("", "");
+        uc.algorithm = "";
+        EUCnvEditDialog dlg = new EUCnvEditDialog();
+        dlg.fillValues(this, uc);
+        launchDialog(dlg);
+        if (dlg.wasChanged())
+        {
+            UnitConverterSet ucs = Database.getDb().unitConverterSet;
+            ucs.addDbConverter(uc);
+            convertersChanged = true;
+            ucTableModel.rebuild();
+            ucTableModel.fireTableDataChanged();
+        }
+    }
 
-			/*
-			  Converters are hashed based on from/to abbreviations. So
-			  if either abbr is changed, delete from set & re-add.
-			  Note: Dialog makes sure there is no clash if abbrs are changed.
-			*/
-			if (!oldFrom.equals(uc.fromAbbr) || !oldTo.equals(uc.toAbbr))
-			{
-				ucs.removeDbConverter(oldFrom, oldTo);
-				ucs.addDbConverter(uc);
-			}
+    /**
+     * Displays the model EU Conversion dialog with the selected conversion.
+     * If OK pressed, the results are added to the table.
+     * @param e ActionEvent
+     */
+    void editEUCnvtButton_actionPerformed(ActionEvent e)
+    {
+        int row = ucTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.unitConvEditInfo"));
+            return;
+        }
 
-			convertersChanged = true;
-			ucTableModel.rebuild();
-			ucTableModel.fireTableDataChanged();
-		}
-	}
+        UnitConverterDb uc = (UnitConverterDb)ucTableModel.getRowObject(row);
+        String oldFrom = uc.fromAbbr;
+        String oldTo = uc.toAbbr;
+        EUCnvEditDialog dlg = new EUCnvEditDialog();
+        dlg.fillValues(this, uc);
 
-	/**
-	 * Deletes the selected EU conversion & adds it to the undo buffer.
-	 * Enables the undo button.
-	 * @param e ActionEvent
-	 */
-	void deleteEUCnvtButton_actionPerformed(ActionEvent e)
-	{
-		int row = ucTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.unitConvDeleteInfo"));
-			return;
-		}
-		deletedConverter = (UnitConverterDb)ucTableModel.getRowObject(row);
-		Database.getDb().unitConverterSet.removeDbConverter(
-			deletedConverter.fromAbbr, deletedConverter.toAbbr);
-		convertersChanged = true;
-		ucTableModel.rebuild();
-		ucTableModel.fireTableDataChanged();
-		undoDelEuCnvtButton.setEnabled(true);
-	}
+        launchDialog(dlg);
+        if (dlg.wasChanged())
+        {
+            UnitConverterSet ucs = Database.getDb().unitConverterSet;
 
-	/**
-	 * Re-adds the deleted EU Conversion back into the table.
-	 * Disables the undo button.
-	 * @param e ActionEvent
-	 */
-	void undoDelEuCnvtButton_actionPerformed(ActionEvent e)
-	{
-		if (deletedConverter == null)
-			return;
-		Database.getDb().unitConverterSet.addDbConverter(deletedConverter);
-		deletedConverter = null;
-		convertersChanged = true;
-		ucTableModel.rebuild();
-		ucTableModel.fireTableDataChanged();
-		undoDelEuCnvtButton.setEnabled(false);
-	}
+            /*
+              Converters are hashed based on from/to abbreviations. So
+              if either abbr is changed, delete from set & re-add.
+              Note: Dialog makes sure there is no clash if abbrs are changed.
+            */
+            if (!oldFrom.equals(uc.fromAbbr) || !oldTo.equals(uc.toAbbr))
+            {
+                ucs.removeDbConverter(oldFrom, oldTo);
+                ucs.addDbConverter(uc);
+            }
 
-	/**
-	 * Displays the DataType Equivalence dialog. If OK pressed, adds a
-	 * new DTE to the table.
-	 * @param e ActionEvent
-	 */
-	void addDTEButton_actionPerformed(ActionEvent e)
-	{
-		undoDeleteDTEButton.setEnabled(false);
-		deletedDte = null;
+            convertersChanged = true;
+            ucTableModel.rebuild();
+            ucTableModel.fireTableDataChanged();
+        }
+    }
 
-		DTEDialog dlg = new DTEDialog(this);
-		dlg.fillValues(dteTableModel, -1);
-		launchDialog(dlg);
-		if (dlg.wasChanged())
-		{
-			dtsChanged = true;
-			dteTableModel.rebuild();
-			dteTableModel.fireTableDataChanged();
-		}
-	}
+    /**
+     * Deletes the selected EU conversion & adds it to the undo buffer.
+     * Enables the undo button.
+     * @param e ActionEvent
+     */
+    void deleteEUCnvtButton_actionPerformed(ActionEvent e)
+    {
+        int row = ucTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.unitConvDeleteInfo"));
+            return;
+        }
+        deletedConverter = (UnitConverterDb)ucTableModel.getRowObject(row);
+        Database.getDb().unitConverterSet.removeDbConverter(
+            deletedConverter.fromAbbr, deletedConverter.toAbbr);
+        convertersChanged = true;
+        ucTableModel.rebuild();
+        ucTableModel.fireTableDataChanged();
+        undoDelEuCnvtButton.setEnabled(true);
+    }
 
-	/**
-	 * Displays the modal DataType Equivalence dialog with the selected
-	 * element in the table.
-	 * @param e ActionEvent
-	 */
-	void editDTEButton_actionPerformed(ActionEvent e)
-	{
-		undoDeleteDTEButton.setEnabled(false);
-		deletedDte = null;
+    /**
+     * Re-adds the deleted EU Conversion back into the table.
+     * Disables the undo button.
+     * @param e ActionEvent
+     */
+    void undoDelEuCnvtButton_actionPerformed(ActionEvent e)
+    {
+        if (deletedConverter == null)
+            return;
+        Database.getDb().unitConverterSet.addDbConverter(deletedConverter);
+        deletedConverter = null;
+        convertersChanged = true;
+        ucTableModel.rebuild();
+        ucTableModel.fireTableDataChanged();
+        undoDelEuCnvtButton.setEnabled(false);
+    }
 
-		int row = dteTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.selectRowEditInfo"));
-			return;
-		}
-		DTEDialog dlg = new DTEDialog(this);
-		dlg.fillValues(dteTableModel, row);
-		launchDialog(dlg);
-		if (dlg.wasChanged())
-		{
-			dtsChanged = true;
-			dteTableModel.rebuild();
-			dteTableModel.fireTableDataChanged();
-		}
-	}
+    /**
+     * Displays the DataType Equivalence dialog. If OK pressed, adds a
+     * new DTE to the table.
+     * @param e ActionEvent
+     */
+    void addDTEButton_actionPerformed(ActionEvent e)
+    {
+        undoDeleteDTEButton.setEnabled(false);
+        deletedDte = null;
 
-	/**
-	 * Restores the deleted data type equivalence to the table.
-	 * Disables the undo button.
-	 * @param e ActionEvent
-	 */
-	void undoDeleteDTEButton_actionPerformed(ActionEvent e)
-	{
-		if (deletedDte != null)
-		{
-			DataType lastDT = null;
-			for(int i=0; i<deletedDte.length; i++)
-			{
-				String v = deletedDte[i];
-				if (v != null && v.length() > 0)
-				{
-					String std = dteTableModel.getColumnName(i);
-					DataType ndt = DataType.getDataType(std, v);
-					if (lastDT != null)
-						lastDT.assertEquivalence(ndt);
-					lastDT = ndt;
-				}
-			}
-			dteTableModel.rebuild();
-			dteTableModel.fireTableDataChanged();
-		}
-		dtsChanged = true;
-		deletedDte = null;
-		undoDeleteDTEButton.setEnabled(false);
-	}
+        DTEDialog dlg = new DTEDialog(this);
+        dlg.fillValues(dteTableModel, -1);
+        launchDialog(dlg);
+        if (dlg.wasChanged())
+        {
+            dtsChanged = true;
+            dteTableModel.rebuild();
+            dteTableModel.fireTableDataChanged();
+        }
+    }
 
-	/**
-	 * Deletes the selected data type equivalence and adds it to the undo buffer.
-	 * Enables the undo button.
-	 * @param e ActionEvent
-	 */
-	void deleteDTEButton_actionPerformed(ActionEvent e)
-	{
-		int row = dteTable.getSelectedRow();
-		if (row == -1)
-		{
-			showError(labels.getString("RefListFrame.selectRowDeleteInfo"));
-			return;
-		}
-		deletedDte = (String[])dteTableModel.getRowObject(row);
-		DataTypeSet dts = Database.getDb().dataTypeSet;
-		for(int i=0; i<dteTableModel.getColumnCount(); i++)
-		{
-			String v = deletedDte[i];
-			if (v != null && v.length() > 0)
-			{
-				String std = dteTableModel.getColumnName(i);
-				DataType dt = dts.get(std, v);
-				if (dt != null)
-					dt.deAssertEquivalence();
-			}
-		}
-		undoDeleteDTEButton.setEnabled(true);
-		dteTableModel.rebuild();
-		dteTableModel.fireTableDataChanged();
-		dtsChanged = true;
-	}
+    /**
+     * Displays the modal DataType Equivalence dialog with the selected
+     * element in the table.
+     * @param e ActionEvent
+     */
+    void editDTEButton_actionPerformed(ActionEvent e)
+    {
+        undoDeleteDTEButton.setEnabled(false);
+        deletedDte = null;
 
-	/**
-	 * Called when save to DB menu item selected.
-	 * @param e ActionEvent
-	 */
-	void mi_saveToDb_actionPerformed(ActionEvent e)
-	{
-		Database db = Database.getDb();
+        int row = dteTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.selectRowEditInfo"));
+            return;
+        }
+        DTEDialog dlg = new DTEDialog(this);
+        dlg.fillValues(dteTableModel, row);
+        launchDialog(dlg);
+        if (dlg.wasChanged())
+        {
+            dtsChanged = true;
+            dteTableModel.rebuild();
+            dteTableModel.fireTableDataChanged();
+        }
+    }
 
-		String what = "";
-		try
-		{
-			if (seasonsChanged)
-			{
-				seasonListTableModel.storeBackToEnum();
-				enumsChanged = true;
-			}
-			if (enumsChanged)
-			{
-				what = "Enumerations";
-				db.enumList.write();
-				enumsChanged = seasonsChanged = false;
-			}
-			if (unitsChanged || convertersChanged)
-			{
-				what = "Engineering Units";
-				db.engineeringUnitList.write();
-				unitsChanged = convertersChanged = false;
-			}
-			if (dtsChanged)
-			{
-				what = "Data Types";
-				db.dataTypeSet.write();
-				dtsChanged = false;
-			}
-			
-			JOptionPane.showConfirmDialog(this, labels.getString("RefListFrame.changesWritten"),
-				"Info", JOptionPane.DEFAULT_OPTION, JOptionPane.INFORMATION_MESSAGE);
-		}
-		catch(DatabaseException ex)
-		{
-			showError(LoadResourceBundle.sprintf(labels.getString(
-					"RefListFrame.writingErr"),what) + ex);
-			ex.printStackTrace();
-		}
-	}
+    /**
+     * Restores the deleted data type equivalence to the table.
+     * Disables the undo button.
+     * @param e ActionEvent
+     */
+    void undoDeleteDTEButton_actionPerformed(ActionEvent e)
+    {
+        if (deletedDte != null)
+        {
+            DataType lastDT = null;
+            for(int i=0; i<deletedDte.length; i++)
+            {
+                String v = deletedDte[i];
+                if (v != null && v.length() > 0)
+                {
+                    String std = dteTableModel.getColumnName(i);
+                    DataType ndt = DataType.getDataType(std, v);
+                    if (lastDT != null)
+                        lastDT.assertEquivalence(ndt);
+                    lastDT = ndt;
+                }
+            }
+            dteTableModel.rebuild();
+            dteTableModel.fireTableDataChanged();
+        }
+        dtsChanged = true;
+        deletedDte = null;
+        undoDeleteDTEButton.setEnabled(false);
+    }
 
-	/**
-	  Launches the passed modal dialog at a reasonable position on the screen.
-	  @param dlg the dialog.
-	*/
-	private void launchDialog(JDialog dlg)
-	{
-		dlg.setModal(true);
-		dlg.validate();
-		dlg.setLocationRelativeTo(this);
-		dlg.setVisible(true);
-	}
+    /**
+     * Deletes the selected data type equivalence and adds it to the undo buffer.
+     * Enables the undo button.
+     * @param e ActionEvent
+     */
+    void deleteDTEButton_actionPerformed(ActionEvent e)
+    {
+        int row = dteTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.selectRowDeleteInfo"));
+            return;
+        }
+        deletedDte = (String[])dteTableModel.getRowObject(row);
+        DataTypeSet dts = Database.getDb().dataTypeSet;
+        for(int i=0; i<dteTableModel.getColumnCount(); i++)
+        {
+            String v = deletedDte[i];
+            if (v != null && v.length() > 0)
+            {
+                String std = dteTableModel.getColumnName(i);
+                DataType dt = dts.get(std, v);
+                if (dt != null)
+                    dt.deAssertEquivalence();
+            }
+        }
+        undoDeleteDTEButton.setEnabled(true);
+        dteTableModel.rebuild();
+        dteTableModel.fireTableDataChanged();
+        dtsChanged = true;
+    }
 
-	/**
-	 * Shows an error message in a JOptionPane and prints it to stderr.
-	 * @param msg the error message.
-	 */
-	public void showError(String msg)
-	{
-		System.err.println(msg);
-		JOptionPane.showMessageDialog(this,
-			AsciiUtil.wrapString(msg, 60), "Error!", JOptionPane.ERROR_MESSAGE);
-	}
+    /**
+     * Called when save to DB menu item selected.
+     * @param e ActionEvent
+     */
+    void mi_saveToDb_actionPerformed(ActionEvent e)
+    {
+        Database db = Database.getDb();
+
+        String what = "";
+        try
+        {
+            if (seasonsChanged)
+            {
+                seasonListTableModel.storeBackToEnum();
+                //enumsChanged = true;
+            }
+            if (EnumTab.enumsChanged())
+            {
+                what = "Enumerations";
+                db.enumList.write();
+                //enumsChanged = seasonsChanged = false;
+            }
+            if (unitsChanged || convertersChanged)
+            {
+                what = "Engineering Units";
+                db.engineeringUnitList.write();
+                unitsChanged = convertersChanged = false;
+            }
+            if (dtsChanged)
+            {
+                what = "Data Types";
+                db.dataTypeSet.write();
+                dtsChanged = false;
+            }
+
+            JOptionPane.showConfirmDialog(this, labels.getString("RefListFrame.changesWritten"),
+                "Info", JOptionPane.DEFAULT_OPTION, JOptionPane.INFORMATION_MESSAGE);
+        }
+        catch(DatabaseException ex)
+        {
+            showError(LoadResourceBundle.sprintf(labels.getString(
+                    "RefListFrame.writingErr"),what) + ex);
+            ex.printStackTrace();
+        }
+    }
+
+    /**
+      Launches the passed modal dialog at a reasonable position on the screen.
+      @param dlg the dialog.
+    */
+    private void launchDialog(JDialog dlg)
+    {
+        dlg.setModal(true);
+        dlg.validate();
+        dlg.setLocationRelativeTo(this);
+        dlg.setVisible(true);
+    }
+
+    /**
+     * Shows an error message in a JOptionPane and prints it to stderr.
+     * @param msg the error message.
+     */
+    public void showError(String msg)
+    {
+        System.err.println(msg);
+        JOptionPane.showMessageDialog(this,
+            AsciiUtil.wrapString(msg, 60), "Error!", JOptionPane.ERROR_MESSAGE);
+    }
 }
 class RefListFrame_jMenuFileExit_ActionAdapter implements ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_jMenuFileExit_ActionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.jMenuFileExit_actionPerformed(e);
-	}
+    RefListFrame_jMenuFileExit_ActionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.jMenuFileExit_actionPerformed(e);
+    }
 }
 
 class RefListFrame_jMenuHelpAbout_ActionAdapter implements ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_jMenuHelpAbout_ActionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.jMenuHelpAbout_actionPerformed(e);
-	}
+    RefListFrame_jMenuHelpAbout_ActionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.jMenuHelpAbout_actionPerformed(e);
+    }
 }
 
-class RefListFrame_enumComboBox_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
 
-	RefListFrame_enumComboBox_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.enumComboBox_actionPerformed(e);
-	}
-}
 
 class RefListFrame_addEUButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_addEUButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.addEUButton_actionPerformed(e);
-	}
-}
-
-class RefListFrame_addEnumValButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
-
-	RefListFrame_addEnumValButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.addEnumValButton_actionPerformed(e);
-	}
-}
-
-class RefListFrame_editEnumValButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
-
-	RefListFrame_editEnumValButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.editEnumValButton_actionPerformed(e);
-	}
-}
-
-class RefListFrame_deleteEnumValButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
-
-	RefListFrame_deleteEnumValButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.deleteEnumValButton_actionPerformed(e);
-	}
-}
-
-class RefListFrame_undoDeleteEnumValButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
-
-	RefListFrame_undoDeleteEnumValButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.undoDeleteEnumValButton_actionPerformed(e);
-	}
-}
-
-class RefListFrame_selectEnumValDefaultButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
-
-	RefListFrame_selectEnumValDefaultButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.selectEnumValDefaultButton_actionPerformed(e);
-	}
-}
-
-class RefListFrame_upEnumValButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
-
-	RefListFrame_upEnumValButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.upEnumValButton_actionPerformed(e);
-	}
-}
-
-class RefListFrame_downEnumValButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
-
-	RefListFrame_downEnumValButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.downEnumValButton_actionPerformed(e);
-	}
+    RefListFrame_addEUButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.addEUButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_editEUButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_editEUButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.editEUButton_actionPerformed(e);
-	}
+    RefListFrame_editEUButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.editEUButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_deleteEUButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_deleteEUButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.deleteEUButton_actionPerformed(e);
-	}
+    RefListFrame_deleteEUButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.deleteEUButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_undoDeleteEUButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_undoDeleteEUButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.undoDeleteEUButton_actionPerformed(e);
-	}
+    RefListFrame_undoDeleteEUButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.undoDeleteEUButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_addEUCnvtButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_addEUCnvtButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.addEUCnvtButton_actionPerformed(e);
-	}
+    RefListFrame_addEUCnvtButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.addEUCnvtButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_editEUCnvtButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_editEUCnvtButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.editEUCnvtButton_actionPerformed(e);
-	}
+    RefListFrame_editEUCnvtButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.editEUCnvtButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_deleteEUCnvtButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_deleteEUCnvtButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.deleteEUCnvtButton_actionPerformed(e);
-	}
+    RefListFrame_deleteEUCnvtButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.deleteEUCnvtButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_undoDelEuCnvtButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_undoDelEuCnvtButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.undoDelEuCnvtButton_actionPerformed(e);
-	}
+    RefListFrame_undoDelEuCnvtButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.undoDelEuCnvtButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_addDTEButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_addDTEButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.addDTEButton_actionPerformed(e);
-	}
+    RefListFrame_addDTEButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.addDTEButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_editDTEButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_editDTEButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.editDTEButton_actionPerformed(e);
-	}
+    RefListFrame_editDTEButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.editDTEButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_undoDeleteDTEButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_undoDeleteDTEButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.undoDeleteDTEButton_actionPerformed(e);
-	}
+    RefListFrame_undoDeleteDTEButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.undoDeleteDTEButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_deleteDTEButton_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_deleteDTEButton_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.deleteDTEButton_actionPerformed(e);
-	}
+    RefListFrame_deleteDTEButton_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.deleteDTEButton_actionPerformed(e);
+    }
 }
 
 class RefListFrame_mi_saveToDb_actionAdapter implements java.awt.event.ActionListener {
-	RefListFrame adaptee;
+    RefListFrame adaptee;
 
-	RefListFrame_mi_saveToDb_actionAdapter(RefListFrame adaptee) {
-		this.adaptee = adaptee;
-	}
-	public void actionPerformed(ActionEvent e) {
-		adaptee.mi_saveToDb_actionPerformed(e);
-	}
+    RefListFrame_mi_saveToDb_actionAdapter(RefListFrame adaptee) {
+        this.adaptee = adaptee;
+    }
+    public void actionPerformed(ActionEvent e) {
+        adaptee.mi_saveToDb_actionPerformed(e);
+    }
 }

--- a/java/opendcs/src/main/java/decodes/rledit/RefListFrame.java
+++ b/java/opendcs/src/main/java/decodes/rledit/RefListFrame.java
@@ -1,6 +1,3 @@
-/*
-*  $Id$
-*/
 package decodes.rledit;
 
 import java.awt.*;
@@ -114,7 +111,7 @@ public class RefListFrame extends JFrame
     private final OpenDcsDatabase database;
 
     /**
-     * No args constructor for JBuilder.
+     * constructor for RefListFrame
      */
     public RefListFrame(OpenDcsDatabase database)
     {
@@ -131,15 +128,6 @@ public class RefListFrame extends JFrame
             enumIt.hasNext(); )
         {
             decodes.db.DbEnum en = enumIt.next();
-            /*if (en.enumName.equalsIgnoreCase("EquationScope")
-             || en.enumName.equalsIgnoreCase("DataOrder")
-             || en.enumName.equalsIgnoreCase("UnitFamily")
-             || en.enumName.equalsIgnoreCase("LookupAlgorithm")
-             || en.enumName.equalsIgnoreCase("RecordingMode")
-             || en.enumName.equalsIgnoreCase("EquipmentType")
-             || en.enumName.equalsIgnoreCase("Season"))
-                continue;
-            String s = TextUtil.capsExpand(en.enumName);*/
             v.add(en);
         }
         Collections.sort(v, (a,b) -> a.enumName.compareTo(b.enumName));
@@ -1044,12 +1032,12 @@ public class RefListFrame extends JFrame
     }
 
     /**
-     * Shows an error message in a JOptionPane and prints it to stderr.
+     * Shows an error message in a JOptionPane and prints it to the error log
      * @param msg the error message.
      */
     public void showError(String msg)
     {
-        System.err.println(msg);
+        log.error(ERROR, msg);
         JOptionPane.showMessageDialog(this,
             AsciiUtil.wrapString(msg, 60), "Error!", JOptionPane.ERROR_MESSAGE);
     }

--- a/java/opendcs/src/main/java/decodes/rledit/RefListFrame.java
+++ b/java/opendcs/src/main/java/decodes/rledit/RefListFrame.java
@@ -120,6 +120,12 @@ public class RefListFrame extends JFrame
     {
         this.database = database;
 
+		/**
+		 * NOTE: this *should* be off the GUI thread but the performance impact for 
+		 * enums is minimal and this shows a good demostration of the getLegacyDatabase.
+		 * 
+		 * TODO: Correct before merge.
+		 */
         ArrayList<DbEnum> v = new ArrayList<>();
         for(Iterator<DbEnum> enumIt = database.getLegacyDatabase(Database.class).get().enumList.iterator();
             enumIt.hasNext(); )

--- a/java/opendcs/src/main/java/decodes/rledit/panels/EnumerationPanel.java
+++ b/java/opendcs/src/main/java/decodes/rledit/panels/EnumerationPanel.java
@@ -31,6 +31,8 @@ import javax.swing.border.BevelBorder;
 import javax.swing.border.Border;
 
 import org.opendcs.database.api.OpenDcsDatabase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import decodes.db.Database;
 import decodes.db.DbEnum;
@@ -45,7 +47,7 @@ import ilex.util.TextUtil;
 
 public class EnumerationPanel extends JPanel
 {
-
+    private static final Logger log = LoggerFactory.getLogger(EnumerationPanel.class);
     private static ResourceBundle genericLabels = RefListEditor.getGenericLabels();
     private static ResourceBundle labels = RefListEditor.getLabels();
 
@@ -84,7 +86,9 @@ public class EnumerationPanel extends JPanel
         catch (Exception ex)
         {
 
-            ex.printStackTrace();
+            log.atError()
+				.setCause(ex)
+				.log("Error creating EnumerationPanel");
         }
     }
 
@@ -366,12 +370,12 @@ public class EnumerationPanel extends JPanel
     }
 
     /**
-     * Shows an error message in a JOptionPane and prints it to stderr.
+     * Shows an error message in a JOptionPane and prints it to the error log
      * @param msg the error message.
      */
     public void showError(String msg)
     {
-        System.err.println(msg);
+        log.error(msg);
         JOptionPane.showMessageDialog(this,
             AsciiUtil.wrapString(msg, 60), "Error!", JOptionPane.ERROR_MESSAGE);
     }

--- a/java/opendcs/src/main/java/decodes/rledit/panels/EnumerationPanel.java
+++ b/java/opendcs/src/main/java/decodes/rledit/panels/EnumerationPanel.java
@@ -1,0 +1,415 @@
+package decodes.rledit.panels;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.ResourceBundle;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextArea;
+import javax.swing.ListSelectionModel;
+import javax.swing.border.BevelBorder;
+import javax.swing.border.Border;
+
+import org.opendcs.database.api.OpenDcsDatabase;
+
+import decodes.db.Database;
+import decodes.db.DbEnum;
+import decodes.db.EnumValue;
+import decodes.gui.SortingListTable;
+import decodes.rledit.EnumTableModel;
+import decodes.rledit.EnumValueDialog;
+import decodes.rledit.RefListEditor;
+import decodes.rledit.RefListFrame;
+import ilex.util.AsciiUtil;
+import ilex.util.TextUtil;
+
+public class EnumerationPanel extends JPanel
+{
+
+    private static ResourceBundle genericLabels = RefListEditor.getGenericLabels();
+    private static ResourceBundle labels = RefListEditor.getLabels();
+
+    private JTextArea jTextArea1 = new JTextArea();
+    private BorderLayout borderLayout2 = new BorderLayout();
+    private GridBagLayout gridBagLayout1 = new GridBagLayout();
+    private JPanel jPanel1 = new JPanel();
+    private JScrollPane jScrollPane1 = new JScrollPane();
+    private EnumTableModel enumTableModel = new EnumTableModel();
+    private JTable enumTable = new SortingListTable(enumTableModel,
+        new int[] { 9, 20, 41, 30 });
+    private JButton addEnumValButton = new JButton();
+    private JButton editEnumValButton = new JButton();
+    private JButton deleteEnumValButton = new JButton();
+    private JButton selectEnumValDefaultButton = new JButton();
+    private JButton upEnumValButton = new JButton();
+    private JButton downEnumValButton = new JButton();
+    private JButton undoDeleteEnumValButton = new JButton();
+    private JPanel jPanel2 = new JPanel();
+    private FlowLayout flowLayout1 = new FlowLayout();
+    private JLabel jLabel1 = new JLabel();
+    private JComboBox enumComboBox = new JComboBox();
+
+    private Border border5;
+
+    private OpenDcsDatabase database;
+    private boolean enumsChanged = false;
+    private EnumValue deletedEnumValue = null;
+
+    public EnumerationPanel(OpenDcsDatabase database)
+    {
+        try
+        {
+            this.database = database;
+            jbInit();
+        }
+        catch (Exception ex)
+        {
+
+            ex.printStackTrace();
+        }
+    }
+
+    public boolean enumsChanged()
+    {
+        return enumsChanged;
+    }
+
+    private void jbInit() throws Exception
+    {
+        jTextArea1.setBackground(Color.white);
+        jTextArea1.setFont(new java.awt.Font("Serif", 0, 14));
+        jTextArea1.setBorder(border5);
+        jTextArea1.setEditable(false);
+        jTextArea1.setText(labels.getString("RefListFrame.enumerationsTab"));
+        jTextArea1.setLineWrap(true);
+        jTextArea1.setRows(3);
+        jTextArea1.setWrapStyleWord(true);
+        this.setLayout(borderLayout2);
+        jPanel1.setLayout(gridBagLayout1);
+        addEnumValButton.setMaximumSize(new Dimension(122, 23));
+        addEnumValButton.setMinimumSize(new Dimension(122, 23));
+        addEnumValButton.setPreferredSize(new Dimension(122, 23));
+        addEnumValButton.setText(genericLabels.getString("add"));
+        addEnumValButton.addActionListener(e -> this.addEnumValButton_actionPerformed(e));
+        editEnumValButton.setMaximumSize(new Dimension(122, 23));
+        editEnumValButton.setMinimumSize(new Dimension(122, 23));
+        editEnumValButton.setPreferredSize(new Dimension(122, 23));
+        editEnumValButton.setText(genericLabels.getString("edit"));
+        editEnumValButton.addActionListener(e -> this.editEnumValButton_actionPerformed(e));
+        deleteEnumValButton.setMaximumSize(new Dimension(122, 23));
+        deleteEnumValButton.setMinimumSize(new Dimension(122, 23));
+        deleteEnumValButton.setPreferredSize(new Dimension(122, 23));
+        deleteEnumValButton.setText(genericLabels.getString("delete"));
+        deleteEnumValButton.addActionListener(e -> this.deleteEnumValButton_actionPerformed(e));
+        selectEnumValDefaultButton.setText(labels.getString("RefListFrame.setDefault"));
+        selectEnumValDefaultButton.addActionListener(e -> this.selectEnumValDefaultButton_actionPerformed(e));
+        upEnumValButton.setMaximumSize(new Dimension(122, 23));
+        upEnumValButton.setMinimumSize(new Dimension(122, 23));
+        upEnumValButton.setPreferredSize(new Dimension(122, 23));
+        upEnumValButton.setText(labels.getString("RefListFrame.moveUp"));
+        upEnumValButton.addActionListener(e -> this.upEnumValButton_actionPerformed(e));
+        downEnumValButton.setMaximumSize(new Dimension(122, 23));
+        downEnumValButton.setMinimumSize(new Dimension(122, 23));
+        downEnumValButton.setPreferredSize(new Dimension(122, 23));
+        downEnumValButton.setText(labels.getString("RefListFrame.moveDown"));
+        downEnumValButton.addActionListener(e -> this.downEnumValButton_actionPerformed(e));
+        undoDeleteEnumValButton.setEnabled(false);
+        undoDeleteEnumValButton.setText(labels.getString("RefListFrame.undoDelete"));
+        undoDeleteEnumValButton.addActionListener(e -> this.undoDeleteEnumValButton_actionPerformed(e));
+        jPanel2.setLayout(flowLayout1);
+        jLabel1.setText(labels.getString("RefListFrame.enumeration"));
+        enumComboBox.setMinimumSize(new Dimension(160, 19));
+        enumComboBox.setPreferredSize(new Dimension(160, 19));
+        enumComboBox.addActionListener(new RefListFrame_enumComboBox_actionAdapter(this));
+        border5 = BorderFactory.createCompoundBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED,Color.white,Color.white,new Color(124, 124, 124),new Color(178, 178, 178)),BorderFactory.createEmptyBorder(6,6,6,6));
+        ArrayList<String> v = new ArrayList<String>();
+        for(Iterator<DbEnum> enumIt = Database.getDb().enumList.iterator();
+            enumIt.hasNext(); )
+        {
+            decodes.db.DbEnum en = enumIt.next();
+            if (en.enumName.equalsIgnoreCase("EquationScope")
+             || en.enumName.equalsIgnoreCase("DataOrder")
+             || en.enumName.equalsIgnoreCase("UnitFamily")
+             || en.enumName.equalsIgnoreCase("LookupAlgorithm")
+             || en.enumName.equalsIgnoreCase("RecordingMode")
+             || en.enumName.equalsIgnoreCase("EquipmentType")
+             || en.enumName.equalsIgnoreCase("Season"))
+                continue;
+            String s = TextUtil.capsExpand(en.enumName);
+            v.add(s);
+        }
+        Collections.sort(v);
+        for(int i=0; i<v.size(); i++)
+        {
+            enumComboBox.addItem(v.get(i));
+        }
+        enumTable.setRowHeight(20);
+        enumTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+
+
+        this.add(jTextArea1, BorderLayout.NORTH);
+        this.add(jPanel1, BorderLayout.CENTER);
+        jPanel1.add(jScrollPane1,     new GridBagConstraints(0, 1, 1, 7, 1.0, 1.0
+                        ,GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(5, 8, 12, 0), 10, -98));
+        jScrollPane1.getViewport().add(enumTable, null);
+
+        //====================================
+        jPanel1.add(editEnumValButton,        new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0
+        ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
+        jPanel1.add(deleteEnumValButton,     new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0
+                ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
+        jPanel1.add(jPanel2,     new GridBagConstraints(0, 0, 2, 1, 1.0, 0.1
+                ,GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL, new Insets(14, 18, 14, 12), 0, 7));
+
+        jPanel2.add(jLabel1, null);
+        jPanel2.add(enumComboBox, null);
+
+        jPanel1.add(addEnumValButton,        new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0
+                ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
+        jPanel1.add(downEnumValButton,     new GridBagConstraints(1, 7, 1, 1, 0.0, 0.0
+                ,GridBagConstraints.NORTH, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
+        jPanel1.add(selectEnumValDefaultButton,     new GridBagConstraints(1, 5, 1, 1, 0.0, 0.0
+                ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
+        jPanel1.add(upEnumValButton,     new GridBagConstraints(1, 6, 1, 1, 0.0, 0.0
+                ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
+        jPanel1.add(undoDeleteEnumValButton,     new GridBagConstraints(1, 4, 1, 1, 0.0, 0.0
+                ,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 20, 5, 20), 0, 0));
+
+    }
+
+
+        /**
+     * Selects an Enumeration to be displayed in the table.
+     * The table is repopulated and the 'Undo' button is disabled.
+     * @param e ActionEvent
+     */
+    void enumComboBox_actionPerformed(ActionEvent e)
+    {
+        // todo: Populate table from selected enum.
+        String s = (String)enumComboBox.getSelectedItem();
+        s = TextUtil.removeAllSpace(s);
+        enumTableModel.setEnum(s);
+        deletedEnumValue = null;
+        undoDeleteEnumValButton.setEnabled(false);
+    }
+
+
+    /**
+     * Displays modal enum value dialog. If OK pressed, results are added
+     * to table.
+     * Sets modified flag.
+     * @param e ActionEvent
+     */
+    void addEnumValButton_actionPerformed(ActionEvent e)
+    {
+        String s = TextUtil.removeAllSpace(
+            (String)enumComboBox.getSelectedItem());
+        decodes.db.DbEnum en = Database.getDb().getDbEnum(s);
+
+        EnumValueDialog evd = new EnumValueDialog();
+        EnumValue ev = new EnumValue(en, "", "", "", "");
+        evd.fillValues(ev);
+        launchDialog(evd);
+        if (evd.wasChanged())
+        {
+            en.replaceValue(ev.getValue(), ev.getDescription(), ev.getExecClassName(), "");
+            enumTableModel.fireTableDataChanged();
+            enumsChanged = true;
+        }
+    }
+
+
+    /**
+    * Displays modal enum-value dialog with selected EV. If OK pressed
+    * the dialog contents are added to the table.
+    * The 'modified' flag is set.
+    * @param e ActionEvent
+    */
+    void editEnumValButton_actionPerformed(ActionEvent e)
+    {
+        int row = enumTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.enumSelectInfo"));
+            return;
+        }
+
+        String s = TextUtil.removeAllSpace(
+            (String)enumComboBox.getSelectedItem());
+        decodes.db.DbEnum en = Database.getDb().getDbEnum(s);
+        EnumValue ev = enumTableModel.getEnumValueAt(row);
+        EnumValueDialog evd = new EnumValueDialog();
+        evd.fillValues(ev);
+        launchDialog(evd);
+        if (evd.wasChanged())
+        {
+            en.replaceValue(ev.getValue(), ev.getDescription(), ev.getExecClassName(), ev.getEditClassName());
+            enumTableModel.fireTableDataChanged();
+            enumsChanged = true;
+        }
+    }
+
+    /**
+     * Deletes the selected enum-value from the table and places it in the
+     * undo buffer. Enables the Undo Delete button.
+     * @param e ActionEvent
+     */
+    void deleteEnumValButton_actionPerformed(ActionEvent e)
+    {
+        int row = enumTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.enumDeleteInfo"));
+            return;
+        }
+
+        String s = TextUtil.removeAllSpace(
+            (String)enumComboBox.getSelectedItem());
+        decodes.db.DbEnum en = Database.getDb().getDbEnum(s);
+        deletedEnumValue = enumTableModel.getEnumValueAt(row);
+        en.removeValue(deletedEnumValue.getValue());
+        enumTableModel.fireTableDataChanged();
+        undoDeleteEnumValButton.setEnabled(true);
+        enumsChanged = true;
+    }
+
+    /**
+     * Adds the deleted enum value back into the table.
+     * Disables the undo button.
+     * @param e ActionEvent
+     */
+    void undoDeleteEnumValButton_actionPerformed(ActionEvent e)
+    {
+        if (deletedEnumValue != null)
+        {
+            String s = TextUtil.removeAllSpace(
+                (String)enumComboBox.getSelectedItem());
+            decodes.db.DbEnum en = Database.getDb().getDbEnum(s);
+            en.replaceValue(deletedEnumValue.getValue(),
+                deletedEnumValue.getDescription(),
+                deletedEnumValue.getExecClassName(), "");
+            deletedEnumValue = null;
+            enumTableModel.fireTableDataChanged();
+        }
+        undoDeleteEnumValButton.setEnabled(false);
+        enumsChanged = true;
+    }
+
+    /**
+     * Marks the currently selected enumeration value as the 'default' value.
+     * @param e ActionEvent
+     */
+    void selectEnumValDefaultButton_actionPerformed(ActionEvent e)
+    {
+        int row = enumTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.enumDefaultInfo"));
+            return;
+        }
+
+        String s = TextUtil.removeAllSpace(
+            (String)enumComboBox.getSelectedItem());
+        decodes.db.DbEnum en = Database.getDb().getDbEnum(s);
+        EnumValue ev = enumTableModel.getEnumValueAt(row);
+        enumTableModel.fireTableDataChanged();
+        en.setDefault(ev.getValue());
+        enumsChanged = true;
+    }
+
+    /**
+     * Moves the currently selected enumeration value up in the table.
+     * When written to the database, the sort order will be set to the
+     * currently displayed order. This and the down button allow you to set
+     * the desired order.
+     * @param e ActionEvent
+     */
+    void upEnumValButton_actionPerformed(ActionEvent e)
+    {
+        int row = enumTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.enumMovUpInfo"));
+            return;
+        }
+        if (enumTableModel.moveUp(row))
+            enumTable.setRowSelectionInterval(row-1, row-1);
+        enumsChanged = true;
+    }
+
+    /**
+     * Moves the currently selected enumeration value down in the table.
+     * When written to the database, the sort order will be set to the
+     * currently displayed order. This and the up button allow you to set
+     * the desired order.
+     * @param e ActionEvent
+     */
+    void downEnumValButton_actionPerformed(ActionEvent e)
+    {
+        int row = enumTable.getSelectedRow();
+        if (row == -1)
+        {
+            showError(labels.getString("RefListFrame.enumMovDnInfo"));
+            return;
+        }
+        if (enumTableModel.moveDown(row))
+        {
+            enumTable.setRowSelectionInterval(row+1, row+1);
+        }
+        enumsChanged = true;
+    }
+
+    /**
+      Launches the passed modal dialog at a reasonable position on the screen.
+      @param dlg the dialog.
+    */
+    private void launchDialog(JDialog dlg)
+    {
+        dlg.setModal(true);
+        dlg.validate();
+        dlg.setLocationRelativeTo(this);
+        dlg.setVisible(true);
+    }
+
+    /**
+     * Shows an error message in a JOptionPane and prints it to stderr.
+     * @param msg the error message.
+     */
+    public void showError(String msg)
+    {
+        System.err.println(msg);
+        JOptionPane.showMessageDialog(this,
+            AsciiUtil.wrapString(msg, 60), "Error!", JOptionPane.ERROR_MESSAGE);
+    }
+
+
+    private static class RefListFrame_enumComboBox_actionAdapter implements java.awt.event.ActionListener
+    {
+        EnumerationPanel adaptee;
+
+        RefListFrame_enumComboBox_actionAdapter(EnumerationPanel adaptee) {
+            this.adaptee = adaptee;
+        }
+        public void actionPerformed(ActionEvent e) {
+            adaptee.enumComboBox_actionPerformed(e);
+        }
+}
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/xml/dao/EnumXmlDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/xml/dao/EnumXmlDao.java
@@ -128,6 +128,7 @@ public class EnumXmlDao implements EnumDAI
 
             Collection<DbEnum> enumList = new HashSet<>();
             XMLInputFactory f = XMLInputFactory.newInstance();
+            f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
             File xmlFile = new File(conn.getDirectory(), "enum/EnumList.xml");
             
             try (InputStream stream = new FileInputStream(xmlFile))


### PR DESCRIPTION
## Problem Description

Additional demonstration and usage of the new `OpenDcsDatabase::getDao` and `DataTransaction` system.

## Solution

1. Modified RefListFrame to extract Enumeration controls to own panel for separation of concerns.
2. Modified RefListEditor and RefListFrame to take an OpenDcsDatabase
3. Change ComboBox model to be DbEnum instead of string, modified usages to follow suite
4. Created functions as appropriate to control and retrieve state of the enumerations.
5. Where Database.getDb was directly used for Enum operations was changed to use new style
6. Saving of values was moved off GUI thread using technique from `RoutingSpecEditPanel` to report database saving exceptions to user (NOTE: will be turning that work flow into generic usage in separate PR. all but doInBackground and refernce value are duplicated.)
7. Saving of values is done in a transaction using the new style DAO.

## how you tested the change

Manually ran RlEdit to see original behavior still exists.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
