### PR TITLE
Disable documentation build, but don't fail the build itself.

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -5,9 +5,24 @@ plugins {
 def pythonExe = osWin ? "python.exe" : "python3"
 def docsVenv = "$buildDir/sphinx"
 def docsDir = projectDir
-def venvPath = (osWin ? "${docsVenv}/Scipts" : "${docsVenv}/bin")
+def venvPath = (osWin ? "${docsVenv}/Scripts" : "${docsVenv}/bin")
+def noDocs = project.findProperty("no.docs") ?: false
+def havePython = checkPython(pythonExe)
 
-
+def checkPython(executableStr) {
+    def result = exec {
+        ignoreExitValue = true
+        if (osWin) {
+            executable "cmd"
+            args += "/c"
+        } else {
+            executable executableStr
+        }
+        args += "-c"
+        args += "import sys; sys.exit(0)"
+    }
+    return result.getExitValue() == 0
+}
 
 configurations {
     docs {
@@ -15,7 +30,6 @@ configurations {
         canBeResolved = false        
     }
 }
-
 
 task prepVenv(type: Exec) {
     executable pythonExe
@@ -43,26 +57,36 @@ task installReqs(type: Exec) {
 }
 
 
-tasks.addRule("Pattern: buidDocs<ID>") { String taskName ->
+tasks.addRule("Pattern: buildDocs<ID>") { String taskName ->
     def builder = taskName.toLowerCase().replace("builddocs","")
     if (taskName.startsWith("buildDocs")) {
+        if (!noDocs && havePython) {
         def theArgs = osWin ? ["/c","make.bat",builder]
                          : [builder]
         def cmd = osWin ? "cmd" : "make"
-        task(taskName, type: Exec) {
-            dependsOn installReqs
+            task(taskName, type: Exec) {
+                dependsOn installReqs
 
-            executable cmd
-            workingDir projectDir
-            args = theArgs
-            environment "PATH": "${venvPath}:${System.getenv('PATH')}"
+                executable cmd
+                workingDir projectDir
+                args = theArgs
+                environment "PATH": "${venvPath}:${System.getenv('PATH')}"
 
-            inputs.files(fileTree('source'))
-                  .withPropertyName('sourceFiles')
-                  .withPathSensitivity(PathSensitivity.RELATIVE)
-    
-            outputs.dir("${buildDir}/${builder}")
-                   .withPropertyName('outputDir')
+                inputs.files(fileTree('source'))
+                    .withPropertyName('sourceFiles')
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
+                outputs.dir("${buildDir}/${builder}")
+                       .withPropertyName('outputDir')
+            }
+        } else {
+            task(taskName) {
+                // Register outputs so downstream usages still behave correctly.
+                outputs.dir("${buildDir}/${builder}")
+                       .withPropertyName('outputDir')
+                doLast {
+                    println('Doc Generation was skipped.')
+                }
+            }
         }
     }
 }
@@ -70,8 +94,12 @@ tasks.addRule("Pattern: buidDocs<ID>") { String taskName ->
 task buildDocs {
     dependsOn 'buildDocsHtml' 
     // work on PDF later,'buildDocsLatexpdf'
+    doFirst {
+        if (!havePython) {
+            logger.warn("Python was not found, the documentation will not be built.")
+        }
+    }
 }
-
 
 artifacts {
     docs(file("${buildDir}/html")) {

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -9,17 +9,18 @@ def venvPath = (osWin ? "${docsVenv}/Scripts" : "${docsVenv}/bin")
 def noDocs = project.findProperty("no.docs") ?: false
 def havePython = checkPython(pythonExe)
 
-def checkPython(executableStr) {
+def checkPython(pythonStr) {
     def result = exec {
         ignoreExitValue = true
         if (osWin) {
             executable "cmd"
             args += "/c"
+            args += pythonStr
         } else {
-            executable executableStr
+            executable pythonStr
         }
         args += "-c"
-        args += "import sys; sys.exit(0)"
+        args += "import sys; print('checking for python'); sys.exit(0)"
     }
     return result.getExitValue() == 0
 }


### PR DESCRIPTION
## Problem Description

The ant build allowed either disabling the documentation build, or ignoring the documentation build if python wasn't available.

## Solution

Provide the same behavior in the Gradle build.

## how you tested the change

Manually.
1. cleaned the build, set the `-Pno.docs=true` flag and verified no documentation was built and the distribution could still be created.
2. added a check for pythons existence and also disabled the build. (Check was done by intentionally misnaming the python executable defined at the top of the file.


## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
