### PR TITLE
make Java languageVersion dynamic in opendcs.java-conventions.gradle

### DIFF
--- a/buildSrc/src/main/groovy/opendcs.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.java-conventions.gradle
@@ -24,7 +24,9 @@ java {
 
 tasks.withType(JavaCompile).configureEach {
     javaCompiler = javaToolchains.compilerFor {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(
+            JavaVersion.current().majorVersion.toInteger()
+        )
     }
 }
 

--- a/buildSrc/src/main/groovy/opendcs.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.java-conventions.gradle
@@ -22,12 +22,9 @@ java {
     withJavadocJar()
 }
 
-tasks.withType(JavaCompile).configureEach {
-    javaCompiler = javaToolchains.compilerFor {
-        languageVersion = JavaLanguageVersion.of(
-            JavaVersion.current().majorVersion.toInteger()
-        )
-    }
+tasks.withType(JavaCompile) {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
 }
 
 configurations {


### PR DESCRIPTION
languageVersion was fixed at java 8.

I could not compile on java 11.

The github actions don't need this change for some reason.  


Thanks @oskarhurst  for assistance on debugging this.
