### PR TITLE
Strawman work on RawMessages as a stream.

### DIFF
--- a/java/opendcs/src/main/java/decodes/datasource/DataSourceExec.java
+++ b/java/opendcs/src/main/java/decodes/datasource/DataSourceExec.java
@@ -20,8 +20,14 @@
 */
 package decodes.datasource;
 
+import java.util.Iterator;
 import java.util.Properties;
+import java.util.Spliterators;
 import java.util.Vector;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.opendcs.utils.FailableResult;
 import java.util.concurrent.DelayQueue;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
@@ -267,6 +273,42 @@ public abstract class DataSourceExec implements PropertiesOwner
 	*/
 	protected abstract RawMessage getSourceRawMessage()
 		throws DataSourceException;
+
+	public Stream<FailableResult<RawMessage,DataSourceException>> getRawMessages() throws DataSourceException
+	{
+		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<FailableResult<RawMessage,DataSourceException>>()
+		{
+			private FailableResult<RawMessage,DataSourceException> nextMessage = null;
+			@Override
+			public boolean hasNext() 
+			{
+				try
+				{
+					nextMessage = FailableResult.success(getRawMessage());
+					if (nextMessage != null)
+					{
+						return true;
+					}
+				}
+				catch (DataSourceException ex)
+				{
+					if (!(ex instanceof DataSourceEndException))
+					{
+						nextMessage =FailableResult.failure(ex);
+						return true;
+					}
+				}
+				return false;
+			}
+
+			@Override
+			public FailableResult<RawMessage,DataSourceException> next()
+			{
+				return nextMessage;
+			}
+
+		}, 0), false );
+	}
 
 	/**
 	  Find the matching transport medium for this platform.

--- a/java/opendcs/src/main/java/decodes/datasource/DataSourceExec.java
+++ b/java/opendcs/src/main/java/decodes/datasource/DataSourceExec.java
@@ -274,17 +274,26 @@ public abstract class DataSourceExec implements PropertiesOwner
 	protected abstract RawMessage getSourceRawMessage()
 		throws DataSourceException;
 
-	public Stream<FailableResult<RawMessage,DataSourceException>> getRawMessages() throws DataSourceException
+	/**
+	 * Provide a stream of DataMessage that can be chained to other operations.
+	 * 
+	 * The stream provided by the default implementation closes only when the source throws DataSourceEndException.
+	 * Other Errors are provided in the Error Result so that callers can design how to handle errors.
+	 * 
+	 * @return Either a valid DataMessage or the exception thrown by getSourceRawMessage.
+	 * @throws DataSourceException exception DataSourceEndException, which terminates the stream.
+	 */
+	public Stream<FailableResult<DataMessage,DataSourceException>> stream() throws DataSourceException
 	{
-		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<FailableResult<RawMessage,DataSourceException>>()
+		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<FailableResult<DataMessage,DataSourceException>>()
 		{
-			private FailableResult<RawMessage,DataSourceException> nextMessage = null;
+			private FailableResult<DataMessage,DataSourceException> nextMessage = null;
 			@Override
 			public boolean hasNext() 
 			{
 				try
 				{
-					nextMessage = FailableResult.success(getRawMessage());
+					nextMessage = FailableResult.success(getDataMessage());
 					if (nextMessage != null)
 					{
 						return true;
@@ -294,7 +303,7 @@ public abstract class DataSourceExec implements PropertiesOwner
 				{
 					if (!(ex instanceof DataSourceEndException))
 					{
-						nextMessage =FailableResult.failure(ex);
+						nextMessage = FailableResult.failure(ex);
 						return true;
 					}
 				}
@@ -302,7 +311,7 @@ public abstract class DataSourceExec implements PropertiesOwner
 			}
 
 			@Override
-			public FailableResult<RawMessage,DataSourceException> next()
+			public FailableResult<DataMessage,DataSourceException> next()
 			{
 				return nextMessage;
 			}

--- a/java/opendcs/src/main/java/decodes/datasource/DataSourceExec.java
+++ b/java/opendcs/src/main/java/decodes/datasource/DataSourceExec.java
@@ -20,9 +20,7 @@
 */
 package decodes.datasource;
 
-import java.util.Iterator;
 import java.util.Properties;
-import java.util.Spliterators;
 import java.util.Vector;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -36,6 +34,7 @@ import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
 
 import org.opendcs.decodes.api.DataMessage;
+import org.opendcs.decodes.datasources.DataSourceSpliterator;
 
 import decodes.db.DataSource;
 import decodes.db.Database;
@@ -280,43 +279,14 @@ public abstract class DataSourceExec implements PropertiesOwner
 	 * The stream provided by the default implementation closes only when the source throws DataSourceEndException.
 	 * Other Errors are provided in the Error Result so that callers can design how to handle errors.
 	 * 
+	 * Default implementation is not parallel. If a given implementation can determine number of messages
+	 * and allowed parallel it should override this method.
+	 * 
 	 * @return Either a valid DataMessage or the exception thrown by getSourceRawMessage.
-	 * @throws DataSourceException exception DataSourceEndException, which terminates the stream.
 	 */
-	public Stream<FailableResult<DataMessage,DataSourceException>> stream() throws DataSourceException
+	public Stream<FailableResult<DataMessage,DataSourceException>> stream()
 	{
-		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<FailableResult<DataMessage,DataSourceException>>()
-		{
-			private FailableResult<DataMessage,DataSourceException> nextMessage = null;
-			@Override
-			public boolean hasNext() 
-			{
-				try
-				{
-					nextMessage = FailableResult.success(getDataMessage());
-					if (nextMessage != null)
-					{
-						return true;
-					}
-				}
-				catch (DataSourceException ex)
-				{
-					if (!(ex instanceof DataSourceEndException))
-					{
-						nextMessage = FailableResult.failure(ex);
-						return true;
-					}
-				}
-				return false;
-			}
-
-			@Override
-			public FailableResult<DataMessage,DataSourceException> next()
-			{
-				return nextMessage;
-			}
-
-		}, 0), false );
+		return StreamSupport.stream(new DataSourceSpliterator(this), false);
 	}
 
 	/**

--- a/java/opendcs/src/main/java/org/opendcs/decodes/datasources/DataSourceSpliterator.java
+++ b/java/opendcs/src/main/java/org/opendcs/decodes/datasources/DataSourceSpliterator.java
@@ -1,0 +1,61 @@
+package org.opendcs.decodes.datasources;
+
+import java.util.Spliterator;
+import java.util.Spliterators.AbstractSpliterator;
+import java.util.function.Consumer;
+
+import org.opendcs.decodes.api.DataMessage;
+import org.opendcs.utils.FailableResult;
+
+import decodes.datasource.DataSourceEndException;
+import decodes.datasource.DataSourceException;
+import decodes.datasource.DataSourceExec;
+
+/**
+ * Default data source spliterator. Advances from one message to the next mapping errors or end of stream
+ * as appropriate.
+ */
+public class DataSourceSpliterator extends AbstractSpliterator<FailableResult<DataMessage, DataSourceException>>
+{
+
+    private final DataSourceExec dataSource;
+
+
+    public DataSourceSpliterator(DataSourceExec dataSource)
+    {
+        super(Long.MAX_VALUE, Spliterator.IMMUTABLE | Spliterator.NONNULL);
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer<? super FailableResult<DataMessage, DataSourceException>> action)
+    {
+        boolean ret = true;
+        FailableResult<DataMessage, DataSourceException> msgRet;
+        try
+        {
+            var msg = dataSource.getDataMessage();
+            if (msg == null)
+            {
+                ret = false;
+                msgRet = FailableResult.failure(new DataSourceEndException("End of Data Source."));
+            }
+            else
+            {
+                msgRet = FailableResult.success(msg);
+            }
+        }
+        catch (DataSourceEndException ex)
+        {
+            ret = false;
+            msgRet = FailableResult.failure(ex);
+        }
+        catch (DataSourceException ex)
+        {
+            msgRet = FailableResult.failure(ex);
+        }
+
+        action.accept(msgRet);
+        return ret;
+    }
+}

--- a/java/opendcs/src/test/java/decodes/datasource/DataSourceTest.java
+++ b/java/opendcs/src/test/java/decodes/datasource/DataSourceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -44,6 +45,10 @@ public class DataSourceTest
         DataSourceException result = testDS.getRawMessages()
                                            .filter(msg -> msg.isSuccess())
                                            .map(msg -> msg.getSuccess())
+                                           .map(msg -> {
+                                                System.out.println("Decoded Message.");
+                                                return msg;
+                                           })
                                            .collect(new MessageCollector());
         assertNotNull(result);
         
@@ -90,6 +95,16 @@ public class DataSourceTest
             {
                 throw new DataSourceEndException("No more data.");
             }
+            if (index > 0)
+            {
+                /* outputing message with some delay to see the affects */
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            }
             RawMessage msg = new RawMessage(messages[index].getBytes());
             index++;
             return msg;
@@ -102,6 +117,10 @@ public class DataSourceTest
         @Override
         public Supplier<List<RawMessage>> supplier()
         {
+            /*
+             This type is arbitrary but the examples used Lists. I'm thinking the instance of the collector
+             takes a "StatusReporter" object as a constructor parameter and this is what's returned.
+            */
             return () -> new ArrayList<RawMessage>();
         }
 
@@ -110,14 +129,24 @@ public class DataSourceTest
         {
             return (list,msg) ->
             {
-                System.out.println("Adding message");
+                /** Here instead of "Accumulating" we'd be updating a status object */
+                System.out.println(new Date().toString() + ": Adding message: " + msg.toString());
                 list.add(msg);
             };
         }
 
+        /**
+         * This only comes up when doing parallel, but for our purpose the same logic as above would seem to
+         * be able to apply
+         */
         @Override
         public BinaryOperator<List<RawMessage>> combiner() {
-            return (left,right) -> {left.addAll(right);return left;};
+            return (left,right) ->
+            {
+                System.out.println("Combining");
+                left.addAll(right);
+                return left;
+            };
         }
 
         @Override
@@ -125,7 +154,11 @@ public class DataSourceTest
         {            
             return (list) -> 
             {
-                System.out.println("Finishing.");
+                for (RawMessage rm :list)
+                {
+                    System.out.println(new Date().toString() + ": " + rm);
+                }
+                System.out.println(new Date().toString() + ": Finishing.");
                 return new DataSourceEndException("The end");
             };    
         }

--- a/java/opendcs/src/test/java/decodes/datasource/DataSourceTest.java
+++ b/java/opendcs/src/test/java/decodes/datasource/DataSourceTest.java
@@ -1,0 +1,142 @@
+package decodes.datasource;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.Vector;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.opendcs.utils.FailableResult;
+
+import decodes.db.InvalidDatabaseException;
+import decodes.db.NetworkList;
+
+public class DataSourceTest
+{
+
+    @Test
+    void test_datasource_stream() throws Exception
+    {
+        TestDataSource testDS = new TestDataSource();
+        List<FailableResult<RawMessage,DataSourceException>> results = testDS.getRawMessages().collect(Collectors.toList());
+        assertEquals(testDS.size(), results.size(), "All messages and the end marker have not been returned.");
+        assertArrayEquals("A message".getBytes(),results.get(0).getSuccess().data, "Correct data was not returned.");
+    }
+
+
+    @Test
+    void test_datasource_stream_collector() throws Exception
+    {
+        TestDataSource testDS = new TestDataSource();
+        DataSourceException result = testDS.getRawMessages()
+                                           .filter(msg -> msg.isSuccess())
+                                           .map(msg -> msg.getSuccess())
+                                           .collect(new MessageCollector());
+        assertNotNull(result);
+        
+    }
+
+
+    public static class TestDataSource extends DataSourceExec
+    {
+        private int index = 0;
+        private String[] messages = {"A message", "B message", "C Message"};        
+
+        public TestDataSource()
+        {
+            super(null, null);
+        }
+
+        @Override
+        public void processDataSource() throws InvalidDatabaseException 
+        {
+            /* nothing to do */
+        }
+
+        public int size()
+        {
+            return messages.length;
+        }
+
+        @Override
+        public void init(Properties routingSpecProps, String since, String until, Vector<NetworkList> networkLists) throws DataSourceException 
+        {
+            /* nothing to do */
+        }
+
+        @Override
+        public void close()
+        {
+            /* nothing to do */
+        }
+
+        @Override
+        public RawMessage getRawMessage() throws DataSourceException
+        {
+            if (index >= messages.length)
+            {
+                throw new DataSourceEndException("No more data.");
+            }
+            RawMessage msg = new RawMessage(messages[index].getBytes());
+            index++;
+            return msg;
+        }
+    }
+
+    public static class MessageCollector implements Collector<RawMessage, List<RawMessage>, DataSourceException>
+    {
+
+        @Override
+        public Supplier<List<RawMessage>> supplier()
+        {
+            return () -> new ArrayList<RawMessage>();
+        }
+
+        @Override
+        public BiConsumer<List<RawMessage>, RawMessage> accumulator()
+        {
+            return (list,msg) ->
+            {
+                System.out.println("Adding message");
+                list.add(msg);
+            };
+        }
+
+        @Override
+        public BinaryOperator<List<RawMessage>> combiner() {
+            return (left,right) -> {left.addAll(right);return left;};
+        }
+
+        @Override
+        public Function<List<RawMessage>, DataSourceException> finisher() 
+        {            
+            return (list) -> 
+            {
+                System.out.println("Finishing.");
+                return new DataSourceEndException("The end");
+            };    
+        }
+
+        @Override
+        public Set<Characteristics> characteristics() 
+        {
+            Set<Characteristics> set = new HashSet<>();
+            set.add(Characteristics.UNORDERED);
+            return set;
+        }
+
+    }
+}

--- a/java/opendcs/src/test/java/decodes/datasource/DataSourceTest.java
+++ b/java/opendcs/src/test/java/decodes/datasource/DataSourceTest.java
@@ -3,7 +3,6 @@ package decodes.datasource;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -20,7 +19,6 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
-import org.opendcs.utils.FailableResult;
 
 import org.opendcs.decodes.api.DataMessage;
 
@@ -99,7 +97,7 @@ public class DataSourceTest
             }
             if (index > 0)
             {
-                /* outputing message with some delay to see the affects */
+                /* outputting message with some delay to see the affects */
                 try {
                     Thread.sleep(5000);
                 } catch (InterruptedException e) {

--- a/java/opendcs/src/test/java/decodes/datasource/DataSourceTest.java
+++ b/java/opendcs/src/test/java/decodes/datasource/DataSourceTest.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.opendcs.utils.FailableResult;
 
+import org.opendcs.decodes.api.DataMessage;
+
 import decodes.db.InvalidDatabaseException;
 import decodes.db.NetworkList;
 
@@ -32,9 +34,9 @@ public class DataSourceTest
     void test_datasource_stream() throws Exception
     {
         TestDataSource testDS = new TestDataSource();
-        List<FailableResult<RawMessage,DataSourceException>> results = testDS.getRawMessages().collect(Collectors.toList());
+        var results = testDS.stream().collect(Collectors.toList());
         assertEquals(testDS.size(), results.size(), "All messages and the end marker have not been returned.");
-        assertArrayEquals("A message".getBytes(),results.get(0).getSuccess().data, "Correct data was not returned.");
+        assertArrayEquals("A message".getBytes(), ((RawMessage)results.get(0).getSuccess()).data, "Correct data was not returned.");
     }
 
 
@@ -42,7 +44,7 @@ public class DataSourceTest
     void test_datasource_stream_collector() throws Exception
     {
         TestDataSource testDS = new TestDataSource();
-        DataSourceException result = testDS.getRawMessages()
+        DataSourceException result = testDS.stream()
                                            .filter(msg -> msg.isSuccess())
                                            .map(msg -> msg.getSuccess())
                                            .map(msg -> {
@@ -89,7 +91,7 @@ public class DataSourceTest
         }
 
         @Override
-        public RawMessage getRawMessage() throws DataSourceException
+        public RawMessage getSourceRawMessage() throws DataSourceException
         {
             if (index >= messages.length)
             {
@@ -111,21 +113,21 @@ public class DataSourceTest
         }
     }
 
-    public static class MessageCollector implements Collector<RawMessage, List<RawMessage>, DataSourceException>
+    public static class MessageCollector implements Collector<DataMessage, List<DataMessage>, DataSourceException>
     {
 
         @Override
-        public Supplier<List<RawMessage>> supplier()
+        public Supplier<List<DataMessage>> supplier()
         {
             /*
              This type is arbitrary but the examples used Lists. I'm thinking the instance of the collector
              takes a "StatusReporter" object as a constructor parameter and this is what's returned.
             */
-            return () -> new ArrayList<RawMessage>();
+            return () -> new ArrayList<DataMessage>();
         }
 
         @Override
-        public BiConsumer<List<RawMessage>, RawMessage> accumulator()
+        public BiConsumer<List<DataMessage>, DataMessage> accumulator()
         {
             return (list,msg) ->
             {
@@ -140,7 +142,7 @@ public class DataSourceTest
          * be able to apply
          */
         @Override
-        public BinaryOperator<List<RawMessage>> combiner() {
+        public BinaryOperator<List<DataMessage>> combiner() {
             return (left,right) ->
             {
                 System.out.println("Combining");
@@ -150,13 +152,13 @@ public class DataSourceTest
         }
 
         @Override
-        public Function<List<RawMessage>, DataSourceException> finisher() 
+        public Function<List<DataMessage>, DataSourceException> finisher() 
         {            
             return (list) -> 
             {
-                for (RawMessage rm :list)
+                for (var message: list)
                 {
-                    System.out.println(new Date().toString() + ": " + rm);
+                    System.out.println(new Date().toString() + ": " + message);
                 }
                 System.out.println(new Date().toString() + ": Finishing.");
                 return new DataSourceEndException("The end");

--- a/java/opendcs/src/test/java/decodes/datasource/DataSourceTest.java
+++ b/java/opendcs/src/test/java/decodes/datasource/DataSourceTest.java
@@ -25,15 +25,23 @@ import org.opendcs.decodes.api.DataMessage;
 import decodes.db.InvalidDatabaseException;
 import decodes.db.NetworkList;
 
-public class DataSourceTest
+class DataSourceTest
 {
 
     @Test
     void test_datasource_stream() throws Exception
     {
         TestDataSource testDS = new TestDataSource();
-        var results = testDS.stream().collect(Collectors.toList());
-        assertEquals(testDS.size(), results.size(), "All messages and the end marker have not been returned.");
+        final var results = testDS.stream().collect(Collectors.toList());
+        assertEquals(testDS.size() + 1 /* the end marker */, results.size(),  () ->
+            "All messages and the end marker have not been returned: " +
+                    String.join(",", results.stream()
+                                            .map(r -> r.isSuccess()
+                                                    ? r.getSuccess().toString()
+                                                    : r.getFailure().getMessage())
+                                            .toList()
+                    )
+        );
         assertArrayEquals("A message".getBytes(), ((RawMessage)results.get(0).getSuccess()).data, "Correct data was not returned.");
     }
 
@@ -98,10 +106,12 @@ public class DataSourceTest
             if (index > 0)
             {
                 /* outputting message with some delay to see the affects */
-                try {
+                try
+                {
                     Thread.sleep(5000);
-                } catch (InterruptedException e) {
-                    // TODO Auto-generated catch block
+                }
+                catch (InterruptedException e)
+                {
                     e.printStackTrace();
                 }
             }
@@ -140,7 +150,8 @@ public class DataSourceTest
          * be able to apply
          */
         @Override
-        public BinaryOperator<List<DataMessage>> combiner() {
+        public BinaryOperator<List<DataMessage>> combiner()
+        {
             return (left,right) ->
             {
                 System.out.println("Combining");
@@ -170,6 +181,5 @@ public class DataSourceTest
             set.add(Characteristics.UNORDERED);
             return set;
         }
-
     }
 }


### PR DESCRIPTION
Okay, so there's definitely more details to work out here, but I've been thinking about how we could make use of the `java.util.streams` library to cleanup the flow of the routing spec processing.

The current logic of RoutingSpecThread is
1. Duplicated a surprising amount
2. A smidge spaghetti with the data
3. Uses exceptions for flow control, which is not great in java.
4. Basically processing a "stream" of messages, just in an archaic way.

This is incomplete and currently built as a strawman for discussion.

But the basic principal is:
- DataSourceExec returns a Stream of RawMessage (technically a wrapped message for error handling)
- To process this appropriate filters and mappings, such as to decodeMessage (which has it's own logic duplication issue), and output message
- Use a collector to handle pulling values from the stream, updating various statistics measurements, return a reason for stream processing to end.

While this mostly just eliminates an exclicit while loop, it has the added benefit of making it very difficult to embedded application (RoutinSpecThread, MessageBrowser) in the main flow. However, this usages could easily include peek operations on the stream to extract information desired during that usage.

The nice thing about this is that while the current getRawMessage could use some design improvements it integrations with this new scheme in a way that wouldn't interfere with existing code.


I'd like to gather some thoughts on the topic and if there's more general agreement I'll start working on something more concrete and useful. 

