### PR TITLE
Remove file from doc build. Too many errors.

### DIFF
--- a/docs/source/reservoir-evaporation-algorithm.rst
+++ b/docs/source/reservoir-evaporation-algorithm.rst
@@ -105,8 +105,7 @@ See the legacy documentation below to better understand how the algorithm behave
 Reservoir Evaporation Legacy Documentation
 ******************************************
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Legacy ResEvap
+.. note::
 
-   Legacy ResEvap <./legacy-resevap-computation.rst>
+   See https://github.com/opendcs/opendcs/blob/main/docs/source/legacy-resevap-computation.rst
+   Documentation is not directly included due to errors with processing the embedded formulas.


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Legacy resevap docs were causing errors that prevented read-the-docs from generating updated documentation.

The errors appear to be a matter of how `.. math:` is used within the tables and how that gets rendered into latex.

## Solution

Remove file from documentation build, put link to raw source in place.

## how you tested the change

Tested locally with `make latexpdf` in doc directory.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
