### PR TITLE
More flexible processing of LddsConnection file.

### DIFF
--- a/java/opendcs/src/main/java/lrgs/rtstat/hosts/LrgsConnection.java
+++ b/java/opendcs/src/main/java/lrgs/rtstat/hosts/LrgsConnection.java
@@ -136,9 +136,25 @@ public final class LrgsConnection
     {
         final String parts[] = input.split("\\s+");
         final int port = Integer.parseInt(parts[0]);
-        final String username = parts[1];
-        final Long lastUsed = Long.parseLong(parts[2]);
-        final String password = parts[3];
+        String username = "<set_me>";
+        long lastUsed = 0;
+        String password = "<set_me>";
+        // Some older files only container the host portion.
+        // this allows them to be successfully loaded and saved
+        // while informing the user which values need
+        // updating.
+        if (parts.length > 1)
+        {
+            username = parts[1];
+        }
+        if (parts.length > 2)
+        {
+            lastUsed = Long.parseLong(parts[2]);
+        }
+        if (parts.length > 3)
+        {
+            password = parts[3];    
+        }
 
         return new LrgsConnection(host, port,
                                   username, password, new Date(lastUsed));


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #918. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Allow missing values for each entry, sets default value on initial read.

## how you tested the change

1. Opened rtstat with LddsConnection file that contains an entry with only the hostname and port.
2. Connected to a different LRGS
3. Review LddsConnection file and verify entry was set to have updated values.

Attempted to just leave as null, but the dialogs now expect real values.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
