### PR TITLE
Bugfix: Update ResultSet Handling of Dates for CWMS DB Support

### DIFF
--- a/java/opendcs/src/main/java/decodes/sql/RoutingSpecListIO.java
+++ b/java/opendcs/src/main/java/decodes/sql/RoutingSpecListIO.java
@@ -268,34 +268,34 @@ public class RoutingSpecListIO extends SqlDbObjIo
                        {
                            if (super._dbio.isCwms())
                            {
-                               Date x = rs.getDate(2);
-                               if (!rs.wasNull())
+                               Date x = resultSet.getDate(2);
+                               if (!resultSet.wasNull())
                                {
                                    ars.setLastActivityTime(x);
                                }
                            }
                            else
                            {
-                                 Long x = rs.getLong(2);
-                                 if(!rs.wasNull())
-                                 {
-                                      ars.setLastActivityTime(new Date(x));
-                                 }
+                             Long x = resultSet.getLong(2);
+                             if(!resultSet.wasNull())
+                             {
+                                  ars.setLastActivityTime(new Date(x));
+                             }
                            }
                            ars.setNumMessages(resultSet.getInt(3));
                            ars.setNumDecodesErrors(resultSet.getInt(4));
                            if (super._dbio.isCwms())
                            {
-                               Date x = rs.getDate(5);
-                               if (!rs.wasNull())
+                               Date x = resultSet.getDate(5);
+                               if (!resultSet.wasNull())
                                {
                                    ars.setLastMessageTime(x);
                                }
                            }
                            else
                            {
-                               Long x = rs.getLong(5);
-                               if(!rs.wasNull())
+                               Long x = resultSet.getLong(5);
+                               if(!resultSet.wasNull())
                                {
                                    ars.setLastMessageTime(new Date(x));
                                }

--- a/java/opendcs/src/main/java/opendcs/dao/DacqEventDAO.java
+++ b/java/opendcs/src/main/java/opendcs/dao/DacqEventDAO.java
@@ -19,6 +19,7 @@ import ilex.util.Logger;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Date;
@@ -288,7 +289,7 @@ public class DacqEventDAO extends DaoBase implements DacqEventDAI
 			else if (timeInMillis != null)
 			{
 				q = q + " " + c + " EVENT_TIME >= ?";
-				parameters.add(timeInMillis);
+				parameters.add(Date.from(Instant.ofEpochMilli(timeInMillis)));
 			}
 		}
 

--- a/java/opendcs/src/main/java/opendcs/dao/DacqEventDAO.java
+++ b/java/opendcs/src/main/java/opendcs/dao/DacqEventDAO.java
@@ -289,7 +289,7 @@ public class DacqEventDAO extends DaoBase implements DacqEventDAI
 			else if (timeInMillis != null)
 			{
 				q = q + " " + c + " EVENT_TIME >= ?";
-				parameters.add(Date.from(Instant.ofEpochMilli(timeInMillis)));
+				parameters.add(new Date(timeInMillis));
 			}
 		}
 

--- a/java/opendcs/src/main/java/opendcs/dao/DacqEventDAO.java
+++ b/java/opendcs/src/main/java/opendcs/dao/DacqEventDAO.java
@@ -19,7 +19,6 @@ import ilex.util.Logger;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Date;


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
OpenTSDB and CWMS databases handle dates differently. When used in the REST API, both databases are supported, but errors will be thrown when the CWMS database is used.

## Solution

Updated database retrieval methods to use getDate instead of getLong for Date fields when retrieving using a ResultSet.

## how you tested the change

Integration tested against OpenTSDB and CWMS Docker instances in the REST API.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
