### PR TITLE
Fixed PresentationGroup deletion from cache

### DIFF
--- a/java/opendcs/src/main/java/decodes/sql/PresentationGroupListIO.java
+++ b/java/opendcs/src/main/java/decodes/sql/PresentationGroupListIO.java
@@ -721,6 +721,15 @@ public class PresentationGroupListIO extends SqlDbObjIo
 
         q = "DELETE FROM PresentationGroup WHERE ID = " + id;
         executeUpdate(q);
+
+        if (pg.getDatabase().getDbIo() != null)
+        {
+            PresentationGroup group = pg.getDatabase().presentationGroupList.getById(id);
+            if (group != null)
+            {
+                pg.getDatabase().presentationGroupList.remove(group);
+            }
+        }
     }
 
 

--- a/java/opendcs/src/main/java/decodes/sql/PresentationGroupListIO.java
+++ b/java/opendcs/src/main/java/decodes/sql/PresentationGroupListIO.java
@@ -722,13 +722,10 @@ public class PresentationGroupListIO extends SqlDbObjIo
         q = "DELETE FROM PresentationGroup WHERE ID = " + id;
         executeUpdate(q);
 
-        if (pg.getDatabase().getDbIo() != null)
+        PresentationGroup group = _pgList.getById(id);
+        if (group != null)
         {
-            PresentationGroup group = pg.getDatabase().presentationGroupList.getById(id);
-            if (group != null)
-            {
-                pg.getDatabase().presentationGroupList.remove(group);
-            }
+            _pgList.remove(group);
         }
     }
 


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Presentation groups were failing to be successfully removed from the cache upon deletion. This caused deleted groups to show up upon retrieval.

## Solution

Added removal from cache to presentation group deletion method.

## how you tested the change

Integration tested within the REST API against OpenTSDB and CWMS database instances.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
