### PR TITLE
Fixed TimeSeries and TimeSeries Group deletion from cache

### DIFF
--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/TimeSeriesDaoIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/TimeSeriesDaoIT.java
@@ -70,24 +70,24 @@ class TimeSeriesDaoIT extends AppTestBase
                 tsDao.saveTimeSeries(tsIn);
                 // Retrieve the TimeSeriesIdentifier that shouldn't been saved to the database.
                 // This will also fill in required metadata so that the retrieval operations are handled correctly.
-                FailableResult<TimeSeriesIdentifier,TsdbException> tsIdSavedResult = tsDao.findTimeSeriesIdentifier(tsIn.getTimeSeriesIdentifier().getUniqueString());
+                FailableResult<TimeSeriesIdentifier, TsdbException> tsIdSavedResult = tsDao.findTimeSeriesIdentifier(tsIn.getTimeSeriesIdentifier().getUniqueString());
                 assertTrue(tsIdSavedResult.isSuccess(), "Time series was not correctly saved.");
                 final TimeSeriesIdentifier tsIdSaved = tsIdSavedResult.getSuccess();
                 final CTimeSeries result = tsDao.makeTimeSeries(tsIdSaved);
                 result.setUnitsAbbr(tsIn.getUnitsAbbr());
                 log.info("Created CTimeseries {}", result);
                 tsDao.fillTimeSeries(result,
-                                     tsIn.sampleAt(0).getTime(), 
-                                     tsIn.sampleAt(tsIn.size()-1).getTime(),
-                                      true, true, false);
+                        tsIn.sampleAt(0).getTime(),
+                        tsIn.sampleAt(tsIn.size() - 1).getTime(),
+                        true, true, false);
                 log.info("Data loaded.");
                 assertEquals(tsIn, result, "Timeseries round trip did not work.");
                 tsDao.deleteTimeSeries(tsIn.getTimeSeriesIdentifier()); // This will also delete the timeseries identifier.
                 final CTimeSeries result2 = tsDao.makeTimeSeries(tsIn.getTimeSeriesIdentifier());
                 assertThrows(BadTimeSeriesException.class, () -> tsDao.fillTimeSeries(result2,
-                                     tsIn.sampleAt(0).getTime(), 
-                                     tsIn.sampleAt(tsIn.size()-1).getTime(),
-                                      true, true, false));
+                         tsIn.sampleAt(0).getTime(),
+                         tsIn.sampleAt(tsIn.size()-1).getTime(),
+                          true, true, false));
             }
         }
     }

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/TimeSeriesDaoIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/TimeSeriesDaoIT.java
@@ -1,15 +1,13 @@
 package org.opendcs.dao;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.opendcs.fixtures.assertions.TimeSeries.assertEquals;
-import static org.opendcs.fixtures.helpers.TestResources.getResource;
 
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.TimeZone;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.opendcs.fixtures.AppTestBase;
@@ -32,26 +30,26 @@ import opendcs.dai.TimeSeriesDAI;
 
 @DecodesConfigurationRequired({
     "shared/test-sites.xml"})
-public class TimeSeriesDaoIT extends AppTestBase
+class TimeSeriesDaoIT extends AppTestBase
 {
-    private Logger log = LoggerFactory.getLogger(TimeSeriesDaoIT.class);
+    private final Logger log = LoggerFactory.getLogger(TimeSeriesDaoIT.class);
 
     @ConfiguredField
     private TimeSeriesDb tsDb;
 
     /**
      * This just tests that timeseries can be saved to the database, retrieved, and totally deleted.
-     * @param inputFile
-     * @throws Exception
+     * @param inputFile The input file containing the timeseries data to import.
+     * @throws Exception If there is an error importing the timeseries data.
      */
     @ParameterizedTest
     @CsvSource({
         "timeseries/${impl}/regular_ts.tsimport"
     })
     @EnableIfTsDb
-    public void test_timeseries_operations(String inputFile) throws Exception
+    void test_timeseries_operations(String inputFile) throws Exception
     {
-        TsImporter importer = new TsImporter(TimeZone.getTimeZone("UTC"), null, (tsIdStr) -> 
+        TsImporter importer = new TsImporter(TimeZone.getTimeZone("UTC"), null, tsIdStr ->
         {
             try
             {
@@ -84,13 +82,12 @@ public class TimeSeriesDaoIT extends AppTestBase
                                       true, true, false);
                 log.info("Data loaded.");
                 assertEquals(tsIn, result, "Timeseries round trip did not work.");
-                tsDao.deleteTimeSeries(tsIn.getTimeSeriesIdentifier());
+                tsDao.deleteTimeSeries(tsIn.getTimeSeriesIdentifier()); // This will also delete the timeseries identifier.
                 final CTimeSeries result2 = tsDao.makeTimeSeries(tsIn.getTimeSeriesIdentifier());
-                tsDao.fillTimeSeries(result2,
+                assertThrows(BadTimeSeriesException.class, () -> tsDao.fillTimeSeries(result2,
                                      tsIn.sampleAt(0).getTime(), 
                                      tsIn.sampleAt(tsIn.size()-1).getTime(),
-                                      true, true, false);
-                assertTrue(result2.size() == 0, "Time series elements were left in the database.");
+                                      true, true, false));
             }
         }
     }

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
@@ -372,6 +372,11 @@ public class CwmsTimeSeriesDAO
             }
         }
 
+        if (tsid == null)
+        {
+            throw new BadTimeSeriesException("Could not retrieve timeseries meta data. TimeSeriesIdentifier is not present.");
+        }
+
         // Part of the contract is to honor the units already specified
         // in the CTimeSeries.
         UnitConverter unitConverter = db.makeUnitConverterForRead(cts);
@@ -1058,8 +1063,15 @@ public class CwmsTimeSeriesDAO
         DbKey sdi = tsid.getKey();
         CTimeSeries ret = new CTimeSeries(sdi, tsid.getInterval(),
             tsid.getTableSelector());
-        ret.setTimeSeriesIdentifier(tsid);
-        ret.setDisplayName(tsid.getDisplayName());
+        try
+        {
+            fillTimeSeriesMetadata(ret);
+            ret.setDisplayName(tsid.getDisplayName());
+        }
+        catch(BadTimeSeriesException ex)
+        {
+            throw new NoSuchObjectException(ex.getMessage());
+        }
         return ret;
     }
 

--- a/java/opendcs/src/main/java/opendcs/dao/TsGroupDAO.java
+++ b/java/opendcs/src/main/java/opendcs/dao/TsGroupDAO.java
@@ -460,6 +460,8 @@ public class TsGroupDAO
 
 		q = "DELETE from tsdb_group WHERE group_id = " + groupId;
 		doModify(q);
+
+		cache.remove(groupId);
 	}
 
 	@Override

--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
@@ -1023,6 +1023,8 @@ public class OpenTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 				{
 					throw new Exception("Unable to create comp depends notification.", ex);
 				}
+
+				cache.remove(ctsid.getKey());
 			});
 		}
 		catch (Exception ex)


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Deletion of timeseries and timeseries group objects only removes them from the database, not the cache. This results in deleted objects being returned upon retrieval.

## Solution

Adds removal from cache to both timeseries and timeseries group deletion methods.

## how you tested the change

Integration tested in REST API against OpenTSDB and CWMS database instances.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
