### PR TITLE
7.0 fix artifact signing

### DIFF
--- a/install/build.gradle
+++ b/install/build.gradle
@@ -30,7 +30,6 @@ distributions
             into('bin')
             {
                 from ('src/main/dist/scripts')
-                
                 filePermissions
                 {
                     user

--- a/install/build.gradle
+++ b/install/build.gradle
@@ -108,9 +108,8 @@ if (shouldSign) {
     }
 }
 
-publish {
-    enabled = false
-}
+// We don't publish the installer to maven central.
+project.tasks.findAll { task -> task.name.startsWith("publish")}.each { task -> task.enabled = false }
 
 def javaVersion = Double.parseDouble(project.findProperty("org.gradle.java.version") ?: "1.8" )
 

--- a/install/build.gradle
+++ b/install/build.gradle
@@ -102,6 +102,14 @@ if (shouldSign) {
         dependsOn signDistTar
         dependsOn signDistZip
     }
+
+    sigstoreSignMavenPublication {
+        enabled = false
+    }
+}
+
+publish {
+    enabled = false
 }
 
 def javaVersion = Double.parseDouble(project.findProperty("org.gradle.java.version") ?: "1.8" )


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
The 7.0 nightly and tagged builds aren't getting signed due to a strange error. =

## Solution

Disable signing of a pom that isn't required (direct cause of the error) and remove the installer artifacts, or any information about them, from being included in the publish task push to maven central.

## how you tested the change

Locally, with signing and the `publishToMavenLocal` to verify the install publish tasks were correctly disabled.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
