### PR TITLE
Use entire platform name, not first value split on spaces.

### DIFF
--- a/java/opendcs/src/main/java/lrgs/common/SearchCriteria.java
+++ b/java/opendcs/src/main/java/lrgs/common/SearchCriteria.java
@@ -655,7 +655,7 @@ public class SearchCriteria implements Serializable
                         throw new SearchSyntaxException("Expected DCP name.",
                             LrgsErrorCode.DBADDCPNAME);
                     }
-                    addDcpName(st.nextToken());
+                    addDcpName(ln.substring(kw.length()).trim());
                 }
                 else if (kw.equalsIgnoreCase("DCP_ADDRESS:")
                       || kw.equalsIgnoreCase("DCPADDRESS:"))

--- a/java/opendcs/src/test/java/lrgs/common/SearchCriteriaTest.java
+++ b/java/opendcs/src/test/java/lrgs/common/SearchCriteriaTest.java
@@ -25,6 +25,7 @@ public class SearchCriteriaTest
         sc.DcpNames = new ArrayList<>();
         sc.DcpNames.add("TEST1");
         sc.DcpNames.add("TEST2");
+        sc.DcpNames.add("Test with spaces");
         sc.spacecraft = SearchCriteria.SC_EAST;
     }
 


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #920. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Retrieve entire value, not first value split on spaces.

## how you tested the change

Existing test was modified to include condition causing the error.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [x] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
