### PR TITLE
 reduce the number of changes in individual dependabot pull request.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,26 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      alldependencies:
+      dependencies-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      dependencies-minor:
         patterns:
           - "*"
         update-types:
           - "minor"
+      dependencies-patch:
+        patterns:
+          - "*"
+        update-types:
           - "patch"
+      dependencies-security:
+        patterns:
+          - "*"
+        update-types:
+          - "security"
     reviewers:
       - "@opendcs/opendcs-core-devs"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Problem Description

dependabot is lumping too many changes together, and the resulting PR's are failing as a result.


## Solution

configure dependabot to make major, minor, patch, and security changes separately. 