### PR TITLE
short circuit copyFrom tasks if input and this are same reference

### DIFF
--- a/java/opendcs/src/main/java/decodes/db/EquipmentModel.java
+++ b/java/opendcs/src/main/java/decodes/db/EquipmentModel.java
@@ -96,6 +96,12 @@ public class EquipmentModel extends IdDatabaseObject
 	 */
 	public void copyFrom(EquipmentModel rhs)
 	{
+		//This and input parameter could be the same reference if accessed via cache
+		if (rhs == this)
+		{
+			return;
+		}
+
 		this.name = rhs.name;
 		this.equipmentType = rhs.equipmentType;
 		this.company = rhs.company;

--- a/java/opendcs/src/main/java/decodes/db/Platform.java
+++ b/java/opendcs/src/main/java/decodes/db/Platform.java
@@ -583,6 +583,11 @@ public class Platform
 	 */
 	public void copyFrom(Platform rhs)
 	{
+		//This and input parameter could be the same reference if accessed via cache
+		if (rhs == this)
+		{
+			return;
+		}
 		this.description = rhs.description;
 		this.agency = rhs.agency;
 		this.isProduction = rhs.isProduction;

--- a/java/opendcs/src/main/java/decodes/db/PlatformConfig.java
+++ b/java/opendcs/src/main/java/decodes/db/PlatformConfig.java
@@ -388,6 +388,11 @@ public class PlatformConfig extends IdDatabaseObject
 	 */
 	public void copyFrom(PlatformConfig rhs)
 	{
+		//This and input parameter could be the same reference if accessed via cache
+		if (rhs == this)
+		{
+			return;
+		}
 		this.configName = rhs.configName;
 		this.description = rhs.description;
 		this.numPlatformsUsing = rhs.numPlatformsUsing;
@@ -395,16 +400,14 @@ public class PlatformConfig extends IdDatabaseObject
 		this.equipmentModel = rhs.equipmentModel;
 
 		this.configSensors.clear();
-		for(Iterator<ConfigSensor> it = rhs.configSensors.iterator(); it.hasNext(); )
+		for(ConfigSensor cs : rhs.configSensors)
 		{
-			ConfigSensor cs = it.next();
 			this.configSensors.add(cs.copy(this));
 		}
 
 		this.decodesScripts.clear();
-		for(Iterator<DecodesScript> it = rhs.decodesScripts.iterator(); it.hasNext(); )
+		for(DecodesScript ds : rhs.decodesScripts)
 		{
-			DecodesScript ds = it.next();
 			this.addScript(ds.copy(this));
 		}
 	}

--- a/java/opendcs/src/main/java/decodes/db/ScheduleEntry.java
+++ b/java/opendcs/src/main/java/decodes/db/ScheduleEntry.java
@@ -235,6 +235,11 @@ public class ScheduleEntry extends IdDatabaseObject
 	 */
 	public void copyFrom(ScheduleEntry rhs)
 	{
+		//This and input parameter could be the same reference if accessed via cache
+		if (rhs == this)
+		{
+			return;
+		}
 		this.name = rhs.name;
 		this.loadingAppId = rhs.loadingAppId;
 		this.routingSpecId = rhs.routingSpecId;

--- a/java/opendcs/src/main/java/decodes/db/Site.java
+++ b/java/opendcs/src/main/java/decodes/db/Site.java
@@ -139,6 +139,11 @@ public class Site extends IdDatabaseObject
 	 */
 	public synchronized void copyFrom(Site rhs)
 	{
+		//This and input parameter could be the same reference if accessed via cache
+		if (rhs == this)
+		{
+			return;
+		}
 		latitude = rhs.latitude;
 		longitude = rhs.longitude;
 		nearestCity = rhs.nearestCity;

--- a/java/opendcs/src/main/java/decodes/sql/ConfigListIO.java
+++ b/java/opendcs/src/main/java/decodes/sql/ConfigListIO.java
@@ -372,7 +372,8 @@ public class ConfigListIO extends SqlDbObjIo
                             String.format("No PlatformConfig found with ID %d", pc.getId().getValue()), thr);
                 }
 
-                putConfig(pc.getId(), rs);
+                PlatformConfig config = putConfig(pc.getId(), rs);
+                pc.copyFrom(config);
             }
         }
     }

--- a/java/opendcs/src/main/java/decodes/tsdb/alarm/AlarmLimitSet.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/alarm/AlarmLimitSet.java
@@ -433,6 +433,11 @@ public class AlarmLimitSet
 	 */
 	public void copyFrom(AlarmLimitSet als)
 	{
+		//This and input parameter could be the same reference if accessed via cache
+		if (als == this)
+		{
+			return;
+		}
 		this.limitSetId = als.limitSetId;
 		this.seasonName = als.seasonName;
 		this.rejectHigh = als.rejectHigh;

--- a/java/opendcs/src/main/java/decodes/tsdb/alarm/AlarmScreening.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/alarm/AlarmScreening.java
@@ -219,6 +219,11 @@ public class AlarmScreening
 	 */
 	public void copyFrom(AlarmScreening scrn)
 	{
+		//This and input parameter could be the same reference if accessed via cache
+		if (scrn == this)
+		{
+			return;
+		}
 		this.screeningName = scrn.screeningName;
 		this.siteId = scrn.siteId;
 		this.datatypeId = scrn.datatypeId;

--- a/java/opendcs/src/main/java/lrgs/common/DcpMsgIndex.java
+++ b/java/opendcs/src/main/java/lrgs/common/DcpMsgIndex.java
@@ -212,6 +212,11 @@ public class DcpMsgIndex implements Comparable
 	 */
 	public void copyFrom(DcpMsgIndex rhs)
 	{
+		//This and input parameter could be the same reference if accessed via cache
+		if (rhs == this)
+		{
+			return;
+		}
 		if (rhs.getLocalRecvTime() != null)
 			setLocalRecvTime(rhs.getLocalRecvTime());
 		setXmitTime(rhs.getXmitTime());


### PR DESCRIPTION
## Problem Description

PlatformConfig was clearing the DecodesScript and ConfigSensors list when using the same reference. There are other classes that have similar copyFrom functionality that also may cause unintentional issues.

When operating on cached data, clearing state can inadvertently cause data to get cleared too early. Also, there is no need to perform redundant clone operations.

## Solution

Short circuit copyFrom if the same reference for all found methods.

## how you tested the change

Existing unit/integration tests should prove this change doesn't break anything.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

