### PR TITLE
Add settings to allow 7.5 to be built.

### DIFF
--- a/.github/workflows/nightly-schedule.yml
+++ b/.github/workflows/nightly-schedule.yml
@@ -34,3 +34,18 @@ jobs:
     with:
       branch: "7.0"
       nightly: true
+  v7_5:
+    permissions:
+      packages: write
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release.yaml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      signingKey: ${{ secrets.SIGNING_KEY }}
+      signingKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+      ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
+      ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+    with:
+      branch: "7.5"
+      nightly: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ on:
         options:
           - "main"
           - "7.0"
+          - "7.5"
       nightly:
         type: boolean
         required: true

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -3,8 +3,8 @@ name: Tagged Release
 on:
   push:
     tags:
-      - '7.0.[0-9]+'
-      - '7.0.[0-9]+-RC[0-9]+'
+      - '7.[05].[0-9]+'
+      - '7.[05].[0-9]+-RC[0-9]+'
       - '8.0.0-M[0-9]+'
   release:
     types: [published,prerelease]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ The following versions are supported.
 
 | Version  | Supported          |
 | -------  | ------------------ |
+| 7.5.x    | :white_check_mark: - not production ready |
 | 7.0.x    | :white_check_mark: |
 | > 6.8.14 | :white_check_mark: |
 


### PR DESCRIPTION
Allow creation of 7.5 artifacts. Primarily for rest_api usage, will also continuously consume the DAO changes as implemented.