### PR TITLE
fix bug where empty line in logfilter causes all loggers to skip

### DIFF
--- a/java/opendcs/src/test/java/org/opendcs/utils/logging/LogFilterTest.java
+++ b/java/opendcs/src/test/java/org/opendcs/utils/logging/LogFilterTest.java
@@ -1,0 +1,34 @@
+package org.opendcs.utils.logging;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class LogFilterTest
+{
+	@Test
+	void testCanLog() throws IOException
+	{
+		Path logFilterFile = Files.createTempFile("OpenDCS", "UnitTest-testCanLog");
+		Files.write(logFilterFile, LogFilterTest.class.getName().getBytes());
+		LogFilter logFilter = new LogFilter(logFilterFile.toString());
+		assertTrue(logFilter.canLog("HelloWorld"));
+		assertFalse(logFilter.canLog(LogFilterTest.class.getName()));
+	}
+
+	@Test
+	void testCanLogEmptyString() throws IOException
+	{
+		Path logFilterFile = Files.createTempFile("OpenDCS", "UnitTest-testCanLogEmptyString");
+		String filterWithBlankLine = LogFilterTest.class.getName() + System.lineSeparator() + System.lineSeparator();
+		Files.write(logFilterFile, filterWithBlankLine.getBytes());
+		LogFilter logFilter = new LogFilter(logFilterFile.toString());
+		assertTrue(logFilter.canLog("HelloWorld"));
+		assertFalse(logFilter.canLog(LogFilterTest.class.getName()));
+	}
+}


### PR DESCRIPTION
## Problem Description

The LogFilter class does not filter out empty lines in the logfilter.txt file. If there is an empty line, then all loggers will be skipped.

## Solution

Filter out empty lines.

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [X] Tests. Check all that apply:
   - [X] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

