### PR TITLE
Correct build artifact setup.

### DIFF
--- a/install/build.gradle
+++ b/install/build.gradle
@@ -102,7 +102,14 @@ if (shouldSign) {
         dependsOn signDistTar
         dependsOn signDistZip
     }
+
+    sigstoreSignMavenPublication {
+        enabled = false
+    }
 }
+
+// We don't publish the installer to maven central.
+project.tasks.findAll { task -> task.name.startsWith("publish")}.each { task -> task.enabled = false }
 
 def javaVersion = Double.parseDouble(project.findProperty("org.gradle.java.version") ?: "1.8" )
 

--- a/integrationtesting/fixtures/build.gradle
+++ b/integrationtesting/fixtures/build.gradle
@@ -20,9 +20,14 @@ dependencies {
 
 publishing {
     publications {
-        mavenJava(MavenPublication) {
+        maven(MavenPublication) {
             artifactId = 'opendcs-integrationtesting-fixtures'
             from components.java
+        
+        pom {
+                name = 'OpenDCS Test Fixtures'
+                description = 'Database Framework, assertions, and other utilities required to implement integration tests against OpenDCS implementations.'
+            }
         }
     }
 }

--- a/java/annotations/build.gradle
+++ b/java/annotations/build.gradle
@@ -15,6 +15,11 @@ publishing {
         maven(MavenPublication) {
             artifactId = 'opendcs-annotations'
             from components.java
+
+            pom {
+                name = 'OpenDCS Annotations'
+                description = 'Contains Annotations and Annotation Processors for OpenDCS configuration elements.'
+            }
         }
     }
 }

--- a/java/opendcs-api/build.gradle
+++ b/java/opendcs-api/build.gradle
@@ -13,6 +13,11 @@ publishing {
         maven(MavenPublication) {
             artifactId = 'opendcs-api'
             from components.java
+
+            pom {
+                name = 'OpenDCS API'
+                description = 'Core interfaces for Database interaction used by OpenDCS Components'
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- if you are referencing a specific issue a problem description is not required -->
Validation on Maven Central requires the resulting pom.xml having a project name and description.
As these are per artifact they must be set on the individual subprojects instead of the template.

Additionally, due to the setup of the installer gradle attempts to make a maven bundle to get pushed to maven central which we don't want or need.

## Solution

* Correct publication type. (cherry picked from commit 70d5c3fa341c9c77709601e2e44c4cd75ed2aadf)
* Add publication information. (cherry picked from commit 62d840eb476fffb1bbd14b773f7f91ffaf351848)
* Prevent install bundle maven publications. (cherry picked from commit 

## how you tested the change

Changes were used on the 7.5 release branch.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
