### PR TITLE
Allow DbEdit to Open with the XML database.

### DIFF
--- a/java/opendcs/src/main/java/decodes/dbeditor/DecodesDbEditor.java
+++ b/java/opendcs/src/main/java/decodes/dbeditor/DecodesDbEditor.java
@@ -122,8 +122,9 @@ public class DecodesDbEditor
         settings.loadFromProfile(cmdLineArgs.getProfile());
         DecodesInterface.setGUI(true);
         OpenDcsDatabase databases = DatabaseService.getDatabaseFor(null, settings);
+        // not great, but saves us the hassle of having to update *every* GUI class and DAO right now.
         Database db = databases.getLegacyDatabase(Database.class).get();
-
+        Database.setDb(db);
         Platform.configSoftLink = true;
         db.initializeForEditing();
 

--- a/java/opendcs/src/main/java/decodes/xml/jdbc/XmlDatabaseProvider.java
+++ b/java/opendcs/src/main/java/decodes/xml/jdbc/XmlDatabaseProvider.java
@@ -29,8 +29,13 @@ public class XmlDatabaseProvider implements DatabaseProvider
     public OpenDcsDatabase createDatabase(String appName, DecodesSettings settings, Properties credentials)
             throws DatabaseException 
     {
-        javax.sql.DataSource dataSource = new SimpleDataSource(settings.editDatabaseLocation, credentials);
-        return createDatabase(dataSource, settings);
+        DecodesSettings settingsCopy = settings.asCopy();
+        if (!settings.editDatabaseLocation.startsWith("jdbc:"))
+        {
+            settingsCopy.editDatabaseLocation = "jdbc:xml:" + settings.editDatabaseLocation;
+        }
+        javax.sql.DataSource dataSource = new SimpleDataSource(settingsCopy.editDatabaseLocation, credentials);
+        return createDatabase(dataSource, settingsCopy);
     }
 
     @Override


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #980. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

- Call Database.setDb with the instance retrieved from the OpenDcsDatabase instance.
- In XmlDatabaseProvider, if the location does not start with "jdbc:" add the appropriate "jdbc:xml:" string on the users behalf.

## how you tested the change

Ran dbedit, created site and then a platform.

NOTE: on reloading of dbedit, the site was listed twice. There appears to be an equality issue between the site and platform. Platform site should really be a reference; whether a XML entity reference or just a marker we can use is debatable, but that duplication is problematic.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
