### PR TITLE
Current application launching. Fix logic error in EnumSqlDao.

### DIFF
--- a/java/opendcs/src/main/java/decodes/launcher/LauncherFrame.java
+++ b/java/opendcs/src/main/java/decodes/launcher/LauncherFrame.java
@@ -1193,11 +1193,24 @@ Logger.instance().info("LauncherFrame ctor - getting dacq launcher actions...");
         try
         {
             // Load the DCS Tool Configuration
-            DecodesSettings settings = DecodesSettings.fromProfile(launchProfile);
+            final DecodesSettings settings = DecodesSettings.fromProfile(launchProfile);
             databases = DatabaseService.getDatabaseFor(null, settings);
+            databases.getLegacyDatabase(Database.class).ifPresent(db ->
+            {
+                try
+                {
+                    db.initMinimal(settings);
+                    Database.setDb(db);
+                }
+                catch (DecodesException ex)
+                {
+                    throw new RuntimeException(ex);
+                }
+            });
+
 
         }
-        catch (Exception ex)
+        catch (Throwable ex)
         {
             throw new DecodesException("Unable to initialize decodes.", ex);
         }

--- a/java/opendcs/src/main/java/decodes/launcher/LauncherFrame.java
+++ b/java/opendcs/src/main/java/decodes/launcher/LauncherFrame.java
@@ -1207,10 +1207,8 @@ Logger.instance().info("LauncherFrame ctor - getting dacq launcher actions...");
                     throw new RuntimeException(ex);
                 }
             });
-
-
         }
-        catch (Throwable ex)
+        catch (RuntimeException | IOException ex)
         {
             throw new DecodesException("Unable to initialize decodes.", ex);
         }

--- a/java/opendcs/src/main/java/decodes/tsdb/TsdbAppTemplate.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/TsdbAppTemplate.java
@@ -276,6 +276,7 @@ public abstract class TsdbAppTemplate
 			db = DatabaseService.getDatabaseFor(appName, settings);
 			decodesDb = db.getLegacyDatabase(Database.class).get();
 			decodesDb.initializeForDecoding();
+			Database.setDb(decodesDb);
 			theDb = db.getLegacyDatabase(TimeSeriesDb.class).get();
 		}
 		catch (DecodesException ex)

--- a/java/opendcs/src/main/java/opendcs/dao/EnumSqlDao.java
+++ b/java/opendcs/src/main/java/opendcs/dao/EnumSqlDao.java
@@ -257,8 +257,10 @@ public class EnumSqlDao extends DaoBase implements EnumDAI
 					DbKey key = DbKey.createDbKey(rs, 1);
 					DbEnum dbEnum = cache.getByKey(key);
 					if (dbEnum != null)
+					{
 						rs2EnumValue(rs, dbEnum);
-					top.addEnum(dbEnum);
+						top.addEnum(dbEnum);
+					}
 				});				
 			}
 		}

--- a/java/opendcs/src/main/java/opendcs/dao/EnumSqlDao.java
+++ b/java/opendcs/src/main/java/opendcs/dao/EnumSqlDao.java
@@ -261,6 +261,10 @@ public class EnumSqlDao extends DaoBase implements EnumDAI
 						rs2EnumValue(rs, dbEnum);
 						top.addEnum(dbEnum);
 					}
+					else
+					{
+						log.warn("Enum not in cache for key {}. Orphaned enum value {}", key, rs.getString("enumValue"));
+					}
 				});				
 			}
 		}


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Due to the various database changes, and a logic bug in enums, several applications would not start correctly.

## Solution

Ensure global database set after calls to getDatabaseFor.
Correct logic bug in EnumSQLDao

## how you tested the change

Run compedit directly, opened several applications through the launcher.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
