### PR TITLE
Connection TimeZone bug fix

### DIFF
--- a/java/opendcs/src/main/java/decodes/cwms/CwmsConnectionPool.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsConnectionPool.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -278,6 +279,8 @@ public final class CwmsConnectionPool implements ConnectionPoolMXBean, javax.sql
             try
             {
                 conn = pool.getConnection();
+                oracle.jdbc.OracleConnection orc_conn = conn.unwrap(oracle.jdbc.OracleConnection.class);
+                orc_conn.setDefaultTimeZone(TimeZone.getTimeZone("UTC"));
                 conn.setAutoCommit(true);
                 setCtxDbOfficeId(conn, info);
                 final WrappedConnection wc = new WrappedConnection(conn,(c)->{

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsConnectionPool.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsConnectionPool.java
@@ -279,8 +279,7 @@ public final class CwmsConnectionPool implements ConnectionPoolMXBean, javax.sql
             try
             {
                 conn = pool.getConnection();
-                oracle.jdbc.OracleConnection orc_conn = conn.unwrap(oracle.jdbc.OracleConnection.class);
-                orc_conn.setDefaultTimeZone(TimeZone.getTimeZone("UTC"));
+                conn.unwrap(oracle.jdbc.OracleConnection.class).setDefaultTimeZone(TimeZone.getTimeZone("UTC"));
                 conn.setAutoCommit(true);
                 setCtxDbOfficeId(conn, info);
                 final WrappedConnection wc = new WrappedConnection(conn,(c)->{

--- a/java/opendcs/src/main/java/decodes/cwms/algo/ResEvapAlgo.java
+++ b/java/opendcs/src/main/java/decodes/cwms/algo/ResEvapAlgo.java
@@ -192,10 +192,10 @@ final public class ResEvapAlgo
     //Initialized hourly water temperature profiles and return double[] of WTP of the previous timeSlice before base.
     private double[] getProfiles(String WTPID) throws DbCompException
     {
-        Date untilTime = new Date(baseTimes.first().getTime() + 86400000);
+        Date sinceTime = new Date(baseTimes.first().getTime() - 86400000);
         try
         {
-            hourlyWTP = new WaterTempProfiles(timeSeriesDAO, reservoirId, WTPID, baseTimes.first(), untilTime, startDepth, depthIncrement);
+            hourlyWTP = new WaterTempProfiles(timeSeriesDAO, reservoirId, WTPID, sinceTime, baseTimes.first(), startDepth, depthIncrement);
         }
         catch (DbIoException ex)
         {
@@ -206,7 +206,7 @@ final public class ResEvapAlgo
         {
             try
             {
-                arrayWTP[i] = hourlyWTP.getTimeSeries().getTimeSeriesAt(i).findPrev(untilTime).getDoubleValue();
+                arrayWTP[i] = hourlyWTP.getTimeSeries().getTimeSeriesAt(i).findPrev(baseTimes.first()).getDoubleValue();
             }
             catch (RuntimeException | NoConversionException ex)
             {
@@ -381,10 +381,11 @@ final public class ResEvapAlgo
             hourlyWTP = new WaterTempProfiles(startDepth, depthIncrement);
             dailyWTP = new WaterTempProfiles(startDepth, depthIncrement);
 
-            //initialized input timeseries
+            //initialize output timeseries
             hourlyEvapTS = getParmRef("hourlyEvap").timeSeries;
             dailyEvapTS = getParmRef("dailyEvap").timeSeries;
 
+            //initialized input timeseries
             windSpeedTS = getParmRef("windSpeed").timeSeries;
             airTempTS = getParmRef("airTemp").timeSeries;
             relativeHumidityTS = getParmRef("relativeHumidity").timeSeries;
@@ -444,10 +445,10 @@ final public class ResEvapAlgo
             double initElev;
             try
             {
-                initElev = elevTS.findPrev(baseTimes.first()).getDoubleValue();
+                initElev = tsdb.getPreviousValue(elevTS, baseTimes.first()).getDoubleValue();
                 reservoir.setElevation(initElev, conn);
             }
-            catch (RuntimeException | NoConversionException ex)
+            catch (RuntimeException | NoConversionException | DbIoException | BadTimeSeriesException ex)
             {
                 throw new DbCompException("Failed to load initial elevation before time window of compute", ex);
             }
@@ -495,11 +496,7 @@ final public class ResEvapAlgo
             {
                 CTimeSeries cts = timeSeriesDAO.makeTimeSeries(hourlyEvapTS.getTimeSeriesIdentifier());
                 cts.setUnitsAbbr("mm/hr");
-                Date until = new Date(baseTimes.first().getTime() + 86400000);
-                Date from = new Date(baseTimes.first().getTime() - 86400000);
-                int k = timeSeriesDAO.fillTimeSeries(cts, from, until, true, true, true);
-                Date test = baseTimes.first();
-                TimedVariable PrevTV = cts.findPrev(test);
+                TimedVariable PrevTV = tsdb.getPreviousValue(cts, baseTimes.first());
                 previousHourlyEvap = PrevTV.getDoubleValue();
             }
             catch (Exception ex)


### PR DESCRIPTION
change the default time zone of the conn to be UTC, and fix related bugs in ResEvap.

## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

The default connection timezone to the Oracle data base is set to the timezone of the local machine. This causes querys which include datetimes to print and return values assosiated with the incorrect time zone.

## Solution

Describe your solution.

By unwrapping the connection within the getconnection function call we can set it to have a new and correct defult time zone of UTC

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

I was able to test the fix the viewing the results of the ResEvap Algorithm, and varifying the calls to the database from that algorithm returned the appropriate values.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
