### PR TITLE
Fix replaceValueWith function

### DIFF
--- a/java/opendcs/src/main/java/decodes/dbeditor/DecodingScriptEditDialog.java
+++ b/java/opendcs/src/main/java/decodes/dbeditor/DecodingScriptEditDialog.java
@@ -1,47 +1,18 @@
-/*
-*	$Id$
-*/
 package decodes.dbeditor;
 
 import java.awt.*;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.Properties;
-import java.util.Date;
 import javax.swing.*;
-import javax.swing.border.*;
 import java.awt.event.*;
-import javax.swing.table.*;
 import java.util.ResourceBundle;
 
-import ilex.util.LoadResourceBundle;
-import ilex.util.Logger;
 import ilex.util.TextUtil;
 
-import decodes.util.DecodesSettings;
 import decodes.util.DecodesException;
 
 import decodes.gui.TopFrame;
 import decodes.gui.GuiDialog;
-import decodes.gui.TableColumnAdjuster;
-import decodes.gui.EnumCellEditor;
-import decodes.db.Database;
 import decodes.db.DecodesScript;
-import decodes.db.FormatStatement;
-import decodes.db.ScriptSensor;
-import decodes.db.UnitConverterDb;
-import decodes.db.Constants;
 import decodes.db.PlatformConfig;
-import decodes.db.PresentationGroup;
-import decodes.db.Platform;
-import decodes.db.TransportMedium;
-
-import decodes.datasource.RawMessage;
-import decodes.datasource.GoesPMParser;
-import decodes.decoder.DecodedMessage;
-import decodes.consumer.StringBufferConsumer;
-import decodes.consumer.OutputFormatter;
 
 /**
 Dialog for editing a decoding script within the database editor.
@@ -100,8 +71,6 @@ public class DecodingScriptEditDialog
 				boolean started=false;
 				public void windowActivated(WindowEvent e)
 				{
-//					if (!started)
-//						scriptNameField.requestFocus();
 					started = true;
 				}
 			});

--- a/java/opendcs/src/main/java/decodes/decoder/ReplaceValueWithFunction.java
+++ b/java/opendcs/src/main/java/decodes/decoder/ReplaceValueWithFunction.java
@@ -13,6 +13,10 @@ import decodes.db.DecodesScript;
 public class ReplaceValueWithFunction extends DecodesFunction
 {
 	public static final String module = "replaceValueWith";
+	private String find;
+	private String replace;
+	private DecodesScript script;
+
 	
 	public ReplaceValueWithFunction()
 	{
@@ -33,7 +37,7 @@ public class ReplaceValueWithFunction extends DecodesFunction
 	@Override
 	public void execute(DataOperations dd, DecodedMessage msg) throws DecoderException
 	{
-		// Execute doesn't do anything. Work is done in setArguments
+		script.addReplace(find,replace);
 	}
 
 	/**
@@ -42,20 +46,19 @@ public class ReplaceValueWithFunction extends DecodesFunction
 	@Override
 	public void setArguments(String argString, DecodesScript script) throws ScriptFormatException
 	{
-		Logger.instance().info(argString);
-		StringTokenizer st = new StringTokenizer(argString, ",");
-		while(st.hasMoreTokens())
+		Logger.instance().debug1(argString);
+		String[] args = argString.split(",");
+		if( args.length == 2)
 		{
-			String find = st.nextToken();
-			find = find.trim();
-			if( st.hasMoreTokens())
-			{
-		        String replace = st.nextToken();
-			    replace = replace.trim();
-				script.addReplace(find,replace);
-			}
-
+			find = args[0].trim();
+			replace = args[1].trim();
+			this.script = script;
 		}
+		else
+		{
+			throw new ScriptFormatException(module + " requires two arguments");
+		}
+ 
 	}
 
 }

--- a/java/opendcs/src/main/java/decodes/decoder/ReplaceValueWithFunction.java
+++ b/java/opendcs/src/main/java/decodes/decoder/ReplaceValueWithFunction.java
@@ -2,8 +2,6 @@ package decodes.decoder;
 
 import ilex.util.Logger;
 
-import java.util.StringTokenizer;
-
 import decodes.db.DecodesScript;
 
 /**


### PR DESCRIPTION
fixes #670 -- replaceValueWith can now be called multiple times with different arguments.
@jbatterman  reported that multiple calls to  replaceValueWith resulted in only arguments from last entry being used.

Solution was to move replace functionality into the execute() method.  Thanks @MikeNeilson for walking me through this fix.