### PR TITLE
fix url to ghcr in docs

### DIFF
--- a/docs/source/start-lrgs.rst
+++ b/docs/source/start-lrgs.rst
@@ -176,9 +176,9 @@ Installation - docker
     
     docker volume create lrgs_home
     # A default password will be generated and in the logs
-    docker run -d --name lrgs -p 16003:16003 -v lrgs_home:/lrgs_home ghcr.io/opendcs/opendcs/lrgs:main-nightly
+    docker run -d --name lrgs -p 16003:16003 -v lrgs_home:/lrgs_home ghcr.io/opendcs/lrgs:main-nightly
     # or if you wish to manually set the password
-    docker run -d --name lrgs -p 16003:16003 -v lrgs_home:/lrgs_home -e LRGS_ADMIN_PASSWORD="<password>" ghcr.io/opendcs/opendcs/lrgs:main-nightly
+    docker run -d --name lrgs -p 16003:16003 -v lrgs_home:/lrgs_home -e LRGS_ADMIN_PASSWORD="<password>" ghcr.io/opendcs/lrgs:main-nightly
 
 Connecting
 ##########


### PR DESCRIPTION
I tried out the following command (after fixing url).

using WSL , and docker desktop.

```bash
 docker run -d --name lrgs -p 16003:16003 -v lrgs_home:/lrgs_home -e LRGS_ADMIN_PASSWORD=test ghcr.io/opendcs/lrgs:main-nightly
```


I'm getting this in the log:

```bash
Generating initial LRGS HOME Directory.
cp: cannot stat '/opt/opendcs/users': No such file or directory
cp: cannot stat '/opt/opendcs/*.conf': No such file or directory
cp: cannot stat '/opt/opendcs/*.xml': No such file or directory
cp: cannot stat '/opt/opendcs/lrgs.conf': No such file or directory
cp: cannot stat '/opt/opendcs/netlist': No such file or directory
Creating Local User Directory and initial properties in /home/opendcs/.opendcs
The default XML database has been copied to this directory.
> A record already exists for user 'lrgsadmin'
> Unrecognized cmd 'test' (type 'help' for list)
> Unrecognized cmd 'test' (type 'help' for list)
> Role 'dds' already assigned.
> Role 'admin' already assigned.
> Wrote /lrgs_home/.lrgs.passwd
> INFO    2025/05/28-21:40:55 ========== Process 'lrgs' Starting ==========
INFO    2025/05/28-21:40:55 ============ LRGS OPENDCS 4234034 42340349e840bc57119f9056c08ed56c37f11af6 Starting ============
INFO    2025/05/28-21:40:55 Lock File =-
WARNING 2025/05/28-21:40:55 LrgsMain:2 Loading configuration file '/lrgs_home/lrgs.conf'
FATAL  2025/05/28-21:40:55 LrgsMain:5- Cannot read config file '/lrgs_home/lrgs.conf': java.io.FileNotFoundException: /lrgs_home/lrgs.conf (No such file or directory)
LrgsMain:5- Cannot read config file '/lrgs_home/lrgs.conf': java.io.FileNotFoundException: /lrgs_home/lrgs.conf (No such file or directory)
FATAL  2025/05/28-21:40:55 ============ LRGS OPENDCS 4234034 42340349e840bc57119f9056c08ed56c37f11af6 INIT FAILED -- Exiting. ============
DBG3    2025/05/28-21:40:55 SIGTERM Caught, Setting shutdown flag to true.

```