### PR TITLE
Devops/correct sonar cloud coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
         # Integration tests require docker now for test containers.
         # More work required to deal with the other platforms. Should be workable
         # at some point though.
-        if: matrix.platform == 'ubuntu-latest' && matrix.jdk = 17
+        if: matrix.platform == 'ubuntu-latest' && matrix.jdk == 17
         run: |
           ./gradlew codeCoverageReport --info
       - name: Cache SonarCloud packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,15 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           ./gradlew :testing:opendcs-tests:test -P"opendcs.test.engine=CWMS-Oracle" --info
+      - name: Gather Code Coverage into single report
+        # There is an odd issues with the log file name on the windows runner.
+        # It does work locally though. Will work on it later.
+        # Integration tests require docker now for test containers.
+        # More work required to deal with the other platforms. Should be workable
+        # at some point though.
+        if: matrix.platform == 'ubuntu-latest' && matrix.jdk = 17
+        run: |
+          ./gradlew codeCoverageReport --info
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         if: matrix.platform == 'ubuntu-latest' && matrix.jdk == 17

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
         gradlePluginPortal()
+        mavenCentral()
     }
     dependencies {
         if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-            classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.4.1.3373"
+            classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:6.2.0.5505"
         }
     }
 }
@@ -12,12 +13,16 @@ buildscript {
 plugins {
     id "com.palantir.git-version" version "3.1.0"
     id 'eclipse'
+    id 'jacoco'
 }
 
 if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
     apply plugin: "org.sonarqube"
 }
 
+repositories {
+    mavenCentral()
+}
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
@@ -48,13 +53,42 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
             property "sonar.host.url", "https://sonarcloud.io"
             property "sonar.pullrequest.provider", "GitHub"
             property "sonar.pullrequest.github.repository", "opendcs/opendcs"
-            property "sonar.coverage.jacoco.xmlReportPaths", "./**/jacoco*.xml"
+                                                                                          
+            
             property "sonar.projectVersion", sonarVersion()
             // TODO: just remove the C files that are no longer used. However, they are still
             // called in some of the java
             property "sonar.c.file.suffixes", "-"
             property "sonar.cpp.file.suffixes", "-"
             property "sonar.objc.file.suffixes", "-"
+        }
+    }
+
+
+    tasks.register("codeCoverageReport", JacocoReport) {
+        subprojects { subproject -> 
+            subproject.plugins.withType(JacocoPlugin).configureEach {
+                subproject.tasks.matching({t -> t.extensions.findByType(JacocoTaskExtension)}).configureEach { testTask ->
+                    if(testTask.extensions.getByType(JacocoTaskExtension).isEnabled()) {
+                        sourceSets subproject.sourceSets.main
+                        executionData(testTask)
+                    }
+                }
+            }
+        }
+
+        // enable the different report types (html, xml, csv)
+        reports {
+            xml.required = true
+            html.required = true
+        }
+    }
+
+    subprojects {
+        sonar {
+            properties {
+                property "sonar.coverage.jacoco.xmlReportPaths", "$rootDir/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,24 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
             xml.required = true
             html.required = true
         }
+        def excludes = [
+                    "**/easy_install/**",
+                    "**/python_packages",
+                    "**/certifi/**",
+                    "**/chardet/**",
+                    "**/urllib3/**",
+                    "**/requests/**",
+                    "**/chardet/**",
+                    "**/urllib3/**",
+                    "**/idna/**",
+                    "**/pkg_resources/**"
+                ]
+
+//        afterEvaluate {
+            classDirectories.setFrom(files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: excludes)
+            }))
+  //      }
     }
 
     subprojects {

--- a/buildSrc/src/main/groovy/opendcs.sonar-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.sonar-conventions.gradle
@@ -1,10 +1,6 @@
 
 if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
     sonar {
-        skipProject = (name == ":testing")
-        properties {
-            property "sonar.sources", "src/main/java"
-            property "sonar.tests", "src/test/java"
-        }
+        skipProject = (name == ":testing") || (name == ":docs") || (name == ":install")
     }
 }

--- a/integrationtesting/lrgs/build.gradle
+++ b/integrationtesting/lrgs/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'opendcs.java-conventions'
     id 'opendcs.deps-conventions'
+    id 'opendcs.sonar-conventions'
 }
 
 
@@ -18,7 +19,7 @@ dependencies {
 
 jacocoTestReport {
     dependsOn test
-    //additionalSourceDirs files(project(":opendcs").sourceSets.main.java.srcDirs)
+    additionalSourceDirs files(project(":opendcs").sourceSets.main.java.srcDirs)
     //additionalClassDirs files(project(":opendcs").sourceSets.main.output)
     sourceSets project(":opendcs").sourceSets.main
     def excludes = [

--- a/integrationtesting/opendcs-tests/build.gradle
+++ b/integrationtesting/opendcs-tests/build.gradle
@@ -4,6 +4,17 @@ plugins {
     id 'opendcs.sonar-conventions'
 }
 
+def commonJacocoExcludes = [
+  "**/easy_install/**",
+  "**/python_packages",
+  "**/certifi/**",
+  "**/chardet/**",
+  "**/urllib3/**",
+  "**/requests/**",
+  "**/idna/**",
+  "**/pkg_resources/**"
+]
+
 dependencies {
     implementation project(":install")
 
@@ -71,18 +82,7 @@ testEngines.each { engine ->
             junitXml {}
         }
         jacoco {
-            excludes += [
-                    "**/easy_install/**",
-                    "**/python_packages",
-                    "**/certifi/**",
-                    "**/chardet/**",
-                    "**/urllib3/**",
-                    "**/requests/**",
-                    "**/chardet/**",
-                    "**/urllib3/**",
-                    "**/idna/**",
-                    "**/pkg_resources/**"
-                ]
+            excludes += commonJacocoExcludes
         }
     }
     test.dependsOn task
@@ -101,22 +101,11 @@ testEngines.each { engine ->
             }
 
         }
-        def excludes = [
-                    "**/easy_install/**",
-                    "**/python_packages",
-                    "**/certifi/**",
-                    "**/chardet/**",
-                    "**/urllib3/**",
-                    "**/requests/**",
-                    "**/chardet/**",
-                    "**/urllib3/**",
-                    "**/idna/**",
-                    "**/pkg_resources/**"
-                ]
+      
 
 
         classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: excludes)
+            fileTree(dir: it, exclude: commonJacocoExcludes)
         }))
 
     }

--- a/integrationtesting/opendcs-tests/build.gradle
+++ b/integrationtesting/opendcs-tests/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'opendcs.java-conventions'
     id 'opendcs.deps-conventions'
+    id 'opendcs.sonar-conventions'
 }
 
 dependencies {

--- a/integrationtesting/opendcs-tests/build.gradle
+++ b/integrationtesting/opendcs-tests/build.gradle
@@ -9,12 +9,12 @@ dependencies {
 
     testCompileOnly project(":opendcs")
 
-    //Includes all jar dependencies from the main OpenDCS build within the opendcs-tests compile 
+    //Includes all jar dependencies from the main OpenDCS build within the opendcs-tests compile
     testCompileOnly fileTree('../../install/build/install/opendcs/dep') {
         include '*.jar'
         builtBy ":install:installDist"
     }
-  
+
     testImplementation project(":testing:fixtures")
     testImplementation enforcedPlatform(libs.junit.bom)
     testImplementation(libs.bundles.junit)
@@ -25,89 +25,103 @@ dependencies {
     testImplementation(libs.webcompere.system.stubs.jupiter)
 }
 
-def impl = project.findProperty("opendcs.test.engine")
-def tmpdir = "${project.layout.buildDirectory.get()}/runs/${impl}/tmp"
+
+
+
+def testEngines = (project.findProperty("opendcs.test.engine")?: "OpenDCS-XML,OpenDCS-Postgres,OpenDCS-Oracle,CWMS-Oracle").split(",")
 
 test {
-    dependsOn ":install:installDist"
-    dependsOn ":opendcs:test"
-    //outputs.upToDateWhen {false}
-
-    enabled = gradle.startParameter.taskNames.contains(":testing:" + project.name + ":" + name)
-    doFirst {
-        project.mkdir(tmpdir)
-    }
-    def install = project(":install")
-    def stageDir = install.layout.getBuildDirectory().dir("install/${install.distributions.main.distributionBaseName.get()}").get()
-    def classPath = (project(':opendcs').jar.outputs.files
-                  + project(":opendcs").configurations.runtimeClasspath).asPath
-    inputs.property "opendcs.test.engine", project.findProperty("opendcs.test.engine")
-    
-    systemProperties += project.properties.findAll {k, v -> k.startsWith("opendcs")}
-    systemProperties += project.properties.findAll {k, v -> k.startsWith("testcontainer")}
-    
-    jvmArgs += "-Djava.io.tmpdir=${tmpdir}"
-    jvmArgs += "-Dbuild.dir=${project.layout.buildDirectory.get()}"
-    jvmArgs += "-Dopendcs.test.classpath=${classPath}"
-    jvmArgs += "-Dresource.dir=${projectDir}/src/test/resources" // TODO: make clearer
-    jvmArgs += "-DDCSTOOL_HOME=${stageDir}"
-    jvmArgs += "-Djava.util.logging.config.file=${projectDir}/src/test/test-config/logging.properties"
-
-    reports {
-        html {
-            outputLocation = reporting.baseDirectory.dir("${impl}")
-        }
-        junitXml {
-            outputLocation = reporting.baseDirectory.dir("${impl}")
-        }
-    }
-    jacoco {
-        destinationFile = layout.buildDirectory.file("jacoco/${impl}.exec").get().asFile
-        excludes += [
-                "**/easy_install/**",
-                "**/python_packages",
-                "**/certifi/**",
-                "**/chardet/**",
-                "**/urllib3/**",
-                "**/requests/**",
-                "**/chardet/**",
-                "**/urllib3/**",
-                "**/idna/**",
-                "**/pkg_resources/**"
-            ]
-    }
+    // The below registered test tasks do all the real work.
+    exclude '**/*'
 }
 
-jacocoTestReport {
-    dependsOn test
-    //additionalSourceDirs files(project(":opendcs").sourceSets.main.java.srcDirs)
-    //additionalClassDirs files(project(":opendcs").sourceSets.main.output)
-    sourceSets project(":opendcs").sourceSets.main
-    reports {
-        html {
-            outputLocation = jacoco.reportsDirectory.dir("jacoco-${impl}-html")
-        }
-        xml {
-            outputLocation = jacoco.reportsDirectory.file("jacoco-${impl}.xml")
-        }
+testEngines.each { engine ->
+    def tmpdir = "${project.layout.buildDirectory.get()}/runs/${engine}/tmp"
 
+    def task = tasks.register("test"+engine.replace("-",""), Test) { task ->
+        dependsOn ":install:installDist"
+        dependsOn ":opendcs:test"
+        //outputs.upToDateWhen {false}
+        useJUnitPlatform()
+
+
+        enabled = gradle.startParameter.taskNames.contains(":testing:" + project.name + ":test")
+        doFirst {
+            project.mkdir(tmpdir)
+        }
+        def install = project(":install")
+        def stageDir = install.layout.getBuildDirectory().dir("install/${install.distributions.main.distributionBaseName.get()}").get()
+        def classPath = (project(':opendcs').jar.outputs.files
+                    + project(":opendcs").configurations.runtimeClasspath).asPath
+        inputs.property "opendcs.test.engine", engine
+
+        systemProperties += project.properties.findAll {k, v -> k.startsWith("opendcs")}
+        systemProperties += project.properties.findAll {k, v -> k.startsWith("testcontainer")}
+        systemProperties += ["opendcs.test.engine": engine]
+
+        jvmArgs += "-Djava.io.tmpdir=${tmpdir}"
+        jvmArgs += "-Dbuild.dir=${project.layout.buildDirectory.get()}"
+        jvmArgs += "-Dopendcs.test.classpath=${classPath}"
+        jvmArgs += "-Dresource.dir=${projectDir}/src/test/resources" // TODO: make clearer
+        jvmArgs += "-DDCSTOOL_HOME=${stageDir}"
+        jvmArgs += "-Djava.util.logging.config.file=${projectDir}/src/test/test-config/logging.properties"
+
+        reports {
+            html {}
+            junitXml {}
+        }
+        jacoco {
+            excludes += [
+                    "**/easy_install/**",
+                    "**/python_packages",
+                    "**/certifi/**",
+                    "**/chardet/**",
+                    "**/urllib3/**",
+                    "**/requests/**",
+                    "**/chardet/**",
+                    "**/urllib3/**",
+                    "**/idna/**",
+                    "**/pkg_resources/**"
+                ]
+        }
     }
-    def excludes = [
-                "**/easy_install/**",
-                "**/python_packages",
-                "**/certifi/**",
-                "**/chardet/**",
-                "**/urllib3/**",
-                "**/requests/**",
-                "**/chardet/**",
-                "**/urllib3/**",
-                "**/idna/**",
-                "**/pkg_resources/**"
-            ]
+    test.dependsOn task
 
-    afterEvaluate {
+    def jtr = tasks.register("jacocoTestReport"+engine.replace("-",""), JacocoReport) {
+        dependsOn task
+        //additionalSourceDirs files(project(":opendcs").sourceSets.main.java.srcDirs)
+        //additionalClassDirs files(project(":opendcs").sourceSets.main.output)
+        sourceSets project(":opendcs").sourceSets.main
+        reports {
+            html {
+                outputLocation = jacoco.reportsDirectory.dir("jacoco-${engine}-html")
+            }
+            xml {
+                outputLocation = jacoco.reportsDirectory.file("jacoco-${engine}.xml")
+            }
+
+        }
+        def excludes = [
+                    "**/easy_install/**",
+                    "**/python_packages",
+                    "**/certifi/**",
+                    "**/chardet/**",
+                    "**/urllib3/**",
+                    "**/requests/**",
+                    "**/chardet/**",
+                    "**/urllib3/**",
+                    "**/idna/**",
+                    "**/pkg_resources/**"
+                ]
+
+
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: excludes)
         }))
+
+    }
+
+    task.configure {
+        finalizedBy jtr
     }
 }

--- a/java/lrgs-web/build.gradle
+++ b/java/lrgs-web/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'opendcs.deps-conventions'
     id 'opendcs.java-conventions'
+    id 'opendcs.sonar-conventions'
 }
 
 dependencies {

--- a/java/opendcs-api/build.gradle
+++ b/java/opendcs-api/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'opendcs.deps-conventions'
     id 'opendcs.java-conventions'
     id 'opendcs.publishing-conventions'
+    id 'opendcs.sonar-conventions'
     id 'java-library'
 }
 

--- a/java/opendcs-slf4j-provider/build.gradle
+++ b/java/opendcs-slf4j-provider/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'opendcs.deps-conventions'
     id 'opendcs.java-conventions'
     id 'opendcs.publishing-conventions'
+    id 'opendcs.sonar-conventions'
     id 'java-library'
 }
 

--- a/java/opendcs/build.gradle
+++ b/java/opendcs/build.gradle
@@ -3,6 +3,7 @@ plugins
     id 'opendcs.deps-conventions'
     id 'opendcs.java-conventions'
     id 'opendcs.publishing-conventions'
+    id 'opendcs.sonar-conventions'
     id 'java-library'
 }
 


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #. 

<!-- if you are referencing a specific issue a problem description is not required -->
SonarCloud is not able to pick up multiple jacoco xml reports.

## Solution

Implement task that gathers all coverage into a single report.
Integration tests are now registered as individual tasks so that the creation of the jacoco files is handled correctly and the new 'codeCoverageReport' task can gather them all up.

## how you tested the change

- Manually ran tests and new task, verify expected coverage showed.
- Will run as part of the ci/cd pipeline and should show increased coverage within sonar cloud.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
