### PR TITLE
fixes #1147  dbedit not loading all datasources

### DIFF
--- a/java/opendcs/src/main/java/decodes/xml/jdbc/XmlDatabaseProvider.java
+++ b/java/opendcs/src/main/java/decodes/xml/jdbc/XmlDatabaseProvider.java
@@ -41,16 +41,23 @@ public class XmlDatabaseProvider implements DatabaseProvider
     @Override
     public OpenDcsDatabase createDatabase(DataSource dataSource, DecodesSettings settings) throws DatabaseException
     {
+        Database old = Database.getDb();
         Database db = new Database(true);
+        
         XmlDatabaseIO dbIo = new XmlDatabaseIO(dataSource, settings);
         db.setDbIo(dbIo);
+        
         try
         {
+            Database.setDb(db);
             db.init(settings);
         }
         catch(DecodesException ex)
         {
             throw new DatabaseException("Unable to initialize decodes.", ex);
+        }
+        finally{
+            Database.setDb(old);
         }
         return new XmlOpenDcsDatabaseWrapper(settings, db, null, dataSource);
     }    

--- a/java/opendcs/src/main/java/org/opendcs/authentication/AuthSourceService.java
+++ b/java/opendcs/src/main/java/org/opendcs/authentication/AuthSourceService.java
@@ -3,6 +3,7 @@ package org.opendcs.authentication;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
+import org.opendcs.authentication.impl.NoOpAuthSourceProvider;
 import org.opendcs.spi.authentication.AuthSource;
 import org.opendcs.spi.authentication.AuthSourceProvider;
 
@@ -32,6 +33,10 @@ public class AuthSourceService
      */
     public static AuthSource getFromString(String configString) throws AuthException
     {
+        if( configString == null || configString.isEmpty() )
+        {
+            return new NoOpAuthSourceProvider().process("noop");
+        }
         int colon = configString.indexOf(":");
         String type = "UserAuthFile";
         String actualConfig = configString;


### PR DESCRIPTION
## Problem Description


Fixes #1147 

## Solution

- Set global Database object so DataSourceParser will work.
- return noop AuthSourceService when no Auth is *not* configured (xml database for example)

## how you tested the change

manual testing

