### PR TITLE
fix for: nation code of <NULL> during dbimport

### DIFF
--- a/java/opendcs/src/main/java/decodes/cwms/CwmsSiteDAO.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsSiteDAO.java
@@ -295,8 +295,7 @@ public class CwmsSiteDAO extends SiteDAO
 					null,                       // publishedLatitude
 					null,                       // publishedLongitude,
 					null,                       // boundingOffice
-					null, // PLACEHOLDER FOR NATIONID, which currently does not work!!!!
-//					site.country,               // nationId
+					newSite.country, 			// NATIONID example: 'US'
 					newSite.nearestCity,
 					true);                      // ignoreNulls
 


### PR DESCRIPTION
progress on #1008

using newSite.country in CwmsSiteDAO.   This fixes the following error:
FAILURE CwmsSiteDAO Error in CwmsLocJdbc.store for site 'WRCH-Crowheart-Wind': java.sql.SQLException: ORA-20998: ERROR: ORA-06512: at "CWMS_20.CWMS_ERR", line 80
....
ORA-20998: ERROR: Cannot use county code of 56000 with nation code of <NULL>

