### PR TITLE
Migrate maven artifact upload to new maven central API.

### DIFF
--- a/.github/workflows/nightly-schedule.yml
+++ b/.github/workflows/nightly-schedule.yml
@@ -14,8 +14,8 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
       signingKey: ${{ secrets.SIGNING_KEY }}
       signingKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
-      ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-      ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+      mavenCentralUsername: ${{ secrets.CENTRALAPI_USERNAME }}
+      mavenCentralPassword: ${{ secrets.CENTRALAPI_PASSWORD }}
     with:
       branch: "main"
       nightly: true
@@ -29,8 +29,8 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
       signingKey: ${{ secrets.SIGNING_KEY }}
       signingKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
-      ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-      ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+      mavenCentralUsername: ${{ secrets.CENTRALAPI_USERNAME }}
+      mavenCentralPassword: ${{ secrets.CENTRALAPI_PASSWORD }}
     with:
       branch: "7.0"
       nightly: true
@@ -44,8 +44,8 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
       signingKey: ${{ secrets.SIGNING_KEY }}
       signingKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
-      ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-      ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+      mavenCentralUsername: ${{ secrets.CENTRALAPI_USERNAME }}
+      mavenCentralPassword: ${{ secrets.CENTRALAPI_PASSWORD }}
     with:
       branch: "7.5"
       nightly: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,9 +16,9 @@ on:
         required: true
       signingKeyPassword:
         required: true
-      ossrhUsername:
+      mavenCentralUsername:
         required: true
-      ossrhPassword:
+      mavenCentralPassword:
         required: true
   workflow_dispatch:
     inputs:
@@ -71,16 +71,18 @@ jobs:
           ./gradlew publish --info -Psign=true \
              -PversionOverride=$VERSION \
              -PsigningKeyPassword="${{ secrets.signingKeyPassword != null && secrets.signingKeyPassword || secrets.SIGNING_KEY_PASSWORD }}" \
-             -PossrhUsername=${{ secrets.ossrhUsername != null && secrets.ossrhUsername || secrets.OSSRH_USERNAME }} \
-             -PossrhPassword=${{ secrets.ossrhPassword != null && secrets.ossrhPassword || secrets.OSSRH_PASSWORD }} \
-             -PsigningKey="${{ secrets.signingKey != null && secrets.signingKey || secrets.SIGNING_KEY }}"
+             -PcentralApiUsername=${{ secrets.mavenCentralUsername != null && secrets.mavenCentralUsername || secrets.CENTRAL_API_USERNAME }} \
+             -PcentralApiPassword=${{ secrets.mavenCentralPassword != null && secrets.mavenCentralPassword || secrets.CENTRAL_API_PASSWORD }} \
+             -PsigningKey="${{ secrets.signingKey != null && secrets.signingKey || secrets.SIGNING_KEY }}" \
+             -PautomaticPublish=true \
+             -PwaitForPublished=false
       - name: Create distributions
         run: |
           ./gradlew signDist -Psign=true \
              -PversionOverride=$VERSION \
              -PsigningKeyPassword="${{ secrets.signingKeyPassword != null && secrets.signingKeyPassword || secrets.SIGNING_KEY_PASSWORD }}" \
-             -PossrhUsername=${{ secrets.ossrhUsername != null && secrets.ossrhUsername || secrets.OSSRH_USERNAME }} \
-             -PossrhPassword=${{ secrets.ossrhPassword != null && secrets.ossrhPassword || secrets.OSSRH_PASSWORD }} \
+             -PcentralApiUsername=${{ secrets.mavenCentralUsername != null && secrets.mavenCentralUsername || secrets.CENTRAL_API_USERNAME }} \
+             -PcentralApiPassword=${{ secrets.mavenCentralPassword != null && secrets.mavenCentralPassword || secrets.CENTRAL_API_PASSWORD }} \
              -PsigningKey="${{ secrets.signingKey != null && secrets.signingKey || secrets.SIGNING_KEY }}"
       - name: create docker images
         run: |

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -2,7 +2,7 @@ name: SonarCloud Scan
 on:
   workflow_run:
     workflows: ["OpenDCS Build and unit tests"]
-    type: [completed]
+    types: [completed]
 
 jobs:
   Sonar:

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -7,7 +7,7 @@ on:
       - '7.[05].[0-9]+-RC[0-9]+'
       - '8.0.0-M[0-9]+'
   release:
-    types: [published,prerelease]
+    types: [published]
 jobs:
   release-from-tag:
     permissions:
@@ -19,8 +19,8 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
       signingKey: ${{ secrets.SIGNING_KEY }}
       signingKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
-      ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-      ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+      mavenCentralUsername: ${{ secrets.CENTRALAPI_USERNAME }}
+      mavenCentralPassword: ${{ secrets.CENTRALAPI_PASSWORD }}
     with:
       branch: ${{github.ref_name}}
       nightly: false

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,9 @@ import org.apache.tools.ant.taskdefs.condition.Os
 def gitDetails = versionDetails()
 
 ext.osWin = Os.isFamily(Os.FAMILY_WINDOWS)
-ext.gitCommit = gitDetails.gitHashFull ?: "Not build from git";
 
+/*
+ext.gitCommit = gitDetails.gitHashFull ?: "Not build from git";
 def static versionLabel(gitInfo) {
     def branch = gitInfo.branchName // all branches are snapshots, only tags get released
     def tag = gitInfo.lastTag
@@ -42,7 +43,7 @@ allprojects {
     group = 'org.opendcs'
     version = project.findProperty("versionOverride") ?: versionLabel(versionDetails())
 }
-
+*/
 
 
 if (JavaVersion.current() != JavaVersion.VERSION_1_8) {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
 }
 
 plugins {
-    id "com.palantir.git-version" version "3.1.0"
     id 'eclipse'
     id 'jacoco'
 }
@@ -26,25 +25,7 @@ repositories {
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-def gitDetails = versionDetails()
-
 ext.osWin = Os.isFamily(Os.FAMILY_WINDOWS)
-
-/*
-ext.gitCommit = gitDetails.gitHashFull ?: "Not build from git";
-def static versionLabel(gitInfo) {
-    def branch = gitInfo.branchName // all branches are snapshots, only tags get released
-    def tag = gitInfo.lastTag
-    // tag is returned as is. Branch may need cleanup
-    return branch == null ? tag : "main.99." + branch.replace("/", "-") + "-SNAPSHOT"
-}
-
-allprojects {
-    group = 'org.opendcs'
-    version = project.findProperty("versionOverride") ?: versionLabel(versionDetails())
-}
-*/
-
 
 if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
     sonar {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     if (JavaVersion.current() >= JavaVersion.VERSION_11) {
         implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.1.5'
         implementation 'dev.sigstore:sigstore-gradle-sign-plugin:1.0.0'
+        implementation 'io.github.opendcs.maven:maven-central-upload:0.1.2'
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,8 +11,10 @@ repositories {
 
 dependencies {
     implementation 'org.opendcs.testing:gradle-plugin:1.0.0-M11'
-    if (JavaVersion.current() >= JavaVersion.VERSION_11) {
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
         implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.1.5'
+    }
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
         implementation 'dev.sigstore:sigstore-gradle-sign-plugin:1.0.0'
         implementation 'io.github.opendcs.maven:maven-central-upload:0.1.2'
     }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     implementation 'org.opendcs.testing:gradle-plugin:1.0.0-M11'
+    implementation 'com.palantir.git-version:com.palantir.git-version.gradle.plugin:3.3.0'
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
         implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.1.5'
     }

--- a/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
@@ -1,6 +1,9 @@
 plugins {
     id 'signing'
     id 'maven-publish'
+    id 'com.palantir.git-version'
+    id 'opendcs.version-conventions'
+    id 'io.github.opendcs.maven.maven-central-upload'
 }
 
 ext.shouldSign = (project.findProperty("sign") ?: "false") == "true"
@@ -61,12 +64,10 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
 
         repositories {
             maven {
-                def releaseUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-                def snapshotUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-                def user = project.findProperty("ossrhUsername")
-                def passwd = project.findProperty("ossrhPassword")
-                name = 'MavenCentral'
-                url = version.endsWith('SNAPSHOT') ? snapshotUrl : releaseUrl
+                name = "mavenCentralApi"
+                url = "https://central.sonatype.com"
+                def user = project.findProperty("centralApiUsername")
+                def passwd = project.findProperty("centralApiPassword")
                 credentials {
                     username = user
                     password = passwd

--- a/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
@@ -3,12 +3,13 @@ plugins {
     id 'maven-publish'
     id 'com.palantir.git-version'
     id 'opendcs.version-conventions'
-    id 'io.github.opendcs.maven.maven-central-upload'
 }
 
 ext.shouldSign = (project.findProperty("sign") ?: "false") == "true"
 
-if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+    plugins.apply('io.github.opendcs.maven.maven-central-upload')
+
     if (shouldSign) {
         plugins.apply('dev.sigstore.sign')
 

--- a/buildSrc/src/main/groovy/opendcs.version-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.version-conventions.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'com.palantir.git-version'
+}
+
+def gitDetails = versionDetails()
+
+ext.gitCommit = gitDetails.gitHashFull ?: "Not build from git";
+
+def static versionLabel(gitInfo) {
+    def branch = gitInfo.branchName // all branches are snapshots, only tags get released
+    def tag = gitInfo.lastTag
+    // tag is returned as is. Branch may need cleanup
+    return branch == null ? tag : 99 + "." + branch.replace("/", "-") + "-SNAPSHOT"
+}
+
+def tmp_version = project.findProperty("versionOverride") ?: versionLabel(gitDetails)
+
+group = 'mil.army.usace.hec'
+version = tmp_version

--- a/install/build.gradle
+++ b/install/build.gradle
@@ -110,7 +110,7 @@ if (shouldSign) {
     }
 }
 
-// We don't publish the installer to maven central.
+// We don't publish the install distribution to maven central.
 project.tasks.findAll { task -> task.name.startsWith("publish")}.each { task -> task.enabled = false }
 
 def javaVersion = Double.parseDouble(project.findProperty("org.gradle.java.version") ?: "1.8" )


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->


<!-- if you are referencing a specific issue a problem description is not required -->
Original Maven central system is being removed on 30 June. Namespace was already migrated.

## Solution

Change upload of artifacts to maven central to use new api and the gradle plugin created.
Cleaned up some build code on the way.

## how you tested the change

credentials are only in github, can't test locally. Will set to `automaticPublish=false` initial in first RC to fully test change before setting back to `automaticPublish=true`

New plugin uses the existing publishing artifact information so I don't foresee any major issues.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
