### PR TITLE
Update apache-header

### DIFF
--- a/apache-header
+++ b/apache-header
@@ -1,5 +1,5 @@
 /*
-* Where Applicable, Copyright 2019 United States Government
+* Where Applicable, Copyright 2025 OpenDCS Consortium and/or its contributors
 * 
 * Licensed under the Apache License, Version 2.0 (the "License"); you may not
 * use this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
change 
from: 
United States Government 
to:
OpenDCS Consortium and/or its contributors

