### PR TITLE
Correct publish action for new API.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ jobs:
         # We don't publish to maven central for the nightly builds
         if: inputs.nightly == false
         run: |
-          ./gradlew publish --info -Psign=true \
+          ./gradlew publishAllToNewMavenCentralApi --info -Psign=true \
              -PversionOverride=$VERSION \
              -PsigningKeyPassword="${{ secrets.signingKeyPassword != null && secrets.signingKeyPassword || secrets.SIGNING_KEY_PASSWORD }}" \
              -PcentralApiUsername=${{ secrets.mavenCentralUsername != null && secrets.mavenCentralUsername || secrets.CENTRAL_API_USERNAME }} \


### PR DESCRIPTION
Forgot that the actions, like the tagged based release, all get their "source" from the main branch.