### PR TITLE
Correct group namespace.

### DIFF
--- a/buildSrc/src/main/groovy/opendcs.version-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.version-conventions.gradle
@@ -15,5 +15,5 @@ def static versionLabel(gitInfo) {
 
 def tmp_version = project.findProperty("versionOverride") ?: versionLabel(gitDetails)
 
-group = 'mil.army.usace.hec'
+group = 'org.opendcs'
 version = tmp_version


### PR DESCRIPTION
Set the wrong namespace when updating the version settings.