### PR TITLE
Upload combined coverage file for analysis.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
           name: coverage
           path: |
             ./**/build/**/jacoco*.xml
+            ./build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
             ./**/build/**/*.class
   containers:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
Discovered that the combined coverage wasn't getting uploading so SonarCloud was reporting lower than actual coverage.