### PR TITLE
Include column names  when saving properties in site_property

### DIFF
--- a/java/opendcs/src/main/java/opendcs/dao/PropertiesSqlDao.java
+++ b/java/opendcs/src/main/java/opendcs/dao/PropertiesSqlDao.java
@@ -120,8 +120,9 @@ public class PropertiesSqlDao extends DaoBase implements PropertiesDAI
     public void writeProperties(String tableName, String idColumn,
         DbKey parentKey, Properties props) throws DbIoException
     {
+        String columnNames = " (site_id,prop_name,prop_value) ";
         deleteProperties(tableName, idColumn, parentKey);
-        final String q = "insert into " + tableName + " values(?,?,?)";
+        final String q = "insert into " + tableName + columnNames+ " values(?,?,?)";
         try
         {
             doModifyBatch(q, key ->

--- a/java/opendcs/src/main/java/opendcs/dao/PropertiesSqlDao.java
+++ b/java/opendcs/src/main/java/opendcs/dao/PropertiesSqlDao.java
@@ -120,7 +120,7 @@ public class PropertiesSqlDao extends DaoBase implements PropertiesDAI
     public void writeProperties(String tableName, String idColumn,
         DbKey parentKey, Properties props) throws DbIoException
     {
-        String columnNames = " (site_id,prop_name,prop_value) ";
+        String columnNames = " ("+idColumn +",prop_name,prop_value) ";
         deleteProperties(tableName, idColumn, parentKey);
         final String q = "insert into " + tableName + columnNames+ " values(?,?,?)";
         try


### PR DESCRIPTION
SQL Inserts into the ccp.site_property table need to specify column names with the current Java code.
This is because there is a new db_office_code column in site_property under control of Oracle Virtual private Database.


This is progress on #1008 

## Solution

```java
        String columnNames = " ("+idColumn +",prop_name,prop_value) ";
        deleteProperties(tableName, idColumn, parentKey);
        final String q = "insert into " + tableName + columnNames+ " values(?,?,?)";
        
 ```