### PR TITLE
Use correct form to establish default publishing information

### DIFF
--- a/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
@@ -33,36 +33,35 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
         }
     }
 
-    publishing {
-        publications {
-            maven(MavenPublication) {
-                pom {
-                    url = 'https://github.com/opendcs/opendcs'
 
-                    scm {
-                        connection = 'scm:git:https://github.com/opendcs/opendcs.git'
-                        developerConnection = 'scm:git:ssh://git@github.com:opendcs/opendcs.git'
-                        url = 'https://github.com/opendcs/opendcs'
-                    }
+    publishing.publications.withType(MavenPublication) {
+        pom {
+            url = 'https://github.com/opendcs/opendcs'
 
-                    licenses {
-                        license {
-                            name = 'The Apache License, Version 2.0'
-                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        }
-                    }
+            scm {
+                connection = 'scm:git:https://github.com/opendcs/opendcs.git'
+                developerConnection = 'scm:git:ssh://git@github.com:opendcs/opendcs.git'
+                url = 'https://github.com/opendcs/opendcs'
+            }
 
-                    developers {
-                        developer {
-                            id = 'opendcs'
-                            name = 'The OpenDCS Team'
-                            email = 'https://github.com/opendcs'
-                        }
-                    }
+            licenses {
+                license {
+                    name = 'The Apache License, Version 2.0'
+                    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                }
+            }
+
+            developers {
+                developer {
+                    id = 'opendcs'
+                    name = 'The OpenDCS Team'
+                    email = 'https://github.com/opendcs'
                 }
             }
         }
-
+    }
+        
+    publishing {
         repositories {
             maven {
                 name = "mavenCentralApi"


### PR DESCRIPTION
## Problem Description


<!-- if you are referencing a specific issue a problem description is not required -->
The current form of establishing default publication information, prevents sub projects from further configuring the given extension, in this case `publishing.publications`.

## Solution

Use a form of acquiring the created publications that allows applying the default information at the correct timing for Gradle's build configuration.

## how you tested the change

Change was taken from the 7.0 branch were releases have been successful.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
