### PR TITLE
Devops/fix build main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Depends on having buildx available for the --mount feature
-FROM openjdk:17-jdk-slim-buster AS builder
+FROM eclipse-temurin:17-jdk-jammy AS builder
 
 RUN --mount=type=cache,target=/var/cache/apt \ 
     apt-get update && apt-get -y upgrade && \

--- a/install/build.gradle
+++ b/install/build.gradle
@@ -104,10 +104,6 @@ if (shouldSign) {
         dependsOn signDistTar
         dependsOn signDistZip
     }
-
-    sigstoreSignMavenPublication {
-        enabled = false
-    }
 }
 
 // We don't publish the install distribution to maven central.


### PR DESCRIPTION
- Updates build image same as #1247 
- remove sigstore section of install/build.gradle that was preventing release.