### PR TITLE
Bugfix/1256 logging fixes

### DIFF
--- a/java/opendcs/src/main/java/ilex/util/FileLogger.java
+++ b/java/opendcs/src/main/java/ilex/util/FileLogger.java
@@ -126,7 +126,16 @@ public class FileLogger extends Logger
 			},
 			"FileLogger-Writer");
 		writerThread.setDaemon(true);
+		writerThread.setUncaughtExceptionHandler((thread, ex) ->
+		{
+			/* Use of System.err is intentional. This is printing an error with the logging system itself and 
+			 * cannot use the logger to present any information.
+			 */
+			System.err.println(String.format("Error on thread %s", thread.getName()));
+			ex.printStackTrace(System.err);
+		});
 		writerThread.start();
+		
 	}
 
 	/**

--- a/java/opendcs/src/main/java/ilex/util/FileLogger.java
+++ b/java/opendcs/src/main/java/ilex/util/FileLogger.java
@@ -38,7 +38,7 @@ public class FileLogger extends Logger
 	 */
 	private static final int MESSAGE_CAPACITY = 5000;
 	/**
-	 * Numbered of queued messages to log in a single batch
+	 * Number of queued messages to log in a single batch
 	 */
 	public static final int DRAIN_TO_QUANTITY = 1000;
 

--- a/java/opendcs/src/test/java/ilex/util/FileLoggerTest.java
+++ b/java/opendcs/src/test/java/ilex/util/FileLoggerTest.java
@@ -47,6 +47,12 @@ public class FileLoggerTest
         final FileLogger loggerUnderTest = new FileLogger("test", myLog.toString(), 700);
         loggerUnderTest.setMinLogPriority(Logger.E_DEBUG3);
         loggerUnderTest.doLog(Logger.E_INFORMATION, testMsg1);
+        // Need to enqueue a sufficient number of messages that the drainTo method doesn't pull in message two.
+        for (int i =0; i < FileLogger.DRAIN_TO_QUANTITY+2; i++)
+        {
+            loggerUnderTest.doLog(Logger.E_INFORMATION, testMsg1+1);
+        }
+        Thread.sleep(2000);
         loggerUnderTest.doLog(Logger.E_WARNING, testMsg1);
         loggerUnderTest.doLog(Logger.E_DEBUG1, testMsg2);
 

--- a/java/opendcs/src/test/java/ilex/util/FileLoggerTest.java
+++ b/java/opendcs/src/test/java/ilex/util/FileLoggerTest.java
@@ -52,7 +52,6 @@ public class FileLoggerTest
         {
             loggerUnderTest.doLog(Logger.E_INFORMATION, testMsg1+1);
         }
-        Thread.sleep(2000);
         loggerUnderTest.doLog(Logger.E_WARNING, testMsg1);
         loggerUnderTest.doLog(Logger.E_DEBUG1, testMsg2);
 


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Possibly Fixes #1256. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Original system was logging one entry at a time using `Queue::poll`
Before changes I printed the entries in queue vs queue size and artificially shrunk the queue. There did appear to be the possibility of things hanging on adding new log entries to the queue which could have gotten things stuck. Additionally it may have been that the log was rotated but never picked up correctly hence the lack of updated log messages.

This change makes the log rotation a tighter part of the writing loop and should handle that situation better.


## how you tested the change

Unit test was updated to verify behavior of rotation.
Manually tests with compproc instance to see if responses were reasonable.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
