### PR TITLE
Bugfix/1256 logging fixes (#1258) -- cherry-pick from main

### DIFF
--- a/java/opendcs/src/main/java/ilex/util/FileLogger.java
+++ b/java/opendcs/src/main/java/ilex/util/FileLogger.java
@@ -3,14 +3,19 @@
 */
 package ilex.util;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.io.*;
-import java.nio.channels.FileChannel;
+
 
 
 /**
@@ -26,6 +31,17 @@ import java.nio.channels.FileChannel;
 */
 public class FileLogger extends Logger
 {
+	/**
+	 * Message Queue capacity.
+	 *
+	 * This number is currently rather arbitrary and may need adjustment in the future.
+	 */
+	private static final int MESSAGE_CAPACITY = 5000;
+	/**
+	 * Number of queued messages to log in a single batch
+	 */
+	public static final int DRAIN_TO_QUANTITY = 1000;
+
 	/**
 	* The current output PrintStream
 	*/
@@ -61,9 +77,8 @@ public class FileLogger extends Logger
 	* Set to false to cause the constructor to zero and start a new log.
 	*/
 	public static boolean appendFlag = true;
-
-	private AtomicBoolean closeOperations = new AtomicBoolean(false);	
-	private BlockingQueue<String> queue = new ArrayBlockingQueue<>(5000); // TODO: intentionally arbitrary number for now.;
+	private final AtomicBoolean closeOperations = new AtomicBoolean(false);
+	private final BlockingQueue<String> queue = new ArrayBlockingQueue<>(MESSAGE_CAPACITY);
 	private Thread writerThread;
 	private boolean isTerminal = false;
 	
@@ -97,34 +112,42 @@ public class FileLogger extends Logger
 		openNewLog();
 		writerThread = new Thread(() ->
 			{
+				ArrayList<String> messages = new ArrayList<>();
 				while (closeOperations.get() == false)
 				{
-					try
+					queue.drainTo(messages, DRAIN_TO_QUANTITY);
+					PrintStream ps = output.get();
+					if (!messages.isEmpty() && ps != null && !ps.checkError())
 					{
-						String msg = queue.poll(1, TimeUnit.SECONDS);
-						PrintStream ps = output.get();
-						if (msg != null && ps != null && !ps.checkError())
+						for (String msg: messages)
 						{
+							ps.println(msg);
 							if (!isTerminal) // avoid any kind of buffer overflow errors since this would just keep accumulating.
 							{
 								bytesWritten.getAndAdd(msg.length());
+								if (bytesWritten.get() >= this.maxLength)
+								{
+									rotateLogs();
+									ps = output.get(); // need to update the output stream
+								}
 							}
-							ps.println(msg);
 						}
-						if (!isTerminal && (bytesWritten.get() >= this.maxLength))
-						{
-							rotateLogs();
-						}
-					}
-					catch (InterruptedException ex)
-					{
-
+						messages.clear();
 					}
 				}
 			},
 			"FileLogger-Writer");
 		writerThread.setDaemon(true);
+		writerThread.setUncaughtExceptionHandler((thread, ex) ->
+		{
+			/* Use of System.err is intentional. This is printing an error with the logging system itself and 
+			 * cannot use the logger to present any information.
+			 */
+			System.err.println(String.format("Error on thread %s", thread.getName())); // NOSONAR
+			ex.printStackTrace(System.err); //NOSONAR
+		});
 		writerThread.start();
+		
 	}
 
 	/**
@@ -156,8 +179,8 @@ public class FileLogger extends Logger
 		catch (InterruptedException ex)
 		{
 			// NOTE: use of STDERR is intentional here. This is an error with logging itself.
-			System.err.println("Unable to put data in the log message queue.");
-			ex.printStackTrace();
+			System.err.println("Unable to put data in the log message queue."); // NOSONAR
+			ex.printStackTrace(System.err); //NOSONAR
 		}
 	}
 

--- a/java/opendcs/src/test/java/ilex/util/FileLoggerTest.java
+++ b/java/opendcs/src/test/java/ilex/util/FileLoggerTest.java
@@ -47,6 +47,11 @@ public class FileLoggerTest
         final FileLogger loggerUnderTest = new FileLogger("test", myLog.toString(), 700);
         loggerUnderTest.setMinLogPriority(Logger.E_DEBUG3);
         loggerUnderTest.doLog(Logger.E_INFORMATION, testMsg1);
+        // Need to enqueue a sufficient number of messages that the drainTo method doesn't pull in message two.
+        for (int i =0; i < FileLogger.DRAIN_TO_QUANTITY+2; i++)
+        {
+            loggerUnderTest.doLog(Logger.E_INFORMATION, testMsg1+1);
+        }
         loggerUnderTest.doLog(Logger.E_WARNING, testMsg1);
         loggerUnderTest.doLog(Logger.E_DEBUG1, testMsg2);
 


### PR DESCRIPTION
Possibly Fixes #1256.   -- cherry-pick from main

## Solution

Original system was logging one entry at a time using `Queue::poll` Before changes I printed the entries in queue vs queue size and artificially shrunk the queue. There did appear to be the possibility of things hanging on adding new log entries to the queue which could have gotten things stuck. Additionally it may have been that the log was rotated but never picked up correctly hence the lack of updated log messages.

This change makes the log rotation a tighter part of the writing loop and should handle that situation better.


## how you tested the change

Unit test was updated to verify behavior of rotation. Manually tests with compproc instance to see if responses were reasonable.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
- [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.

---------

## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Describe your solution.

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
