### PR TITLE
Remove 7.5 nightly build

### DIFF
--- a/.github/workflows/nightly-schedule.yml
+++ b/.github/workflows/nightly-schedule.yml
@@ -34,18 +34,4 @@ jobs:
     with:
       branch: "7.0"
       nightly: true
-  v7_5:
-    permissions:
-      packages: write
-      contents: write
-      id-token: write
-    uses: ./.github/workflows/release.yaml
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-      signingKey: ${{ secrets.SIGNING_KEY }}
-      signingKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
-      mavenCentralUsername: ${{ secrets.ORG_OPENDCS_CENTRALAPI_USERNAME }}
-      mavenCentralPassword: ${{ secrets.ORG_OPENDCS_CENTRALAPI_PASSWORD }}
-    with:
-      branch: "7.5"
-      nightly: true
+  


### PR DESCRIPTION
Will bring back when we determine how to properly do the 7.5 nightly from main.

Build keeping failing and emailing me about it.