### PR TITLE
Fix hourly WTP save

### DIFF
--- a/java/opendcs/src/main/java/decodes/tsdb/WaterTempProfiles.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/WaterTempProfiles.java
@@ -244,7 +244,7 @@ final public class WaterTempProfiles
                 {
                     CTimeSeries tseryCopy = timeSeriesDAO.makeTimeSeries(tsery.getTimeSeriesIdentifier());
                     tseryCopy.addSample(tsery.sampleAt(idx));
-                    tseries.addTimeSeries(tsery);
+                    tseries.addTimeSeries(tseryCopy);
                 }
                 catch (DuplicateTimeSeriesException | NoSuchObjectException | DbIoException  ex)
                 {


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Resevap was saving everyhour of the WTP instead of the last hour 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Made sure to only append the new timersies which contains the final WTP value

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
