### PR TITLE
Allow, if asked, flyway system to take over existing database.

### DIFF
--- a/java/opendcs/src/main/resources/db/CWMS-Oracle/functions/R__create_user.sql
+++ b/java/opendcs/src/main/resources/db/CWMS-Oracle/functions/R__create_user.sql
@@ -44,12 +44,19 @@ begin
 end check_dynamic_sql;
 /
 
-create or replace procedure create_user(username varchar2, password varchar2) authid current_user
+create or replace procedure create_user(p_username varchar2, p_password varchar2) authid current_user
 is
     l_sql varchar2(512);
+    l_exists number;
 begin
-    l_sql := 'create user ' || username || ' identified by "' || password || '"';
+    select count(*) into l_exists from all_users where upper(username) = upper(p_username);
+    if l_exists = 0 then
+        l_sql := 'create user ' || p_username || ' identified by "' || p_password || '"';
+    else
+        l_sql := 'alter user ' || p_username || ' identified by "' || p_password || '"';
+    end if;
     check_dynamic_sql(l_sql);
     execute immediate l_sql;
+
 end;
 /


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Users generally have existing databases that were not initially created by the new "Flyway" schema management system.

## Solution

Implement support for baselineOnMigrate that Flyway supports, determining existing version.
This allows an existing database at that version that recieve the flyway_schema_history table and then apply the appropriate updates.

## how you tested the change

- Does not break integration tests
- Locally, with a database that had the flyway_schema_history table removed and decodesdatabaseversion set appropriately.


## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
