### PR TITLE
correct coverage creation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
 
     tasks.register("codeCoverageReport", JacocoReport) {
         subprojects { subproject -> 
-            subproject.plugins.withType(JacocoPlugin).configureEach {
-                subproject.tasks.matching({t -> t.extensions.findByType(JacocoTaskExtension)}).configureEach { testTask ->
+            subproject.plugins.withType(JacocoPlugin).each {
+                subproject.tasks.matching({t -> t.extensions.findByType(JacocoTaskExtension)}).each { testTask ->
                     if(testTask.extensions.getByType(JacocoTaskExtension).isEnabled()) {
                         sourceSets subproject.sourceSets.main
                         executionData(testTask)
@@ -77,11 +77,11 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
                     "**/pkg_resources/**"
                 ]
 
-//        afterEvaluate {
-            classDirectories.setFrom(files(classDirectories.files.collect {
-                fileTree(dir: it, exclude: excludes)
-            }))
-  //      }
+
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: excludes)
+        }))
+
     }
 
     subprojects {

--- a/integrationtesting/opendcs-tests/build.gradle
+++ b/integrationtesting/opendcs-tests/build.gradle
@@ -94,6 +94,7 @@ testEngines.each { engine ->
         //additionalSourceDirs files(project(":opendcs").sourceSets.main.java.srcDirs)
         //additionalClassDirs files(project(":opendcs").sourceSets.main.output)
         sourceSets project(":opendcs").sourceSets.main
+        executionData = files("${buildDir}/jacoco/test"+engine.replace("-","")+".exec") // Use the .exec file from the custom test task
         reports {
             html {
                 outputLocation = jacoco.reportsDirectory.dir("jacoco-${engine}-html")


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #. 

<!-- if you are referencing a specific issue a problem description is not required -->
Corrects final generation of code coverage allowing sonar cloud, and the locally generated report, to actually see all coverage.

## Solution

Change the way that the codeCoverageReport task is setup.

## how you tested the change

This PR should show additional coverage from the integration tests.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
