### PR TITLE
Remove sigstore plugin usage to allow maven central publish.

### DIFF
--- a/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.publishing-conventions.gradle
@@ -11,20 +11,6 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     plugins.apply('io.github.opendcs.maven.maven-central-upload')
 
     if (shouldSign) {
-        plugins.apply('dev.sigstore.sign')
-
-        sigstoreSign {
-            oidcClient {
-                gitHub {
-                    audience.set("sigstore")
-                }
-
-                web {
-                    clientId.set("sigstore")
-                    issuer.set("https://oauth2.sigstore.dev/auth")
-                }
-            }
-        }
         signing {
             def signingKey = project.getProperty("signingKey").trim().replace("\n","")
             def signingPassword = project.getProperty("signingKeyPassword")


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #. 

<!-- if you are referencing a specific issue a problem description is not required -->
maven central push task could not run due to the sigstore plugin still being present.

## Solution

remove sigstore plugin.

## how you tested the change

Tested manual to be sure we didn't get the same configuration error.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
