### PR TITLE
Remove edgecase for -P option. (#1489)

### DIFF
--- a/install/src/main/dist/scripts/decj
+++ b/install/src/main/dist/scripts/decj
@@ -112,9 +112,6 @@ while [[ $# -gt 0 ]]; do
         if [ "$OPTARG" == "D" ]; then
           shift
           ARGS="$ARGS $1"
-        elif [ "$OPTARG" == "P" ]; then
-          shift
-          ARGS="$ARGS $1"
         else
           ARGS="$ARGS -$OPTARG"
         fi


### PR DESCRIPTION
Discovered that we aren't processing the -P option correctly anymore.

(cherry picked from commit f2207eaf6c3e53869fd859b164184565941594ab)

