### PR TITLE
Modify RingBuffer interface to be inline with 7.0

### DIFF
--- a/java/opendcs-api/src/main/java/org/opendcs/logging/LoggingEvent.java
+++ b/java/opendcs-api/src/main/java/org/opendcs/logging/LoggingEvent.java
@@ -2,45 +2,33 @@ package org.opendcs.logging;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.Map;
 
 /**
  * Based on https://logback.qos.ch/manual/encoders.html#JsonEncoder as it is sufficiently
  * complete to allow any logger backend to map to this structure
  */
-public final class LoggingEvent {
-    public final Long sequence;
-    public final ZonedDateTime timestamp;
-    public final String level;
-    public final String threadName;
-    public final String loggerName;
-    public final Map<String, String> context;
-    public final Map<String, String> diagnosticContext;
-    public final Map<String, String> keyValuePairs;
-    public final String message;
-    public final LoggedThrowable throwable;
-
-
-    public LoggingEvent(Long sequence, ZonedDateTime timestamp, String level, String threadName, String loggerName,
-                        Map<String, String> context, Map<String, String> diagnosticContext,
-                        Map<String, String> keyValuePairs, String message, LoggedThrowable throwable)
-    {
-        this.sequence = sequence;
-        this.timestamp = timestamp;
-        this.level = level;
-        this.threadName = threadName;
-        this.loggerName = loggerName;
-        this.context = Collections.unmodifiableMap(context);
-        this.diagnosticContext = Collections.unmodifiableMap(diagnosticContext);
-        this.keyValuePairs = Collections.unmodifiableMap(keyValuePairs);
-        this.message = message;
-        this.throwable = throwable;
-    }
+public record LoggingEvent (
+    Long sequence, ZonedDateTime timestamp, String level, String threadName, String loggerName,
+    Map<String, String> context, Map<String, String> diagnosticContext,
+    Map<String, String> keyValuePairs, String message, LoggedThrowable throwable)
+{
 
     @Override
     public String toString()
     {
         return String.format("%s %s [%s] %s %s", timestamp.format(DateTimeFormatter.ISO_ZONED_DATE_TIME), level, threadName, loggerName, message);
+    }
+
+    public static final LoggingEvent of(String msg)
+    {
+        return of(msg, null);
+    }
+
+    public static final LoggingEvent of(String msg, Throwable throwable)
+    {
+        LoggedThrowable lt = LoggedThrowable.from(throwable);
+        return new LoggingEvent(0L, ZonedDateTime.now(), "INFO", Thread.currentThread().getName(),
+                         "manual", null, null, null, msg, lt);
     }
 }

--- a/java/opendcs-api/src/main/java/org/opendcs/util/RingBuffer.java
+++ b/java/opendcs-api/src/main/java/org/opendcs/util/RingBuffer.java
@@ -4,6 +4,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.concurrent.Flow.Publisher;
+import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.SubmissionPublisher;
 
 /**
@@ -13,10 +15,11 @@ import java.util.concurrent.SubmissionPublisher;
  *
  * @see java.util.concurrent.SubmissionPublisher
  */
-public class RingBuffer<T> extends SubmissionPublisher<T> implements List<T>
+public class RingBuffer<T> implements List<T>, Publisher<T>
 {
     // Performance hit, but easier to deal with initially
     private final LinkedList<T> list = new LinkedList<>();
+    private final SubmissionPublisher<T> publisher = new SubmissionPublisher<>();
     private int maxSize;
 
     public RingBuffer(int size)
@@ -44,7 +47,7 @@ public class RingBuffer<T> extends SubmissionPublisher<T> implements List<T>
         boolean added = list.add(element);
         if (added)
         {
-            submit(element);
+            publisher.submit(element);
         }
         return added;
     }
@@ -191,7 +194,7 @@ public class RingBuffer<T> extends SubmissionPublisher<T> implements List<T>
 
     @Override
     public ListIterator<T> listIterator()
-    {   
+    {
         return list.listIterator();
     }
 
@@ -207,5 +210,12 @@ public class RingBuffer<T> extends SubmissionPublisher<T> implements List<T>
     public List<T> subList(int fromIndex, int toIndex)
     {
         return list.subList(fromIndex, toIndex);
+    }
+
+
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber)
+    {
+        publisher.subscribe(subscriber);
     }
 }

--- a/java/opendcs-logback-event-provider/src/test/java/org/opendcs/logging/logback/LogbackEventProviderTest.java
+++ b/java/opendcs-logback-event-provider/src/test/java/org/opendcs/logging/logback/LogbackEventProviderTest.java
@@ -25,7 +25,7 @@ class LogbackEventProviderTest
         log.info(msg);
         assertFalse(buffer.isEmpty());
         LoggingEvent le = buffer.get(0);
-        assertEquals(msg, le.message);
+        assertEquals(msg, le.message());
     }
     
 }

--- a/java/opendcs/src/main/java/org/opendcs/utils/logging/LoggingEventBuffer.java
+++ b/java/opendcs/src/main/java/org/opendcs/utils/logging/LoggingEventBuffer.java
@@ -5,7 +5,7 @@ import org.opendcs.logging.spi.LoggingEventProvider;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.Flow.Publisher;
 
 import org.opendcs.logging.LoggingEvent;
 import org.opendcs.util.RingBuffer;
@@ -52,12 +52,12 @@ public final class LoggingEventBuffer
     }
 
     /**
-     * Return SubmissionPublisher implemented by the Ring buffer.
+     * Return Publisher implemented by the Ring buffer.
      * For use by systems that either don't want to Poll or only require notification
      * of recent events.
      * @return
      */
-    public SubmissionPublisher<LoggingEvent> getPublisher()
+    public Publisher<LoggingEvent> getPublisher()
     {
         return this.eventList;
     }


### PR DESCRIPTION
* Expose only Publisher instead of SubmissionPublisher.
* Changes to account for the more generic publisher interface.
* Move LoggingEvent and LoggedThrowable to records now that we're on Java 21.

## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
After working on https://github.com/opendcs/opendcs/pull/1505 I realized the interface design was rather specific.

## Solution

Expose only generic interfaces from the root level objects.
Also took the time to convert the LoggingEvent and LoggedThrowable classes to Records now that we are on Java 21

## how you tested the change

Existing tests and and manually running an LRGS and older rtstat to verify log messages arrived.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
