### PR TITLE
Restore complock list and stop comp. Simplify parameter processing.

### DIFF
--- a/install/build.gradle
+++ b/install/build.gradle
@@ -130,10 +130,10 @@ task runApp(type: Exec) {
     println("Using app ${app}")
     if (osWin) {
         executable "cmd"
-        args "/c", binDir+app+ext, "-d3", "-DLOG_DIR={$runDir}"
+        args "/c", binDir+app+ext, "-d3"
     } else {
         executable binDir+app
-        args "-d3", "-DLOG_DIR=${runDir}"
+        args "-d3"
     }
     if (!profile.equals("default")) {
         args += ["-P", profile]
@@ -158,6 +158,7 @@ task runApp(type: Exec) {
     }
 
     environment "DECJ_OPTS", decjOpts
+    environment "LOG_DIR", runDir
     environment "DCSTOOL_HOME": file(installDist.destinationDir)
     environment "DECODES_INSTALL_DIR": file(installDist.destinationDir)
     environment "PATH": (files (file(binDir),

--- a/install/src/main/dist/scripts/complocklist
+++ b/install/src/main/dist/scripts/complocklist
@@ -3,4 +3,4 @@ SCRIPT=$(readlink -f "$0")
 # Absolute path this script is in, thus /home/user/bin
 APP_PATH=$(dirname "$SCRIPT")
 
-${APP_PATH}/decj decodes.tsdb.test.ListLocks $*
+${APP_PATH}/decj decodes.tsdb.locks.ListLocks $*

--- a/install/src/main/dist/scripts/complocklist.bat
+++ b/install/src/main/dist/scripts/complocklist.bat
@@ -1,1 +1,1 @@
-@"%~dp0\decj" decodes.tsdb.test.ListLocks %*%
+@"%~dp0\decj" decodes.tsdb.locks.ListLocks %*%

--- a/install/src/main/dist/scripts/decj
+++ b/install/src/main/dist/scripts/decj
@@ -73,62 +73,108 @@ fi
 APP_NAME=$1
 LOG_FILE=""
 LOG_LEVEL="-DLOG_LEVEL=info"
-
 ARGS=""
-while [[ $# -gt 0 ]]; do
-  OPTIND=1
-  if getopts ":a:l:d:p:k:" opt "$@"; then
-    case $opt in
-      a)
-      APP_NAME=${OPTARG}
-      ARGS="$ARGS -a ${APP_NAME}" # need to put this back if it exists
-      ;;
-      l) LOG_FILE="-DLOG_FILE=${OPTARG}" ;;
-      d)
-        level=$OPTARG
-        levelStr="info"
-        case $level in
-          "-2") levelStr="ERROR" ;;
-          "-1") levelStr="WARN" ;;
-          "0") levelStr="INFO" ;;
-          "1") levelStr="DEBUG" ;;
-          "2") levelStr="TRACE" ;;
-          "3") levelStr="TRACE" ;;
-        esac
-        LOG_LEVEL="-DLOG_LEVEL=${levelStr}" ;;
-      p)
-        # may be a -p option or it might be the -pp flag
-        if [ $OPTARG == "p" ]; then
-          ARGS="$ARGS -pp"
-          shift # skip ahead to the value
-          ARGS="$ARGS $1"
-          echo "$1"
-        else
-          ARGS="$ARGS -p $OPTARG"
-        fi
-        ;;
-      k) ARGS="$ARGS -k '$OPTARG'" ;;
-      :) ARGS="$ARGS -$OPTARG" ;;
-      \?)
-        if [ "$OPTARG" == "D" ]; then
-          # For some reason things didn't want to behave well if the -D values didn't come before
-          # the class to run.
-          ARGS="$1 $ARGS"
-        else
-          # Otherwise pass on the unknown argument and it's input to the application.
-          ARGS="$ARGS $1"
-        fi
-        shift
-        ;;
-      *) ARGS="$ARGS $opt" ;;
-      esac
-    shift $((OPTIND - 1))
-    unset OPTIND
+
+# https://stackoverflow.com/a/36475789
+_ARGS=()
+
+
+shift_globally () {
+  shift
+  _ARGS=$@
+}
+# end https://stackoverflow.com/a/36475789
+
+function handle_arg {
+  arg=$1
+  next_arg=$2
+  if [[ "${arg:0:2}" == "-a" ]]; then
+    handle_app $arg $next_arg
+  elif [[ "${arg:0:2}" == "-d" ]]; then
+    handle_debug $arg $next_arg
+  elif [[ "${arg:0:2}" == "-D" ]]; then
+    handle_jvm_prop $arg $next_arg
+  elif [[ "${arg:0:2}" == "-l" ]]; then
+    handle_log $arg $next_arg
   else
-    ARGS="$ARGS $1"
-    shift
+    ARGS="$ARGS $arg" # pass through
+  fi
+}
+
+function handle_jvm_prop {
+  arg=$1
+  prop=$2
+  
+  if [[ "$arg" == "-D" ]]; then
+    shift_globally "$@"
+  else
+    prop=${arg:2}
+  fi
+  ARGS="-D$prop $ARGS" # these come before the class name so that the jvm sets them for us.
+}
+
+
+function handle_debug {
+    arg=$1
+    level=$2
+    if [[ "$arg" == "-d" ]]; then # value is in next argument
+      shift_globally "$@"
+    else
+      level=${arg:2}
+    fi
+    levelStr="info"
+    case $level in
+      "-2") levelStr="ERROR" ;;
+      "-1") levelStr="WARN" ;;
+      "0") levelStr="INFO" ;;
+      "1") levelStr="DEBUG" ;;
+      "2") levelStr="TRACE" ;;
+      "3") levelStr="TRACE" ;;
+    esac    
+    LOG_LEVEL="-DLOG_LEVEL=${levelStr}" 
+}
+
+function handle_log {
+  arg=$1
+  log_file=$2
+  if [[ "$arg" == "-l" ]]; then
+    shift_globally "$@"
+  else
+    log_file=${arg:2}
+  fi
+  LOG_FILE="-DLOG_FILE=${log_file}"
+}
+
+function handle_app {
+  arg=$1
+  APP_NAME=$2
+  if [[ "$arg" == "-a" ]]; then
+    shift_globally "$@"
+  else
+    APP_NAME=${arg:2}
+  fi
+  ARGS="$ARGS -a $APP_NAME" # this one gets used *and* passed through
+}
+
+while [[ $# -gt 0 ]]; do
+  arg=$1
+  shift
+  next_arg=$1
+
+  if [[ "$arg" == "--" ]]; then # stop trying to special process anything
+    break
+  elif [[ ${arg:0:1} == "-" ]]; then
+    handle_arg $arg $next_arg # extract our desired elements
+  else
+    ARGS="$ARGS $arg" # pass through
   fi
 done
+# remaining args are assumed correct as is and the application will deal
+while [[ $# -gt 0 ]]; do
+  ARGS="$ARGS $1"
+  shift
+done
+
 
 if [ "${LOGBACK_OVERRIDE+x}" ]; then
   LOGBACK="$LOGBACK_OVERRIDE"
@@ -137,4 +183,5 @@ else
 fi
 
 cmd="java -Xms120m $DECJ_MAXHEAP $DECJ_OPTS -cp $CP -DDCSTOOL_HOME=$DH -DDECODES_INSTALL_DIR=$DH -DDCSTOOL_USERDIR=$DCSTOOL_USERDIR $LOGBACK $ARGS"
-eval $cmd
+echo $cmd
+exec $cmd

--- a/install/src/main/dist/scripts/stopcomp
+++ b/install/src/main/dist/scripts/stopcomp
@@ -3,4 +3,4 @@ SCRIPT=$(readlink -f "$0")
 # Absolute path this script is in, thus /home/user/bin
 APP_PATH=$(dirname "$SCRIPT")
 
-${APP_PATH}/decj decodes.tsdb.test.ReleaseLock $*
+${APP_PATH}/decj decodes.tsdb.locks.ReleaseLock $*

--- a/install/src/main/dist/scripts/stopcomp.bat
+++ b/install/src/main/dist/scripts/stopcomp.bat
@@ -1,1 +1,1 @@
-@"%~dp0\decj" decodes.tsdb.test.ReleaseLock %*%
+@"%~dp0\decj" decodes.tsdb.locks.ReleaseLock %*%

--- a/java/opendcs/src/main/java/decodes/tsdb/locks/ListLocks.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/locks/ListLocks.java
@@ -1,0 +1,57 @@
+package decodes.tsdb.locks;
+
+import java.util.List;
+
+import lrgs.gui.DecodesInterface;
+import opendcs.dai.LoadingAppDAI;
+import decodes.tsdb.*;
+import decodes.util.CmdLineArgs;
+import decodes.util.DecodesException;
+
+public class ListLocks 
+	extends TsdbAppTemplate
+{
+	public static final String module = "ListLocks";
+	
+	public ListLocks()
+	{
+		super("util.log");
+		appNameArg.setDefaultValue("utility");
+	}
+
+	@Override
+	protected void runApp()
+		throws Exception
+	{
+		LoadingAppDAI loadingAppDao = decodes.db.Database.getDb().getDbIo().makeLoadingAppDAO();
+		List<TsdbCompLock> locks = loadingAppDao.getAllCompProcLocks();
+		System.out.println("" + locks.size() + " Locks Retrieved:");
+
+		for(TsdbCompLock lock : locks)
+			System.out.println(lock.toString());
+		loadingAppDao.close();
+	}
+
+	public static void main(String args[])
+		throws Exception
+	{
+		ListLocks tp = new ListLocks();
+		tp.execute(args);
+	}
+	
+	@Override
+	public void initDecodes()
+		throws DecodesException
+	{
+		DecodesInterface.initDecodes(cmdLineArgs.getPropertiesFile());
+	}
+
+	@Override
+	public void createDatabase() {}
+	
+	@Override
+	public void tryConnect() {}
+
+
+
+}

--- a/java/opendcs/src/main/java/decodes/tsdb/locks/ReleaseLock.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/locks/ReleaseLock.java
@@ -1,0 +1,61 @@
+package decodes.tsdb.locks;
+
+import java.util.List;
+
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.slf4j.Logger;
+
+import opendcs.dai.LoadingAppDAI;
+
+import decodes.tsdb.*;
+import decodes.util.DecodesException;
+import decodes.db.Constants;
+
+public class ReleaseLock extends TsdbAppTemplate
+{
+	private static final Logger log = OpenDcsLoggerFactory.getLogger();
+
+	public ReleaseLock()
+	{
+		super(null);
+	}
+
+	protected void runApp()
+		throws Exception
+	{
+		if (getAppId() == Constants.undefinedId)
+		{
+			log.error("-a <appName> argument required -- No action taken!");
+			return;
+		}
+		// Note, the -a arg will have us connect to the database as the
+		// desired application.
+		LoadingAppDAI loadingAppDAO = theDb.makeLoadingAppDAO();
+		try
+		{
+			List<TsdbCompLock> locks = loadingAppDAO.getAllCompProcLocks();
+			log.info("{} Locks Retrieved.", locks.size());
+			for(TsdbCompLock lock : locks)
+				if (lock.getAppId() == getAppId())
+				{
+					loadingAppDAO.releaseCompProcLock(lock);
+					break;
+				}
+		}
+		finally
+		{
+			loadingAppDAO.close();
+		}
+	}
+	
+	public void initDecodes()
+		throws DecodesException
+	{
+	}
+	
+	public static void main(String args[]) throws Exception
+	{
+		ReleaseLock tp = new ReleaseLock();
+		tp.execute(args);
+	}
+}

--- a/java/opendcs/src/main/java/decodes/tsdb/locks/TestProg.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/locks/TestProg.java
@@ -1,0 +1,158 @@
+/*
+* Where Applicable, Copyright 2025 OpenDCS Consortium and/or its contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package decodes.tsdb.locks;
+
+import java.util.Properties;
+
+import org.opendcs.authentication.AuthSourceService;
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.slf4j.Logger;
+
+import lrgs.gui.DecodesInterface;
+
+import ilex.cmdline.*;
+import ilex.util.EnvExpander;
+
+import decodes.util.CmdLineArgs;
+import decodes.util.DecodesSettings;
+import decodes.tsdb.*;
+import decodes.sql.DbKey;
+
+/**
+ * @deprecated We have an integration test system setup. Such usages should be moved to there.
+ */
+@Deprecated
+public abstract class TestProg
+{
+	private static final Logger log = OpenDcsLoggerFactory.getLogger();
+	// Static command line arguments and initialization for main method.
+	private CmdLineArgs cmdLineArgs;
+	protected StringToken cfgFileArg;
+	protected BooleanToken testModeArg;
+	protected IntegerToken modelRunArg;
+	protected StringToken appNameArg;
+
+	public TimeSeriesDb theDb;
+	protected DbKey appId;
+
+	public TestProg(String logname)
+	{
+		if (logname == null)
+			logname = "test.log";
+		cmdLineArgs = new CmdLineArgs(false, logname);
+		cfgFileArg = new StringToken("c", "config-file",
+			"", TokenOptions.optSwitch, "$DECODES_INSTALL_DIR/comp.conf");
+		testModeArg = new BooleanToken("t", "test-mode",
+			"", TokenOptions.optSwitch, false);
+		modelRunArg = new IntegerToken("m",
+			"output-model-run-ID", "", TokenOptions.optSwitch, -1);
+		appNameArg = new StringToken("a", "App-Name", "",
+			TokenOptions.optSwitch, "");
+		cmdLineArgs.addToken(cfgFileArg);
+		cmdLineArgs.addToken(testModeArg);
+		cmdLineArgs.addToken(modelRunArg);
+		cmdLineArgs.addToken(appNameArg);
+	}
+
+	/**
+	 * The sub-class main method should call this.
+	 */
+	public void execute(String args[])
+		throws Exception
+	{
+		addCustomArgs(cmdLineArgs);
+		parseArgs(args);
+		initConfig();
+		createDatabase();
+		initDecodes();
+		runTest();
+	}
+
+	/**
+	 * Override this and add any test-specific arguments.
+	 */
+	protected void addCustomArgs(CmdLineArgs cmdLineArgs)
+	{
+		// Default impl does nothing.
+	}
+
+	/**
+	 * Override this with the guts of your test program.
+	 */
+	protected abstract void runTest()
+		throws Exception;
+
+	protected void parseArgs(String args[])
+		throws Exception
+	{
+
+		// Parse command line arguments.
+		try { cmdLineArgs.parseArgs(args); }
+		catch(IllegalArgumentException ex)
+		{
+			log.atError().setCause(ex).log("Unable to parse arguments.");
+			System.exit(1);
+		}
+	}
+
+	// Call this method second.
+	public void initConfig()
+		throws Exception
+	{
+	}
+
+	// Call this method third.
+	public void createDatabase()
+		throws Exception
+	{
+		String className = DecodesSettings.instance().getTsdbClassName();
+		String authFileName = EnvExpander.expand(DecodesSettings.instance().DbAuthFile);
+		try
+		{
+			ClassLoader cl = Thread.currentThread().getContextClassLoader();
+			Class dbClass = cl.loadClass(className);
+			theDb = (TimeSeriesDb)dbClass.newInstance();
+		}
+		catch(Exception ex)
+		{
+			throw new Exception("Cannot create database interface for class '" + className + "'", ex);
+		}
+
+		// Get authorization parameters.
+		Properties props = AuthSourceService.getFromString(authFileName)
+											.getCredentials();
+		// Set test-mode flag & model run ID in the database interface.
+		theDb.setTestMode(testModeArg.getValue());
+		int modelRunId = modelRunArg.getValue();
+		if (modelRunId != -1)
+			theDb.setWriteModelRunId(modelRunId);
+
+		// Connect to the database!
+		appId =theDb.getAppId();
+		log.info("Connected with appId={}", appId);
+	}
+
+	public void initDecodes()
+		throws Exception
+	{
+		DecodesInterface.initDecodes(cmdLineArgs.getPropertiesFile());
+	}
+
+	public CmdLineArgs getCmdLineArgs()
+	{
+		return cmdLineArgs;
+	}
+}


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
LockList and ReleaseLock were mistakenly removed.
Parameter processing was breaking several normal usages

## Solution

Restore classes - renamed package to avoid confusion.
Simply parameter processing. Provide standard "--" to indicate any remaining parameter should be presented as-is

## how you tested the change

Manually, using runApp and on cli to verify output was correct.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
