### PR TITLE
Prevent duplicate log statements.

### DIFF
--- a/install/src/main/dist/logback.xml
+++ b/install/src/main/dist/logback.xml
@@ -29,27 +29,13 @@
             <pattern>%date{ISO8601} %level [%thread] %logger %mdc %marker %kvp %msg %ex %n</pattern>
         </encoder>
     </appender>
-    <logger name="covesw" level="${LOG_LEVEL}">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="decodes" level="${LOG_LEVEL}">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="ilex" level="${LOG_LEVEL}">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="lqm" level="${LOG_LEVEL}">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="lrgs" level="${LOG_LEVEL}">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="org.opendcs" level="${LOG_LEVEL}">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="opendcs" level="${LOG_LEVEL}">
-        <appender-ref ref="FILE"/>
-    </logger>
+    <logger name="covesw" level="trace"/>
+    <logger name="decodes" level="trace"/>
+    <logger name="ilex" level="trace"/>
+    <logger name="lqm" level="trace"/>
+    <logger name="lrgs" level="trace"/>
+    <logger name="org.opendcs" level="trace"/>
+    <logger name="opendcs" level="trace"/>
     <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDERR"/>

--- a/integrationtesting/opendcs-tests/src/test/test-config/logback-test-child.xml
+++ b/integrationtesting/opendcs-tests/src/test/test-config/logback-test-child.xml
@@ -21,27 +21,13 @@
     <reconnectionDelay>10000</reconnectionDelay>
     <includeCallerData>false</includeCallerData>
   </appender>
-  <logger name="covesw" level="trace">
-    <appender-ref ref="FILE"/>
-  </logger>
-  <logger name="decodes" level="trace">
-    <appender-ref ref="FILE"/>
-  </logger>
-  <logger name="ilex" level="trace">
-    <appender-ref ref="FILE"/>
-  </logger>
-  <logger name="lqm" level="trace">
-    <appender-ref ref="FILE"/>
-  </logger>
-  <logger name="lrgs" level="trace">
-    <appender-ref ref="FILE"/>
-  </logger>
-  <logger name="org.opendcs" level="trace">
-    <appender-ref ref="FILE"/>
-  </logger>
-  <logger name="opendcs" level="trace">
-    <appender-ref ref="FILE"/>
-  </logger>
+  <logger name="covesw" level="trace"/>
+  <logger name="decodes" level="trace"/>
+  <logger name="ilex" level="trace"/>
+  <logger name="lqm" level="trace"/>
+  <logger name="lrgs" level="trace"/>
+  <logger name="org.opendcs" level="trace"/>
+  <logger name="opendcs" level="trace"/>
   <root level="INFO">
     <!--<appender-ref ref="SOCKET"/>-->
     <appender-ref ref="FILE"/>

--- a/integrationtesting/opendcs-tests/src/test/test-config/logback-test-driver.xml
+++ b/integrationtesting/opendcs-tests/src/test/test-config/logback-test-driver.xml
@@ -20,27 +20,13 @@
             <pattern>%date{ISO8601} %level [%thread] %contextName %logger %mdc %marker %kvp %msg %ex %n</pattern>
         </encoder>
     </appender>
-    <logger name="covesw" level="trace">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="decodes" level="trace">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="ilex" level="trace">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="lqm" level="trace">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="lrgs" level="trace">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="org.opendcs" level="trace">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="opendcs" level="trace">
-        <appender-ref ref="FILE"/>
-    </logger>
+    <logger name="covesw" level="trace"/>
+    <logger name="decodes" level="trace"/>
+    <logger name="ilex" level="trace"/>
+    <logger name="lqm" level="trace"/>
+    <logger name="lrgs" level="trace"/>
+    <logger name="org.opendcs" level="trace"/>
+    <logger name="opendcs" level="trace"/>
     <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDERR"/>


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #1535. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Remove appender ref from each logger element

## how you tested the change

manually, discovered during runs of integration tests which copied from our default logback.xml.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
