### PR TITLE
Correct redirect behavior of startLrgs, general JVM properties handli…

### DIFF
--- a/install/src/main/dist/scripts/decj
+++ b/install/src/main/dist/scripts/decj
@@ -74,6 +74,7 @@ APP_NAME=$1
 LOG_FILE=""
 LOG_LEVEL="-DLOG_LEVEL=info"
 APP_ARGS=()
+JVM_ARGS=()
 
 # https://stackoverflow.com/a/36475789
 _ARGS=( "$@" )
@@ -108,7 +109,7 @@ function handle_jvm_prop {
   else
     prop="${arg:2}"
   fi
-  APP_ARGS+=("-D$prop") # these come before the class name so that the jvm sets them for us.
+  JVM_ARGS+=("-D$prop") # these come before the class name so that the jvm sets them for us.
 }
 
 
@@ -194,5 +195,5 @@ fi
 cmd=(java -Xms120m $DECJ_MAXHEAP $DECJ_OPTS)
 cmd+=(-cp $CP -DDCSTOOL_HOME=$DH -DDECODES_INSTALL_DIR=$DH)
 cmd+=(-DDCSTOOL_USERDIR=$DCSTOOL_USERDIR $LOGBACK)
-echo "cli: ${cmd[@]} ${APP_ARGS[@]@Q}"
-exec "${cmd[@]}"  "${APP_ARGS[@]}"
+echo "cli: ${cmd[@]} ${JVM_ARGS[@]} ${APP_ARGS[@]@Q}"
+exec "${cmd[@]}" "${JVM_ARGS[@]}"  "${APP_ARGS[@]}"

--- a/install/src/main/dist/scripts/startLRGS
+++ b/install/src/main/dist/scripts/startLRGS
@@ -13,4 +13,4 @@ then
 fi
 LD_LIBRARY_PATH=$LRGSHOME/lib
 export LD_LIBRARY_PATH
-nohup ${APP_PATH}/decj -DLRGSHOME=$LRGSHOME lrgs.lrgsmain.LrgsMain $* >>lrgs.nohup 2>&1 &
+nohup ${APP_PATH}/decj  lrgs.lrgsmain.LrgsMain -DLRGSHOME=$LRGSHOME $* >> lrgs.nohup 2>/dev/null &

--- a/install/src/test/java/org/opendcs/app/DecjTest.java
+++ b/install/src/test/java/org/opendcs/app/DecjTest.java
@@ -29,9 +29,11 @@ class DecjTest
     @ParameterizedTest
     @ArgsSource({"-l","test.log"})
     @ArgsSource({"-l","test.log", "-Dtest=test"})
+    @ArgsSource({"-l","test.log", "-Dtest=test", "-DLRGSHOME=testdir"})
     @ArgsSource({"-ltest.log"})
-    @ArgsSource({"-ltest.log","-d3"})
-    @ArgsSource({"-ltest.log","-d", "3"})
+    @ArgsSource({"-ltest.log", "-d3"})
+    @ArgsSource({"-ltest.log", "-d", "3"})
+    @ArgsSource({"-DLRGSHOME=testdir", "-l", "test.log", "-Dtest=test"})
     void test_arguments_consumed(String[] args) throws Exception
     {
         final Result output = appOutput(args);


### PR DESCRIPTION
…ng improvements.

## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
More corrections to CLI issues.

## Solution

- have startLrgs redirect stderr to /dev/null now that we have proper logging setup
- Correct JVM arguments handling.

## how you tested the change

Manually, running lrgs in `./gradlew runApp -Popendcs.app=lrgs`

added cases to the DecjTest but seemed to always behavior correctly there.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
