### PR TITLE
Add LF correction for gradlew

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-*.sh text eol=lf
+*.sh    text eol=lf
+gradlew text eol=lf


### PR DESCRIPTION
## Problem Description


I was attempting to run the opendcs docker compose on windows and ran into issues with the build failing because the `gradlew` file was showing it had CRLF set. 

I assumed this was on me, corrected it in my git global config, and moved on. 

But submitting this here with the `gradlew` file fixed and the `.gitattributes` to help going forward as well. 

Might help with 
- #1670