### PR TITLE
Update java client to use jakarta namespace. Correct package space.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ jwt = "4.4.0"
 jaxb = "4.0.0"
 
 swagger-codegen = "3.0.61"
-jakarta-annotation-api = "1.3.5"
+jakarta-annotation-api = "3.0.0"
 jsr305 = "3.0.2"
 openapitools-databind-nullable = "0.2.1"
 

--- a/java/api-clients/api-client-java/build.gradle
+++ b/java/api-clients/api-client-java/build.gradle
@@ -27,9 +27,9 @@ openApiGenerate {
     outputDir = "$buildDir/generated/openApi"
     generatorName = "java"
     library = "native"
-    apiPackage = "org/opendcs/rest/client/api"
-    modelPackage = "org/opendcs/rest/client/model"
-    invokerPackage = "org/opendcs/rest/client/invoker"
+    apiPackage = "org.opendcs.rest.client.api"
+    modelPackage = "org.opendcs.rest.client/model"
+    invokerPackage = "org.opendcs.rest.client/invoker"
     globalProperties.set([
         modelDocs: "true",
         modelTests: "false",
@@ -37,6 +37,9 @@ openApiGenerate {
         apiTests: "false",
         enabledPostProcessFile: "false"
     ])
+    configOptions = [
+        useJakartaEe: "true"
+    ]
     ignoreFileOverride = "$projectDir/.openapi-generator-ignore"
     
 }


### PR DESCRIPTION
## Problem Description

Subproject should've already been using the jakarta namespace, changing the annotation-api to 3.0.0 causes it to break if not configured correctly. Dependabot PR unable to pass 

## Solution

- Update annotations-api dependency
- Correctly set output to use the Jakarta namespace.

## how you tested the change

- subproject is not currently used except as a canary for the REST API generation abilities. The generation of the library is the test.


## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
