### PR TITLE
Devops/more timing tweaks

### DIFF
--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
@@ -102,7 +102,6 @@ public class ComputationApp extends TsdbAppTemplate
 	private int checkTimedCompsSec = 600;
 	private SimpleDateFormat debugSdf = new SimpleDateFormat("yyyy/MM/dd-HH:mm:ss");
 
-	
 	private static ComputationApp _instance = null;
 	public static ComputationApp instance() { return _instance; }
 

--- a/java/opendcs/src/main/java/org/opendcs/utils/logging/MDCTimer.java
+++ b/java/opendcs/src/main/java/org/opendcs/utils/logging/MDCTimer.java
@@ -17,7 +17,7 @@ public final class MDCTimer implements AutoCloseable
         mdc = MDC.putCloseable("timer:" + name, String.format("%d", this.start));
 
         this.name = name;
-        log.info("Timer {} started {}", name, start);
+        log.info("Timer '{}' started {}", name, start);
     }
 
     public static MDCTimer startTimer(String name)
@@ -29,7 +29,7 @@ public final class MDCTimer implements AutoCloseable
     public void close() throws Exception
     {
         long diff = System.currentTimeMillis() - start;
-        log.info("Timer {} ended in {} ms", name, diff);
+        log.info("Timer '{}' ended in {} ms", name, diff);
         mdc.close();
     }
     


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Initial results from a large run in USACE's new environment showed odd results. Additionally the timer context name got overridden with nested timers.



## Solution

- Correct timer context name to prefix with timer
- Additional timer contexts and key areas
- Some additional logging to show settings that are used
- Add computation name to MDC context in main ComputationApp loop (was only present in timed computation sections

## how you tested the change

Manually reviewing logs. Have a script to process the logs but doesn't really make sense to include in the tests as these should all be replaced with otel metric contexts as soon as practical.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
