### PR TITLE
Correct sizing of User Menu toggle, make own component.

### DIFF
--- a/javascript/opendcs-web-ui-react/public/locales/en-US/translation.json
+++ b/javascript/opendcs-web-ui-react/public/locales/en-US/translation.json
@@ -21,5 +21,6 @@
   "description": "Description",
   "cancel": "Cancel",
   "save": "Save",
-  "loading_reference_lists": "Loading Reference Lists Data..."
+  "loading_reference_lists": "Loading Reference Lists Data...",
+  "user-settings": "User Settings"
 }

--- a/javascript/opendcs-web-ui-react/src/components/index.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/index.tsx
@@ -1,2 +1,2 @@
-export { ColorModes } from "./ColorMode";
+export { ColorModes } from "./menus/ColorMode/ColorMode";
 export { ModeIcon, ModeIcons } from "./ModeIcon";

--- a/javascript/opendcs-web-ui-react/src/components/layout/TopBar.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/layout/TopBar.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect } from "storybook/test";
+import { expect, fn } from "storybook/test";
 import { TopBar } from "./TopBar";
 import { ModeIcons } from "../ModeIcon";
+import { AuthContext } from "../../contexts/app/AuthContext";
 
 const meta = {
   component: TopBar,
@@ -22,6 +23,30 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  play: async ({ canvas, mount }) => {
+    await mount();
+    const text = await canvas.findByText("OpenDCS");
+    expect(text).toBeInTheDocument();
+  },
+};
+
+export const WithUser: Story = {
+  args: {},
+  decorators: [
+    (Story) => {
+      return (
+        <AuthContext
+          value={{
+            logout: fn(),
+            setUser: fn(),
+            user: { email: "testuser@example.com" },
+          }}
+        >
+          <Story />
+        </AuthContext>
+      );
+    },
+  ],
   play: async ({ canvas, mount }) => {
     await mount();
     const text = await canvas.findByText("OpenDCS");

--- a/javascript/opendcs-web-ui-react/src/components/layout/TopBar.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/layout/TopBar.tsx
@@ -1,15 +1,13 @@
 import { useContext } from "react";
-import { Button, Container, NavDropdown } from "react-bootstrap";
-import { PersonGear } from "react-bootstrap-icons";
 import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
 import { AuthContext } from "../../contexts/app/AuthContext";
 import { ColorModes } from "../";
-import { useTranslation } from "react-i18next";
-import LangPicker from "../LangPicker";
+import LangPicker from "../menus/Language/LangPicker";
+import UserMenu from "../menus/User/UserMenu";
+import { Container } from "react-bootstrap";
 
 export function TopBar() {
-  const { t } = useTranslation();
   const { user, logout } = useContext(AuthContext);
 
   return (
@@ -25,20 +23,7 @@ export function TopBar() {
           <ColorModes />
         </Nav.Item>
         <Nav.Item></Nav.Item>
-        {user && (
-          <NavDropdown
-            title={<PersonGear className="theme-icon my-1" height="1em" />}
-            id="user-settings"
-            drop="start"
-          >
-            <NavDropdown.Item>Profile - {user?.email}</NavDropdown.Item>
-            <NavDropdown.Item>Admin</NavDropdown.Item>
-            <NavDropdown.Divider />
-            <NavDropdown.Item>
-              <Button onClick={logout}>{t("translation:logout")}</Button>
-            </NavDropdown.Item>
-          </NavDropdown>
-        )}
+        {user && <UserMenu user={user} logout={logout} />}
       </Nav>
     </Navbar>
     //  <nav class="navbar  navbar-expand-lg bg-primary sticky-top">

--- a/javascript/opendcs-web-ui-react/src/components/menus/ColorMode/ColorMode.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/menus/ColorMode/ColorMode.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { ColorModes } from "./ColorMode";
 import { Nav } from "react-bootstrap";
-import { ModeIcons } from "./ModeIcon";
+import { ModeIcons } from "../../ModeIcon";
 
 const meta = {
   component: ColorModes,

--- a/javascript/opendcs-web-ui-react/src/components/menus/ColorMode/ColorMode.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/menus/ColorMode/ColorMode.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
-import { useTheme } from "../contexts/app/ThemeContext";
-import { ModeIcon } from "./ModeIcon";
+import { useTheme } from "../../../contexts/app/ThemeContext";
+import { ModeIcon } from "../../ModeIcon";
 import { Button, Dropdown } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 

--- a/javascript/opendcs-web-ui-react/src/components/menus/ColorMode/index.ts
+++ b/javascript/opendcs-web-ui-react/src/components/menus/ColorMode/index.ts
@@ -1,0 +1,1 @@
+export * from "./ColorMode";

--- a/javascript/opendcs-web-ui-react/src/components/menus/Language/LangPicker.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/menus/Language/LangPicker.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent } from "storybook/test";
 
 import LangPicker from "./LangPicker";
-import i18n from "../i18n";
+import i18n from "../../../i18n";
 
 const meta = {
   component: LangPicker,

--- a/javascript/opendcs-web-ui-react/src/components/menus/Language/LangPicker.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/menus/Language/LangPicker.tsx
@@ -2,7 +2,7 @@ import type { i18n } from "i18next";
 import React from "react";
 import { Button, ButtonGroup, Dropdown } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
-import availableLanguages from "../lang";
+import availableLanguages from "../../../lang";
 
 interface ToggleProperties {
   i18n: i18n;

--- a/javascript/opendcs-web-ui-react/src/components/menus/Language/index.ts
+++ b/javascript/opendcs-web-ui-react/src/components/menus/Language/index.ts
@@ -1,0 +1,1 @@
+export * from "./LangPicker";

--- a/javascript/opendcs-web-ui-react/src/components/menus/User/UserMenu.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/menus/User/UserMenu.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { UserMenu } from "./UserMenu";
+import { expect, fn } from "storybook/test";
+import { act } from "react";
+
+const meta = {
+  component: UserMenu,
+} satisfies Meta<typeof UserMenu>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    user: { email: "Test Email" },
+    logout: fn(),
+  },
+  play: async ({ mount }) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _canvas = await mount();
+  },
+};
+
+export const CanClickLogout: Story = {
+  args: {
+    user: { email: "Test Email" },
+    logout: fn(),
+  },
+  play: async ({ args, mount, parameters, userEvent }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    const toggle = await canvas.findByRole("button", { name: i18n.t("user-settings") });
+    await act(async () => userEvent.click(toggle));
+
+    const logout = await canvas.findByRole("button", { name: i18n.t("logout") });
+    await act(async () => userEvent.click(logout));
+
+    expect(args.logout).toHaveBeenCalled();
+  },
+};

--- a/javascript/opendcs-web-ui-react/src/components/menus/User/UserMenu.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/menus/User/UserMenu.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Button, Dropdown } from "react-bootstrap";
+import { PersonGear } from "react-bootstrap-icons";
+import { useTranslation } from "react-i18next";
+import type { User } from "../../../../../../java/api-clients/api-client-typescript/build/generated/openApi/dist";
+
+const UserToggle: React.FC = ({ ...args }) => {
+  return (
+    <Button {...args} size="lg">
+      <PersonGear className="bi me-2 opacity-50 my-1 mode-icon-active" />
+    </Button>
+  );
+};
+
+export interface UserMenuProperties {
+  user: User;
+  logout: () => void;
+}
+
+export const UserMenu: React.FC<UserMenuProperties> = ({ user, logout }) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [t, _i18n] = useTranslation();
+  return (
+    <Dropdown drop="start">
+      <Dropdown.Toggle as={UserToggle} aria-label={t("user-settings")} />
+      <Dropdown.Menu>
+        <Dropdown.Item>Profile - {user.email}</Dropdown.Item>
+        <Dropdown.Item>Admin</Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item onClick={logout}>{t("translation:logout")}</Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};
+
+export default UserMenu;


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
The User settings icon wasn't rendering the correct size. Additionally it was using NavDropDown instead of Dropdown which exhibits some different behavior.

## Solution

Move implementation of `UserMenu` to it's own component (`UserMenu`) and made implementation inline with other menus. Additionally setup stories for UserMenu and an additional Story for the TopBar that includes the user menu.

## how you tested the change

- Visual correction was tested manually (the icon is now the same size as the others in the menu)
- Additional Storybook tests.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
