### PR TITLE
NOS Air Gap sensor decoding update

### DIFF
--- a/java/opendcs/src/main/java/decodes/decoder/Nos6Min.java
+++ b/java/opendcs/src/main/java/decodes/decoder/Nos6Min.java
@@ -167,17 +167,23 @@ public class Nos6Min extends NosDecoder
                                 sigma = getInt(2, false);
                                 outlier = getInt(1, false);
 
+				// With the switch to MWWL sensors for air gap, we no longer
+                                // require the AQT1 and AQT2 values to be transmitted. Set to
+                                // dummy empty.
+                                log.info("Skipping read of dummy air gap AQT1 and AQT2 values");
+                                x = 999999;
+                                y = 999999;
                                 // For the second DCP Air Gap data, there are no AQT1 or AQT2.
-                                if (Qcount ==0)
-                                {
-                                   x = getInt(2, true); // AQT1
-                                   y = getInt(2, true); // AQT2
-                                }
-                                else
-                                {
-                                   x = 999999;
-                                   y = 999999;
-                                }
+                                // if (Qcount ==0)
+                                // {
+                                //    x = getInt(2, true); // AQT1
+                                //    y = getInt(2, true); // AQT2
+                                // }
+                                // else
+                                // {
+                                //   x = 999999;
+                                //   y = 999999;
+                                //}
 
                                 sensorNum = getSensorNumber(
                                         flag == '1' ? 'A' :

--- a/java/opendcs/src/main/java/decodes/decoder/Nos6Min.java
+++ b/java/opendcs/src/main/java/decodes/decoder/Nos6Min.java
@@ -161,7 +161,38 @@ public class Nos6Min extends NosDecoder
                                          x, y, timeOffset, dataTime, redundantDataTime);
                                 break;
                         case '1': // PWL Aqua Track = Acousitic Water Level
-                        case '(': // Air Gap
+                  
+				wl = getInt(3, false);
+
+                                sigma = getInt(2, false);
+                                outlier = getInt(1, false);
+
+                                if (Qcount ==0)
+                                {
+                                   x = getInt(2, true); // AQT1
+                                   y = getInt(2, true); // AQT2
+                                }
+                                else
+                                {
+                                  x = 999999;
+                                  y = 999999;
+                                }
+
+                                sensorNum = getSensorNumber('A', config);
+                                if (sensorNum == -1)
+                                        continue;
+
+                                v = new Variable("" + wl + "," + sigma + "," + outlier
+                                        + "," + x + "," + y);
+                                if (isValid(wl))
+                                   msg.addSampleWithTime(sensorNum, v, dataTime, 1);
+                                else
+                                   log.warn("Aqua WL sensor data is discarded for station {}{} WL={}",
+                                            stationId, dcpNum, wl);
+
+                                Qcount++;
+                                break;
+			case '(': // Air Gap
                                 wl = getInt(3, false);
 
                                 sigma = getInt(2, false);
@@ -173,21 +204,8 @@ public class Nos6Min extends NosDecoder
                                 log.info("Skipping read of dummy air gap AQT1 and AQT2 values");
                                 x = 999999;
                                 y = 999999;
-                                // For the second DCP Air Gap data, there are no AQT1 or AQT2.
-                                // if (Qcount ==0)
-                                // {
-                                //    x = getInt(2, true); // AQT1
-                                //    y = getInt(2, true); // AQT2
-                                // }
-                                // else
-                                // {
-                                //   x = 999999;
-                                //   y = 999999;
-                                //}
 
-                                sensorNum = getSensorNumber(
-                                        flag == '1' ? 'A' :
-                                        flag == '(' ? 'Q' : 'A', config);
+                                sensorNum = getSensorNumber('Q', config);
                                 if (sensorNum == -1)
                                         continue;
 
@@ -196,7 +214,7 @@ public class Nos6Min extends NosDecoder
 		         	if (isValid(wl))
                                    msg.addSampleWithTime(sensorNum, v, dataTime, 1);
 				else
-				   log.warn("Aqua or Air Gap WL sensor data is discarded for station {}{} WL={}",
+				   log.warn("Air Gap WL sensor data is discarded for station {}{} WL={}",
                 	                    stationId, dcpNum, wl);
 
                                 Qcount++;

--- a/java/opendcs/src/main/java/decodes/decoder/NosMessageDecoder.java
+++ b/java/opendcs/src/main/java/decodes/decoder/NosMessageDecoder.java
@@ -1,0 +1,368 @@
+/*
+* Where Applicable, Copyright 2025 OpenDCS Consortium and/or its contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package decodes.decoder;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+import ilex.util.PseudoBinary;
+import ilex.util.TextUtil;
+
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.slf4j.Logger;
+
+public final class NosMessageDecoder
+{
+    private static final Logger log = OpenDcsLoggerFactory.getLogger();
+    private NosMessageDecoder() {
+        // prevent instantiation
+    }
+
+    /**	Formats */
+    private static final NumberFormat DP1 = nfFrac(1);
+    private static final NumberFormat DP2 = nfFrac(2);
+    private static final NumberFormat DP3 = nfFrac(3);
+
+    private static final NumberFormat I1  = nfInt(1);
+    private static final NumberFormat I2  = nfInt(2);
+    private static final NumberFormat I6  = nfInt(6);
+    private static final NumberFormat I8  = nfInt(8);
+
+    private static final DecimalFormat D1 = new DecimalFormat("0.0");
+    private static final DecimalFormat D3 = new DecimalFormat("0.000");
+
+    /**	NOS sensor flags */
+    private static final String NORTEK_LEGACY = "CA";
+    private static final String NORTEK_GEN2   = "CN";
+    private static final String RESERVED_VAR  = "CX";
+    
+
+    /** Helpers to build NumberFormats */
+    private static NumberFormat nfFrac(int minFrac)
+    {
+        NumberFormat nf = NumberFormat.getNumberInstance();
+        nf.setGroupingUsed(false);
+        nf.setMinimumFractionDigits(minFrac);
+        return nf;
+    }
+    
+    private static NumberFormat nfInt(int minDigits)
+    {
+        NumberFormat nf = NumberFormat.getIntegerInstance();
+        nf.setGroupingUsed(false);
+        nf.setMinimumIntegerDigits(minDigits);
+        return nf;
+    }
+
+    public static String updateSensortype(byte[] field)
+    {
+        String snsType = RESERVED_VAR;
+        if (field.length >= 3)
+        {
+            String firstThree = new String(field, 0, 3);
+            if (firstThree.contains(NORTEK_LEGACY))     snsType = NORTEK_LEGACY;
+            else if (firstThree.contains(NORTEK_GEN2))  snsType = NORTEK_GEN2;
+        }
+        return snsType;
+    }
+
+    public static byte[] appendHeaderByte(byte[] field)
+    {
+        /** If first char is 'C', prepend '*' */
+        if (field.length > 0 && field[0] == 'C')
+        {
+            byte[] updatedField = new byte[field.length + 1];
+            updatedField[0] = '*';
+            System.arraycopy(field, 0, updatedField, 1, field.length);
+            field = updatedField;
+        }
+        return field;
+    }
+
+    /** Nortek Legacy (CA) Header. */
+    public static String decodeLegacyHeader(byte[] field)
+    {
+        log.debug("Legacy Nortek field='" + new String(field) + "', len=" + field.length);
+        StringBuilder header = new StringBuilder();
+
+        // first 8 chars after signature (idx 3..10)
+        for (int idx = 3; idx < 11; idx++)
+        {
+            header.append((char) field[idx]);
+        }
+        header.append('\n');
+
+        int x; double d;
+
+        x = PseudoBinary.decodePB(new String(field, 12, 2), false); // MM
+        header.append(I2.format(x)).append(' ');
+        x = PseudoBinary.decodePB(new String(field, 14, 2), false); // DD
+        header.append(I2.format(x)).append(' ');
+        x = PseudoBinary.decodePB(new String(field, 16, 2), false); // YYYY (upstream formatting)
+        header.append(I2.format(x)).append(' ');
+        x = PseudoBinary.decodePB(new String(field, 18, 2), false); // HR
+        header.append(I2.format(x)).append(' ');
+        x = PseudoBinary.decodePB(new String(field, 20, 2), false); // MN
+        header.append(I2.format(x)).append(' ');
+        x = PseudoBinary.decodePB(new String(field, 22, 2), false); // SS
+        header.append(I2.format(x)).append(' ');
+
+        x = PseudoBinary.decodePB(new String(field, 24, 3), false); // 8-digit binary #
+        header.append(I8.format(x)).append(' ');
+        x = PseudoBinary.decodePB(new String(field, 27, 3), false); // 8-digit binary #
+        header.append(I8.format(x)).append(' ');
+
+        d = PseudoBinary.decodePB(new String(field, 30, 2), false) * 0.1;
+        header.append(TextUtil.setLengthRightJustify(DP1.format(d), 5)).append(' ');
+        d = PseudoBinary.decodePB(new String(field, 32, 3), false) * 0.1;
+        header.append(TextUtil.setLengthRightJustify(DP1.format(d), 6)).append(' ');
+        d = PseudoBinary.decodePB(new String(field, 35, 2), false) * 0.1;
+        header.append(TextUtil.setLengthRightJustify(DP1.format(d), 5)).append(' ');
+        d = PseudoBinary.decodePB(new String(field, 37, 2), true) * 0.1;
+        header.append(TextUtil.setLengthRightJustify(DP1.format(d), 5)).append(' ');
+        d = PseudoBinary.decodePB(new String(field, 39, 2), true) * 0.1;
+        header.append(TextUtil.setLengthRightJustify(DP1.format(d), 5)).append(' ');
+        d = PseudoBinary.decodePB(new String(field, 41, 2), false) * 0.001;
+        header.append(TextUtil.setLengthRightJustify(DP3.format(d), 7)).append(' ');
+        d = PseudoBinary.decodePB(new String(field, 43, 2), false) * 0.01;
+        header.append(TextUtil.setLengthRightJustify(DP2.format(d), 6)).append(' ');
+
+        x = PseudoBinary.decodePB(new String(field, 45, 3), false);
+        header.append(TextUtil.setLengthRightJustify(I2.format(x), 5)).append(' ');
+        x = PseudoBinary.decodePB(new String(field, 48, 3), false);
+        header.append(TextUtil.setLengthRightJustify(I2.format(x), 5)).append('\n');
+        log.debug("Legacy Nortek header '" + header + "'");
+        return header.toString();
+    }
+
+    /** Nortek Legacy (CA) Body. */
+    public static String decodeLegacyBins(byte[] field)
+    {
+        StringBuilder result = new StringBuilder();
+        String strResult;
+
+        int fieldIndex;
+        for (fieldIndex = 52; fieldIndex < field.length - 1; fieldIndex++)
+        {
+            for (int i = 0; i < 6; i++)
+            {
+                if (fieldIndex > field.length - 2) {
+                    break;
+                }
+
+                String temp = "";
+                temp += (char) field[fieldIndex++];
+                temp += (char) field[fieldIndex++];
+
+                // First three values per bin are 3-byte pseudo-binary (only if a byte remains)
+                if ((i == 0 || i == 1 || i == 2) && fieldIndex < field.length - 1)
+                {
+                    temp += (char) field[fieldIndex++];
+                }
+
+                int number = PseudoBinary.decodePB(temp, true);
+                double dnum;
+                String pad = "";
+
+                if (i == 0 || i == 1 || i == 2)
+                {
+                    dnum = number * 0.001;
+                    strResult = D3.format(dnum);
+                    while (strResult.length() + pad.length() < 8) pad += " ";
+                }
+                else
+                {
+                    dnum = number;
+                    strResult = String.valueOf(dnum);
+                    if (strResult.equalsIgnoreCase("0.0")) strResult = "0.000";
+                    while (strResult.length() + pad.length() < 6) pad += " ";
+                }
+                result.append(pad).append(strResult);
+            }
+            result.append('\n');
+        }
+        return result.toString();
+    }
+
+    /** Nortek Gen-2 (CN) Header. */
+    public static String decodeGen2Header(byte[] field) throws FieldParseException
+    {
+        log.debug("Nortek Generation 2 field='" + new String(field) + "', len=" + field.length);
+        StringBuilder header = new StringBuilder();
+
+        // first 8 chars after signature (idx 3..10)
+        for (int idx = 3; idx < 11; idx++)
+        {
+            header.append((char) field[idx]);
+        }
+        header.append('\n');
+
+        int x;
+        x = PseudoBinary.decodePB(new String(field, 12, 1), false); // Instrument type
+        header.append(I1.format(x)).append(", ");
+        x = PseudoBinary.decodePB(new String(field, 13, 4), false); // Head ID
+        header.append(I6.format(x)).append(", ");
+        x = PseudoBinary.decodePB(new String(field, 17, 1), false); // No of beams
+        int beamNo = x;
+        header.append(I1.format(x)).append(", ");
+        x = PseudoBinary.decodePB(new String(field, 18, 2), false); // No of cells
+        header.append(I2.format(x)).append(", ");
+
+        double blankingDistance = PseudoBinary.decodePB(new String(field, 20, 2), false) * .01; // m
+        header.append(TextUtil.setLengthRightJustify(DP2.format(blankingDistance), 5)).append(", ");
+        double cellSize = PseudoBinary.decodePB(new String(field, 22, 2), false) * .01; // m
+        header.append(TextUtil.setLengthRightJustify(DP2.format(cellSize), 5)).append(", ");
+
+        x = PseudoBinary.decodePB(new String(field, 24, 1), false); // Coordinate System
+        header.append(I1.format(x)).append('\n');
+
+        x = PseudoBinary.decodePB(new String(field, 25, 3), false); // Date
+        header.append(I6.format(x)).append(", ");
+        x = PseudoBinary.decodePB(new String(field, 28, 3), false); // Time
+        header.append(I6.format(x)).append(", ");
+        x = PseudoBinary.decodePB(new String(field, 31, 3), false); // Error code
+        header.append(I6.format(x)).append(", ");
+
+        x = PseudoBinary.decodePB(new String(field, 34, 4), false); // Status code (hex reshape)
+        String y = Integer.toHexString(x);
+        String firstFour = y.length() >= 4 ? y.substring(0, 4) : String.format("%-4s", y).replace(' ', '0');
+        char lastChar = y.charAt(y.length() - 1);
+        y = (firstFour + "000" + lastChar).toUpperCase();
+        header.append(y).append(", ");
+
+        double d;
+        d = PseudoBinary.decodePB(new String(field, 38, 2), false) * .1;  // Battery Voltage
+        header.append(TextUtil.setLengthRightJustify(DP1.format(d), 4)).append(", ");
+        d = PseudoBinary.decodePB(new String(field, 40, 3), false) * .1;   // Sound Speed
+        header.append(TextUtil.setLengthRightJustify(DP1.format(d), 6)).append(", ");
+        d = PseudoBinary.decodePB(new String(field, 43, 2), false) * .01;  // Heading Std Dev
+        header.append(TextUtil.setLengthRightJustify(DP2.format(d), 5)).append(", ");
+        d = PseudoBinary.decodePB(new String(field, 45, 2), false) * .1;   // Heading
+        header.append(TextUtil.setLengthRightJustify(DP1.format(d), 5)).append(", ");
+        d = PseudoBinary.decodePB(new String(field, 47, 2), true) * .1;    // Pitch
+        header.append(TextUtil.setLengthRightJustify(DP1.format(d), 5)).append(", ");
+        d = PseudoBinary.decodePB(new String(field, 49, 2), false) * .01;  // Pitch Std Dev
+        header.append(TextUtil.setLengthRightJustify(DP2.format(d), 5)).append(", ");
+        d = PseudoBinary.decodePB(new String(field, 51, 2), true) * .1;    // Roll
+        header.append(TextUtil.setLengthRightJustify(DP1.format(d), 5)).append(", ");
+        d = PseudoBinary.decodePB(new String(field, 53, 2), false) * .01;  // Roll Std Dev
+        header.append(TextUtil.setLengthRightJustify(DP2.format(d), 5)).append(", ");
+        d = PseudoBinary.decodePB(new String(field, 55, 3), false) * .001; // Pressure
+        header.append(TextUtil.setLengthRightJustify(DP3.format(d), 7)).append(", ");
+        d = PseudoBinary.decodePB(new String(field, 58, 2), false) * .01;  // Pressure Std Dev
+        header.append(TextUtil.setLengthRightJustify(DP2.format(d), 5)).append(", ");
+        d = PseudoBinary.decodePB(new String(field, 60, 3), true) * .01;   // Temperature
+        header.append(TextUtil.setLengthRightJustify(DP2.format(d), 6)).append('\n');
+        log.debug("Nortek Generation 2 header '" + header + "'");
+        return header.toString();
+    }
+
+    /** Nortek Gen-2 (CN) Body. */
+    public static String decodeGen2Body(byte[] field) throws FieldParseException
+    {
+        // Read beams
+        int beamNo = PseudoBinary.decodePB(new String(field, 17, 1), false);
+
+        // Check for profile presence
+        if (field.length < 64)
+        {
+            throw new FieldParseException("No profile message in data");
+        }
+
+        // Find '+' marker and compute countProfile
+        int plusAt = -1;
+        for (int i = 64; i < field.length; i++)
+        {
+            if (field[i] == '+')
+            {
+                plusAt = i; break;
+            }
+        }
+        int countProfile = (plusAt - 64) / beamNo;
+        if (countProfile != 5 && countProfile != 7)
+        {
+            throw new FieldParseException("Cannot identify message type");
+        }
+
+        // Distances
+        double blankingDistance = PseudoBinary.decodePB(new String(field, 20, 2), false) * .01;
+        double cellSize         = PseudoBinary.decodePB(new String(field, 22, 2), false) * .01;
+
+        // Determine loopLimit from beamNo & countProfile
+        int loopLimit = 0;
+        if ((beamNo == 2 && countProfile == 7) || (beamNo == 3 && countProfile == 5))       loopLimit = 6;
+        else if (beamNo == 2 && countProfile == 5)                                          loopLimit = 4;
+        else if (beamNo == 3 && countProfile == 7)                                          loopLimit = 9;
+
+        StringBuilder result = new StringBuilder();
+        String strResult;
+        int fieldIndex;
+        int cellNumber = 1;
+
+        for (fieldIndex = 64; fieldIndex < field.length - 1; fieldIndex++)
+        {
+            result.append(String.format("%2d", cellNumber)).append(",");
+            result.append(" ").append(TextUtil.setLengthRightJustify(
+                    DP1.format(blankingDistance + cellSize * cellNumber++), 6)).append(",");
+
+            for (int i = 0; i < loopLimit; i++)
+            {
+                if (fieldIndex > field.length - 2) break;
+
+                String temp = "";
+                temp += (char) field[fieldIndex++];
+                temp += (char) field[fieldIndex++];
+                if (i < beamNo) temp += (char) field[fieldIndex++];
+
+                int number = (i <= beamNo - 1) ? PseudoBinary.decodePB(temp, true)
+                                               : PseudoBinary.decodePB(temp, false);
+
+                double dnum = (i <= beamNo - 1) ? number * 0.001
+                              : (i > beamNo - 1 && i <= 2 * beamNo - 1) ? number * 0.1
+                              : number;
+
+                // Format selection based on position and message type
+                if (i <= beamNo - 1)
+                {
+                    strResult = D3.format(dnum);
+                }
+                else if (i > beamNo - 1 && i <= 2 * beamNo - 1 && countProfile == 7)
+                {
+                    strResult = D1.format(dnum);
+                }
+                else if (countProfile == 7)
+                {
+                    strResult = String.valueOf((int) dnum);
+                }
+                else
+                {
+                    strResult = D1.format(dnum);
+                }
+
+                String pad = "";
+                int padLen = (i <= beamNo - 1) ? 10 : 8;
+                while (strResult.length() + pad.length() < padLen) pad += " ";
+
+                result.append(pad).append(strResult).append(',');
+            }
+
+            // replace trailing comma with newline
+            result.setLength(result.length() - 1);
+            result.append('\n');
+        }
+        return result.toString();
+    }
+}

--- a/java/opendcs/src/main/java/decodes/decoder/NosMessageDecoder.java
+++ b/java/opendcs/src/main/java/decodes/decoder/NosMessageDecoder.java
@@ -236,35 +236,32 @@ public final class NosMessageDecoder
         x = PseudoBinary.decodePB(new String(field, 31, 3), false); // Error code
         header.append(I6.format(x)).append(", ");
 
-        x = PseudoBinary.decodePB(new String(field, 34, 4), false); // Status code (hex reshape)
-        String y = Integer.toHexString(x);
-        String firstFour = y.length() >= 4 ? y.substring(0, 4) : String.format("%-4s", y).replace(' ', '0');
-        char lastChar = y.charAt(y.length() - 1);
-        y = (firstFour + "000" + lastChar).toUpperCase();
+        x = PseudoBinary.decodePB(new String(field, 34, 5), false); // Status code (hex reshape)
+        String y = String.format("%08X", x);
         header.append(y).append(", ");
 
         double d;
-        d = PseudoBinary.decodePB(new String(field, 38, 2), false) * .1;  // Battery Voltage
+        d = PseudoBinary.decodePB(new String(field, 39, 2), false) * .1;  // Battery Voltage
         header.append(TextUtil.setLengthRightJustify(DP1.format(d), 4)).append(", ");
-        d = PseudoBinary.decodePB(new String(field, 40, 3), false) * .1;   // Sound Speed
+        d = PseudoBinary.decodePB(new String(field, 41, 3), false) * .1;   // Sound Speed
         header.append(TextUtil.setLengthRightJustify(DP1.format(d), 6)).append(", ");
-        d = PseudoBinary.decodePB(new String(field, 43, 2), false) * .01;  // Heading Std Dev
+        d = PseudoBinary.decodePB(new String(field, 44, 2), false) * .01;  // Heading Std Dev
         header.append(TextUtil.setLengthRightJustify(DP2.format(d), 5)).append(", ");
-        d = PseudoBinary.decodePB(new String(field, 45, 2), false) * .1;   // Heading
+        d = PseudoBinary.decodePB(new String(field, 46, 2), false) * .1;   // Heading
         header.append(TextUtil.setLengthRightJustify(DP1.format(d), 5)).append(", ");
-        d = PseudoBinary.decodePB(new String(field, 47, 2), true) * .1;    // Pitch
+        d = PseudoBinary.decodePB(new String(field, 48, 2), true) * .1;    // Pitch
         header.append(TextUtil.setLengthRightJustify(DP1.format(d), 5)).append(", ");
-        d = PseudoBinary.decodePB(new String(field, 49, 2), false) * .01;  // Pitch Std Dev
+        d = PseudoBinary.decodePB(new String(field, 50, 2), false) * .01;  // Pitch Std Dev
         header.append(TextUtil.setLengthRightJustify(DP2.format(d), 5)).append(", ");
-        d = PseudoBinary.decodePB(new String(field, 51, 2), true) * .1;    // Roll
+        d = PseudoBinary.decodePB(new String(field, 52, 2), true) * .1;    // Roll
         header.append(TextUtil.setLengthRightJustify(DP1.format(d), 5)).append(", ");
-        d = PseudoBinary.decodePB(new String(field, 53, 2), false) * .01;  // Roll Std Dev
+        d = PseudoBinary.decodePB(new String(field, 54, 2), false) * .01;  // Roll Std Dev
         header.append(TextUtil.setLengthRightJustify(DP2.format(d), 5)).append(", ");
-        d = PseudoBinary.decodePB(new String(field, 55, 3), false) * .001; // Pressure
+        d = PseudoBinary.decodePB(new String(field, 56, 3), false) * .001; // Pressure
         header.append(TextUtil.setLengthRightJustify(DP3.format(d), 7)).append(", ");
-        d = PseudoBinary.decodePB(new String(field, 58, 2), false) * .01;  // Pressure Std Dev
+        d = PseudoBinary.decodePB(new String(field, 59, 2), false) * .01;  // Pressure Std Dev
         header.append(TextUtil.setLengthRightJustify(DP2.format(d), 5)).append(", ");
-        d = PseudoBinary.decodePB(new String(field, 60, 3), true) * .01;   // Temperature
+        d = PseudoBinary.decodePB(new String(field, 61, 3), true) * .01;   // Temperature
         header.append(TextUtil.setLengthRightJustify(DP2.format(d), 6)).append('\n');
         log.debug("Nortek Generation 2 header '" + header + "'");
         return header.toString();
@@ -273,25 +270,28 @@ public final class NosMessageDecoder
     /** Nortek Gen-2 (CN) Body. */
     public static String decodeGen2Body(byte[] field) throws FieldParseException
     {
+        // Index check
+        int indexCheck = 65;
+
         // Read beams
         int beamNo = PseudoBinary.decodePB(new String(field, 17, 1), false);
 
         // Check for profile presence
-        if (field.length < 64)
+        if (field.length < indexCheck)
         {
             throw new FieldParseException("No profile message in data");
         }
 
         // Find '+' marker and compute countProfile
         int plusAt = -1;
-        for (int i = 64; i < field.length; i++)
+        for (int i = indexCheck; i < field.length; i++)
         {
             if (field[i] == '+')
             {
                 plusAt = i; break;
             }
         }
-        int countProfile = (plusAt - 64) / beamNo;
+        int countProfile = (plusAt - indexCheck) / beamNo;
         if (countProfile != 5 && countProfile != 7)
         {
             throw new FieldParseException("Cannot identify message type");
@@ -302,17 +302,14 @@ public final class NosMessageDecoder
         double cellSize         = PseudoBinary.decodePB(new String(field, 22, 2), false) * .01;
 
         // Determine loopLimit from beamNo & countProfile
-        int loopLimit = 0;
-        if ((beamNo == 2 && countProfile == 7) || (beamNo == 3 && countProfile == 5))       loopLimit = 6;
-        else if (beamNo == 2 && countProfile == 5)                                          loopLimit = 4;
-        else if (beamNo == 3 && countProfile == 7)                                          loopLimit = 9;
+        int loopLimit = beamNo * (countProfile - 1) / 2;
 
         StringBuilder result = new StringBuilder();
         String strResult;
         int fieldIndex;
         int cellNumber = 1;
 
-        for (fieldIndex = 64; fieldIndex < field.length - 1; fieldIndex++)
+        for (fieldIndex = indexCheck; fieldIndex < field.length - 1; fieldIndex++)
         {
             result.append(String.format("%2d", cellNumber)).append(",");
             result.append(" ").append(TextUtil.setLengthRightJustify(


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #. NOS Air Gap sensor decoding update #1813

<!-- if you are referencing a specific issue a problem description is not required -->

The existing Nos6Min.java expects primary Air Gap sensor raw data to have both AQT1 and AQT2 readings. In fact, the AQT1 and AQT2 (air temperature) values have never been used, and will be no longer provided with new Air Gap sensors. 

## Solution

Update Nos6Min.java to not read AQT1 and AQT2 (air temperature), and set them to undefined in the decoded data

## how you tested the change

NOS integrated the fix in a 7.0 OPENDCS built and deployed the opendcs.jar to a development server. The new opendcs.jar can decode Air Gap raw data with or without AQT1 and AQT2 readings.

Sample raw data, decoded data, and decodescript are included in the issue report (https://github.com/opendcs/opendcs/issues/1813)

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
