### PR TITLE
Improve sonar.yaml flow for fork PRs, now working on coverage.

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -9,6 +9,29 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run && github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: 'Get PR number'
+        id: pr-context
+        env:
+          # The GH CLI uses this ENV for providing an auth token:
+          GH_TOKEN: ${{ github.token }}
+          PR_TARGET_REPO: ${{ github.repository }}
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
+        # Query the PR number by repo + branch, then assign to step output:
+        run: |
+          gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" --json 'number' --jq '"number=\(.number)"' >> "${GITHUB_OUTPUT}"
+          echo "source_branch=${PR_BRANCH}" >> ${GITHUB_OUTPUT}
+          base_ref=`gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" --json 'baseRefName' --jq '(.baseRefName)'`
+          if [[ "${base_ref}" =~ (main|7.0) ]]; then
+            echo "target_branch=${base_ref}" >> ${GITHUB_OUTPUT}
+          else
+            echo "PR is targetting an invalid branch"
+            exit 1
+          fi
       - name: Set up JDK
         uses: actions/setup-java@v5.2.0
         with:
@@ -19,12 +42,27 @@ jobs:
           python-version: "3.8"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5.0.1
-      - name: Checkout PR
+      - name: Checkout base code (for build tasks)
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ steps.pr-context.outputs.target_branch }}
+          fetch-depth: 1
+      - name: Checkout PR code
         uses: actions/checkout@v6.0.2
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
+          path:
+            source_branch_code
+          
+      - name: Copy only source/gh
+        run: |
+          shopt -s globstar
+          mv .github .github.orig
+          mv source_branch_code/.github ./.github
+          cp -r source_branch_code/java/**/src ./
+
     # perform the analaysis now
       - name: Cache SonarCloud packages
         uses: actions/cache@v5.0.3
@@ -53,8 +91,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-         ./gradlew sonar --info -Dorg.gradle.jvmargs=-Xmx4096M \
+          ./gradlew sonar --info -Dorg.gradle.jvmargs=-Xmx4096M \
             -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
-            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }} \
-            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }} \
-            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+            -Dsonar.pullrequest.key=${{ steps.pr-context.outputs.number }} \
+            -Dsonar.pullrequest.branch=${{ steps.pr-context.outputs.source_branch }} \
+            -Dsonar.pullrequest.base=${{ steps.pr-context.outputs.target_branch }}

--- a/buildSrc/src/main/groovy/opendcs.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/opendcs.java-conventions.gradle
@@ -51,6 +51,8 @@ jacocoTestReport {
     reports {
         xml.required = true
     }
+    
+    sourceDirectories.setFrom(sourceSets.main.java.srcDirs)
 }
 
 checkstyle {

--- a/event.json
+++ b/event.json
@@ -1,0 +1,22 @@
+{
+	"workflow_run": {
+		"repository": {
+			"owner": {
+				"login": "opendcs"
+			}
+		},
+		"head": {
+			"ref": "main"
+		},
+		"id": 23202544017,
+		"head_branch": "feature/web_computation_execution",
+		"head_repository": {
+			"full_name": "zack-rma/opendcs",
+			"owner": {
+				"login": "zack-rma"
+			}
+		},
+		"head_sha": "d54024502d0f3615aa0de6c3d888a7a9ae81258b",
+		"conclusion": "success"
+	}
+}

--- a/integrationtesting/opendcs-tests/build.gradle
+++ b/integrationtesting/opendcs-tests/build.gradle
@@ -181,6 +181,9 @@ testEngines.each { engine ->
         }
 
 
+        sourceDirectories.from(project(":opendcs").sourceSets.main.java.srcDirs)
+        sourceDirectories.from(project(":opendcs-rest-api").sourceSets.main.java.srcDirs)
+        sourceDirectories.from(project(":opendcs-api").sourceSets.main.java.srcDirs)
 
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: commonJacocoExcludes)


### PR DESCRIPTION
## Problem Description

Operation and Safety improvement to sonar cloud flows.

PRs from works did not have the required information provide to sonar and thus the analysis never ran/showed correctly.

## Solution

Alter how the PR information is retrieved.
Only retrieve java files from the PR as we don't want an altered build to extra any info.

## how you tested the change

Tested locally with nektos/act. Sonar was submitted successfully, the code coverage is was still misbehaving; however, I'm not sure if that was a test environment issue or something else.

Will merge this in, have @zack-rma rebase #1680 and see what happens and go from there.


## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
