### PR TITLE
Add the always after method to close resources in a finally block (#1…

### DIFF
--- a/docs/source/dev-docs.rst
+++ b/docs/source/dev-docs.rst
@@ -598,6 +598,81 @@ Algorithms
 ~~~~~~~~~~
 - **Purpose**: This section describes how to test algorithmic implementations for solving specific problems or performing computations.
 
+Algorithm Lifecycle
+~~~~~~~~~~~~~~~~~~~
+
+Custom algorithms extend ``AW_AlgorithmBase`` and override lifecycle methods that the
+computation framework calls in a specific order. Understanding this lifecycle is essential
+for correct resource management and error handling.
+
+.. code-block:: text
+
+   try {
+       beforeAllTimeSlices()          — one-time setup (open DAOs, load ratings)
+
+       For AGGREGATING algorithms, for each aggregate period:
+           beforeTimeSlices()         — per-period setup
+           for each time slice:
+               doAWTimeSlice()        — core computation (exceptions caught per-slice)
+           afterTimeSlices()          — per-period finalization
+
+       For TIME_SLICE algorithms:
+           beforeTimeSlices()         — called once
+           for each time slice:
+               doAWTimeSlice()        — core computation (exceptions caught per-slice)
+           afterTimeSlices()          — called once
+
+       afterAllTimeSlices()           — one-time finalization (save results)
+   } finally {
+       alwaysAfterTimeSlices()        — guaranteed cleanup (release resources)
+   }
+
+**Key methods:**
+
+- ``beforeAllTimeSlices()`` — Called once before any time slices are processed. Use this
+  to acquire resources such as database connections and DAOs.
+
+- ``beforeTimeSlices()`` — Called before each group of time slices. For aggregating
+  algorithms, this is called once per aggregate period. Use for per-period initialization.
+
+- ``doAWTimeSlice()`` — Called for each individual time slice. Exceptions thrown here
+  (``DbCompException``) are caught per-slice — a single failed slice does not abort the
+  entire period.
+
+- ``afterTimeSlices()`` — Called after each group of time slices. For aggregating
+  algorithms, this is called once per aggregate period. Use for per-period output
+  (e.g., daily totals). Exceptions here abort the computation.
+
+- ``afterAllTimeSlices()`` — Called once after all periods complete successfully. Use
+  for final output operations (e.g., saving accumulated profiles). Do **not** release
+  resources here — an exception earlier in the lifecycle will skip this method.
+
+- ``alwaysAfterTimeSlices()`` — Called in a ``finally`` block, guaranteed to run
+  regardless of whether an exception occurred. Use this to release all resources
+  acquired in ``beforeAllTimeSlices()`` (connections, DAOs, etc.). Always include
+  null checks since ``beforeAllTimeSlices()`` may have failed partway through.
+
+**Resource management example:**
+
+.. code-block:: java
+
+   public void beforeAllTimeSlices() throws DbCompException {
+       myDAO = tsdb.makeTimeSeriesDAO();
+       conn = tsdb.getConnection();
+       // ... load data ...
+   }
+
+   public void afterAllTimeSlices() throws DbCompException {
+       // Save results — only runs on success
+       myProfiles.save(myDAO);
+   }
+
+   public void alwaysAfterTimeSlices() {
+       // Release resources — always runs, even on failure
+       if (conn != null) tsdb.freeConnection(conn);
+       if (myDAO != null) myDAO.close();
+   }
+
 Adding Tests for Algorithms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 To add new tests for algorithms, developers need to create a new directory within `./opendcs/integrationtesting/opendcs-tests/src/test/resources/data/Comps`. This folder must be titled with the name of the algorithm you wish to test.

--- a/java/opendcs/src/main/java/decodes/cwms/algo/ResEvapAlgo.java
+++ b/java/opendcs/src/main/java/decodes/cwms/algo/ResEvapAlgo.java
@@ -456,11 +456,33 @@ final public class ResEvapAlgo
                 //If missing data overwrite with site info
                 if (longitude == 0)
                 {
-                    longitude = Double.parseDouble(site.longitude);
+                    if (site.longitude == null)
+                    {
+                        throw new DbCompException("Longitude property is 0 and site '" + reservoirId + "' has no longitude defined");
+                    }
+                    try
+                    {
+                        longitude = Double.parseDouble(site.longitude);
+                    }
+                    catch (NumberFormatException ex)
+                    {
+                        throw new DbCompException("Cannot parse longitude '" + site.longitude + "' for site '" + reservoirId + "'", ex);
+                    }
                 }
                 if (latitude == 0)
                 {
-                    latitude = Double.parseDouble(site.latitude);
+                    if (site.latitude == null)
+                    {
+                        throw new DbCompException("Latitude property is 0 and site '" + reservoirId + "' has no latitude defined");
+                    }
+                    try
+                    {
+                        latitude = Double.parseDouble(site.latitude);
+                    }
+                    catch (NumberFormatException ex)
+                    {
+                        throw new DbCompException("Cannot parse latitude '" + site.latitude + "' for site '" + reservoirId + "'", ex);
+                    }
                 }
 
                 //initialize output timeseries
@@ -613,7 +635,7 @@ final public class ResEvapAlgo
             {
                 successful = resEvap.compute(_timeSliceBaseTime, 0.0, conn);
             }
-            catch (ResEvapException ex)
+            catch (DbCompException ex)
             {
                 throw new DbCompException("ResEvap Compute Not Successful. Exiting Script.", ex);
             }
@@ -706,7 +728,14 @@ final public class ResEvapAlgo
             setOutput(dailyEvapDepth, dailyEvapMM, _timeSliceBaseTime);
             setOutput(dailyEvapAsFlow, dailyEvapFlowCms, _timeSliceBaseTime);
 
-            dailyWTP.append(hourlyWTP, _timeSliceBaseTime, timeSeriesDAO);
+            try
+            {
+                dailyWTP.append(hourlyWTP, _timeSliceBaseTime, timeSeriesDAO);
+            }
+            catch (RuntimeException ex)
+            {
+                throw new DbCompException("Failed to append hourly water temperature profiles", ex);
+            }
         }
         else
         {
@@ -730,11 +759,25 @@ final public class ResEvapAlgo
         {
             throw new DbCompException("Failed to save water temperature profiles", ex);
         }
-        finally
+    }
+
+    @Override
+    public void alwaysAfterTimeSlices()
+    {
+        if (conn != null)
         {
             tsdb.freeConnection(conn);
+        }
+        if (crd != null)
+        {
             crd.close();
+        }
+        if (siteDAO != null)
+        {
             siteDAO.close();
+        }
+        if (timeSeriesDAO != null)
+        {
             timeSeriesDAO.close();
         }
     }

--- a/java/opendcs/src/main/java/decodes/tsdb/algo/AW_AlgorithmBase.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/algo/AW_AlgorithmBase.java
@@ -50,9 +50,52 @@ import decodes.cwms.CwmsFlags;
 import decodes.hdb.HdbFlags;
 
 /**
-This is the base class of Algorithms built and maintained by the Algorithm
-Wizard (AW)
-*/
+ * Base class for algorithms built and maintained by the Algorithm Wizard (AW).
+ * <p>
+ * <h3>Algorithm Lifecycle</h3>
+ * The computation framework calls lifecycle methods in the following order:
+ * <pre>
+ * try {
+ *     {@link #beforeAllTimeSlices()}          — one-time setup (open resources, load data)
+ *
+ *     For AGGREGATING / RUNNING_AGGREGATE algorithms:
+ *         for each aggregate period:
+ *             {@link #beforeTimeSlices()}      — per-period setup
+ *             for each time slice:
+ *                 {@link #doAWTimeSlice()}     — core computation (caught individually)
+ *             {@link #afterTimeSlices()}       — per-period finalization
+ *
+ *     For TIME_SLICE algorithms:
+ *         {@link #beforeTimeSlices()}          — called once before all slices
+ *         for each time slice:
+ *             {@link #doAWTimeSlice()}         — core computation (caught individually)
+ *         {@link #afterTimeSlices()}           — called once after all slices
+ *
+ *     {@link #afterAllTimeSlices()}            — one-time finalization (save results)
+ * } finally {
+ *     {@link #alwaysAfterTimeSlices()}         — guaranteed cleanup (release resources)
+ * }
+ * </pre>
+ * <h3>Resource Management</h3>
+ * Algorithms that acquire resources (database connections, DAOs, etc.) in
+ * {@code beforeAllTimeSlices()} must release them in
+ * {@link #alwaysAfterTimeSlices()}, NOT in {@code afterAllTimeSlices()}.
+ * The {@code alwaysAfterTimeSlices()} method runs in a {@code finally}
+ * block, guaranteeing cleanup even when exceptions occur during computation.
+ * Use {@code afterAllTimeSlices()} only for work that should happen on
+ * successful completion (e.g., saving output profiles).
+ * <p>
+ * <h3>Exception Handling</h3>
+ * <ul>
+ *   <li>{@code doAWTimeSlice()} exceptions ({@link DbCompException}) are caught
+ *       per-timeslice — a single slice failure does not abort the period.</li>
+ *   <li>{@code beforeTimeSlices()} and {@code afterTimeSlices()} exceptions
+ *       are NOT caught per-period — they abort the entire computation.</li>
+ *   <li>{@code RuntimeException} from any method is caught by
+ *       {@code applyAlgorithm()} and re-thrown as {@link DbCompException}.</li>
+ *   <li>In all cases, {@code alwaysAfterTimeSlices()} is guaranteed to run.</li>
+ * </ul>
+ */
 public abstract class AW_AlgorithmBase extends DbAlgorithmExecutive implements PropertiesOwner
 {
 	private static final Logger log = OpenDcsLoggerFactory.getLogger();
@@ -426,12 +469,32 @@ public abstract class AW_AlgorithmBase extends DbAlgorithmExecutive implements P
 		{
 			throw new DbCompException("RunTime Error: "+ex+"\nAt: "+ex.getStackTrace()[0].toString(), ex);
 		}
+		finally
+		{
+			alwaysAfterTimeSlices();
+		}
 	}
 
 	public void afterAllTimeSlices()
 		throws DbCompException
 	{
 		// Nothing to do here.
+	}
+
+	/**
+	 * Called in a finally block after applyAlgorithm completes, regardless
+	 * of whether an exception occurred. Use this method to release resources
+	 * (database connections, DAOs, etc.) that were acquired in
+	 * {@link #beforeAllTimeSlices()}.
+	 * <p>
+	 * Unlike {@link #afterAllTimeSlices()}, this method is guaranteed to
+	 * run even when exceptions occur during computation. Algorithms that
+	 * open resources in beforeAllTimeSlices should override this method
+	 * to ensure those resources are always released.
+	 */
+	public void alwaysAfterTimeSlices()
+	{
+		// Nothing to do here. Subclasses override to release resources.
 	}
 
 	public void beforeAllTimeSlices()

--- a/java/opendcs/src/main/java/decodes/tsdb/algo/AW_AlgorithmTemplate.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/algo/AW_AlgorithmTemplate.java
@@ -107,6 +107,36 @@ public class AW_AlgorithmTemplate extends AW_AlgorithmBase
 	}
 
 	/**
+	 * Called once after all aggregate periods (or all time slices) complete
+	 * successfully. Use for saving final results. Do NOT release resources
+	 * here — use alwaysAfterTimeSlices() instead.
+	 */
+	public void afterAllTimeSlices()
+		throws DbCompException
+	{
+		// Example: save accumulated output profiles
+	}
+
+	/**
+	 * Called in a finally block — guaranteed to run even if an exception
+	 * occurred during computation. Use this to release any resources
+	 * (database connections, DAOs, etc.) that were acquired in
+	 * beforeAllTimeSlices().
+	 *
+	 * Example:
+	 * <pre>
+	 *     public void alwaysAfterTimeSlices() {
+	 *         if (conn != null) tsdb.freeConnection(conn);
+	 *         if (myDAO != null) myDAO.close();
+	 *     }
+	 * </pre>
+	 */
+	public void alwaysAfterTimeSlices()
+	{
+		// Release resources here. This runs even on failure.
+	}
+
+	/**
 	 * Required method returns a list of all input time series names.
 	 */
 	public String[] getInputNames()


### PR DESCRIPTION
Add always after block to 7.0 to make sure resources are always closed after an exception.


## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
