### PR TITLE
Refactor/comp operations

### DIFF
--- a/java/opendcs/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
@@ -1154,58 +1154,60 @@ public class CwmsTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 
         // Each TSID will need a site, so prefill the site cache to prevent
         // it from doing individual reads for each site.
-
-        String q = cwmsTsidQueryBase + " WHERE upper(a.DB_OFFICE_ID) = upper(?)";
-        int origFetchSize = getFetchSize();
-        try
+        synchronized(CwmsTimeSeriesDAO.class)
         {
-            int tsidFetchSize = DecodesSettings.instance().tsidFetchSize;
-            if (tsidFetchSize > 0)
+            String q = cwmsTsidQueryBase + " WHERE upper(a.DB_OFFICE_ID) = upper(?)";
+            int origFetchSize = getFetchSize();
+            try
             {
-                setFetchSize(tsidFetchSize);
+                int tsidFetchSize = DecodesSettings.instance().tsidFetchSize;
+                if (tsidFetchSize > 0)
+                {
+                    setFetchSize(tsidFetchSize);
+                }
+
+
+                List<TimeSeriesIdentifier> tsidList = getResultsIgnoringNull(q, rs ->
+                {
+                    CwmsTsId retVal = null;
+                    try
+                    {
+                        retVal = rs2TsId(rs, false);
+                    }
+                    catch (DbIoException | NoSuchObjectException ex)
+                    {
+                        log.atWarn()
+                        .setCause(ex)
+                        .log("Error creating Cwms TSID -- skipped.");
+                    }
+                    return retVal;
+                }, dbOfficeId);
+
+                synchronized(cache)
+                {
+                    cache.clear();
+                    for(TimeSeriesIdentifier tsid: tsidList)
+                    {
+                        cache.put(tsid);
+                    }
+                }
+
+                log.debug("After fill, cache has {} TSIDs.", cache.size());
             }
-
-
-            List<TimeSeriesIdentifier> tsidList = getResultsIgnoringNull(q, rs ->
+            catch (SQLException ex)
             {
-                CwmsTsId retVal = null;
-                try
-                {
-                    retVal = rs2TsId(rs, false);
-                }
-                catch (DbIoException | NoSuchObjectException ex)
-                {
-                    log.atWarn()
-                       .setCause(ex)
-                       .log("Error creating Cwms TSID -- skipped.");
-                }
-                return retVal;
-            }, dbOfficeId);
-
-            synchronized(cache)
-            {
-                cache.clear();
-                for(TimeSeriesIdentifier tsid: tsidList)
-                {
-                    cache.put(tsid);
-                }
+                final String msg = "Failed to reload CwmsTimeSeriesDb TsId Cache.";
+                log.atError()
+                .setCause(ex)
+                .log(msg);
+                throw new DbIoException(msg, ex);
             }
-
-            log.debug("After fill, cache has {} TSIDs.", cache.size());
+            finally
+            {
+                setFetchSize(origFetchSize);
+            }
+            lastCacheReload = System.currentTimeMillis();
         }
-        catch (SQLException ex)
-        {
-            final String msg = "Failed to reload CwmsTimeSeriesDb TsId Cache.";
-            log.atError()
-               .setCause(ex)
-               .log(msg);
-            throw new DbIoException(msg, ex);
-        }
-        finally
-        {
-            setFetchSize(origFetchSize);
-        }
-        lastCacheReload = System.currentTimeMillis();
     }
 
     @Override

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
@@ -1,16 +1,16 @@
 /*
 * Where Applicable, Copyright 2025 OpenDCS Consortium and/or its contributors
-* 
+*
 * Licensed under the Apache License, Version 2.0 (the "License"); you may not
 * use this file except in compliance with the License. You may obtain a copy
 * of the License at
-* 
+*
 *   http://www.apache.org/licenses/LICENSE-2.0
-* 
-* Unless required by applicable law or agreed to in writing, software 
+*
+* Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations 
+* License for the specific language governing permissions and limitations
 * under the License.
 */
 package decodes.cwms;
@@ -40,7 +40,6 @@ import org.opendcs.utils.FailableResult;
 import org.opendcs.utils.logging.MDCTimer;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import decodes.db.Constants;
 import decodes.db.DataType;
@@ -165,7 +164,7 @@ public class CwmsTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
         {
             return ExceptionHelpers.throwDbIoNoSuchObject(ret.getFailure());
         }
-        
+
     }
 
     private CwmsTsId rs2TsId(ResultSet rs, boolean createDataType)
@@ -285,14 +284,14 @@ public class CwmsTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
                 new NoSuchObjectException("No timeseries with name '"+uniqueString+"' is defined in this database.")
             );
         }
-        
+
         FailableResult<TimeSeriesIdentifier,TsdbException> tmp = findTimeSeriesIdentifier(ts_code);
         if (tmp.isSuccess())
         {
             if (displayName != null)
             {
                 tmp.getSuccess().setDisplayName(displayName);
-            }        
+            }
         }
         return tmp;
     }
@@ -1183,13 +1182,11 @@ public class CwmsTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
                     return retVal;
                 }, dbOfficeId);
 
-                synchronized(cache)
+
+                cache.clear();
+                for(TimeSeriesIdentifier tsid: tsidList)
                 {
-                    cache.clear();
-                    for(TimeSeriesIdentifier tsid: tsidList)
-                    {
-                        cache.put(tsid);
-                    }
+                    cache.put(tsid);
                 }
 
                 log.debug("After fill, cache has {} TSIDs.", cache.size());

--- a/java/opendcs/src/main/java/decodes/hdb/HdbTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/decodes/hdb/HdbTimeSeriesDAO.java
@@ -1052,38 +1052,41 @@ public class HdbTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 	@Override
 	public synchronized void reloadTsIdCache() throws DbIoException
 	{
-		// Each TSID will need a site, so prefill the site cache to prevent
-		// it from doing individual reads for each site.
-		if (System.currentTimeMillis() - siteDAO.getLastCacheFillMsec() > 60000L * 10)
-			siteDAO.fillCache();
-
-		String q = tsidQuery + tsidJoinClause;
-
-		// MJM 2016/1/8 Added this block of code to minimize reloading the entire cache.
-		boolean doFullLoad = System.currentTimeMillis() - lastCacheLoad > CACHE_RELOAD_INTERVAL;
-		log.trace("reloadTsIdCache doFullLoad={}, lastCacheLoad={}, lastCacheRefresh={}",
-				  doFullLoad, new Date(lastCacheLoad), new Date(lastCacheRefresh));
-		if (!doFullLoad)
-			q = q + " and a.date_time_loaded > "
-				  + db.sqlDate(new Date(lastCacheRefresh-CACHE_REFRESH_OVERLAP));
-		lastCacheRefresh = System.currentTimeMillis();
-		if (doFullLoad)
-			lastCacheLoad = lastCacheRefresh;
-
-		try(ResultSet rs = doQuery(q))
+		synchronized(HdbTimeSeriesDAO.class)
 		{
-			while (rs.next())
+			// Each TSID will need a site, so prefill the site cache to prevent
+			// it from doing individual reads for each site.
+			if (System.currentTimeMillis() - siteDAO.getLastCacheFillMsec() > 60000L * 10)
+				siteDAO.fillCache();
+
+			String q = tsidQuery + tsidJoinClause;
+
+			// MJM 2016/1/8 Added this block of code to minimize reloading the entire cache.
+			boolean doFullLoad = System.currentTimeMillis() - lastCacheLoad > CACHE_RELOAD_INTERVAL;
+			log.trace("reloadTsIdCache doFullLoad={}, lastCacheLoad={}, lastCacheRefresh={}",
+					doFullLoad, new Date(lastCacheLoad), new Date(lastCacheRefresh));
+			if (!doFullLoad)
+				q = q + " and a.date_time_loaded > "
+					+ db.sqlDate(new Date(lastCacheRefresh-CACHE_REFRESH_OVERLAP));
+			lastCacheRefresh = System.currentTimeMillis();
+			if (doFullLoad)
+				lastCacheLoad = lastCacheRefresh;
+
+			try(ResultSet rs = doQuery(q))
 			{
-				try { cache.put(rs2TsId(rs)); }
-				catch(NoSuchObjectException ex)
+				while (rs.next())
 				{
-					// do nothing, warning already issued from rs2TsId
+					try { cache.put(rs2TsId(rs)); }
+					catch(NoSuchObjectException ex)
+					{
+						// do nothing, warning already issued from rs2TsId
+					}
 				}
 			}
-		}
-		catch(Exception ex)
-		{
-			throw new DbIoException("HdbTimeSeriesDAO: Error listing time series", ex);
+			catch(Exception ex)
+			{
+				throw new DbIoException("HdbTimeSeriesDAO: Error listing time series", ex);
+			}
 		}
 	}
 

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
@@ -383,9 +383,10 @@ public class ComputationApp extends TsdbAppTemplate
 								{
 									try
 									{
+										log.info("Saving {} values for {}", ts.size(), ts.getNameString());
 										timeSeriesDAO.saveTimeSeries(ts);
 									}
-									catch (Exception ex)
+									catch (DbIoException | BadTimeSeriesException ex)
 									{
 										log.atWarn()
 										.setCause(ex)

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
@@ -372,26 +372,34 @@ public class ComputationApp extends TsdbAppTemplate
 						action = "Applying computations";
 						ComputationExecution execution = new ComputationExecution(db);
 
-						ComputationExecution.CompResults results = execution.execute(List.of(comps), dataCollection);
+						ComputationExecution.CompResults results = execution.execute(List.of(comps), dataCollection,
+						dc ->
+						{
+							List<CTimeSeries> tsList = dc.getAllTimeSeries();
+							log.trace("Saving results for {} time series in data.", tsList.size());
+							try (var allTsTimer = MDCTimer.startTimer("saving results"))
+							{
+								for(CTimeSeries ts : tsList)
+								{
+									try
+									{
+										timeSeriesDAO.saveTimeSeries(ts);
+									}
+									catch (Exception ex)
+									{
+										log.atWarn()
+										.setCause(ex)
+										.log("Cannot save time series '{}'", ts.getNameString());
+									}
+								}
+							}
+							return dc;
+						});
 						compsTried += results.computesTried();
 						compErrors += results.numErrors();
 
-						action = "Saving results";
-						List<CTimeSeries> tsList = dataCollection.getAllTimeSeries();
-						log.trace("{} {} time series in data.", action, tsList.size());
-						try (var allTsTimer = MDCTimer.startTimer(action))
-						{
-							for(CTimeSeries ts : tsList)
-							{
-								try { timeSeriesDAO.saveTimeSeries(ts); }
-								catch(Exception ex)
-								{
-									log.atWarn()
-									.setCause(ex)
-									.log("Cannot save time series '{}'", ts.getNameString());
-								}
-							}
-						}
+
+
 
 						action = "Releasing new data";
 						try (var dataReleaseTimer = MDCTimer.startTimer(action))

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import ilex.var.TimedVariable;
@@ -31,14 +32,14 @@ import org.opendcs.utils.logging.MDCTimer;
 import org.slf4j.MDC;
 import org.slf4j.event.Level;
 
-import static org.opendcs.utils.logging.ThreadUtils.propegate;
+import static org.opendcs.utils.logging.ThreadUtils.propagate;
 
 public final class ComputationExecution
 {
 	private static final String COMPUTATION_KEY = "computation";
 	private final OpenDcsDatabase db;
-	private int numErrors = 0;
-	private int computesTried = 0;
+	private AtomicInteger numErrors = new AtomicInteger(0);
+	private AtomicInteger computesTried = new AtomicInteger(0);
 	private final ExecutorService executor;
 
 	/**
@@ -169,7 +170,7 @@ public final class ComputationExecution
 		for(DbComputation comp : toRun)
 		{
 			var future = CompletableFuture.supplyAsync(
-				propegate(() ->
+				propagate(() ->
 				{
 					DataCollection ret = new DataCollection();
 					try (var mdcComputation = MDC.putCloseable(COMPUTATION_KEY, comp.getName());
@@ -177,14 +178,14 @@ public final class ComputationExecution
 					{
 						listener.onProgress(String.format("Executing computation '%s' #trigs=%d",
 								comp.getName(), comp.getTriggeringRecNums().size()), Level.DEBUG, null);
-						computesTried++;
+						computesTried.incrementAndGet();
 						boolean ignoreTimeWindow = start == null && end == null;
 						ret = executeSingleComp(comp, start, end, theData, ignoreTimeWindow, listener);
 					}
 					catch(DbIoException ex)
 					{
 						listener.onProgress(String.format("Computation '%s' failed.", comp.getName()), Level.WARN, ex);
-						numErrors++;
+						numErrors.incrementAndGet();
 						for (Integer rn : comp.getTriggeringRecNums())
 						{
 							theData.getTasklistHandle().markComputationFailed(rn);
@@ -193,7 +194,7 @@ public final class ComputationExecution
 					catch (Exception ex)
 					{
 						listener.onProgress(String.format("Unexpected error in computation %s", comp.getName()), Level.WARN, ex);
-						numErrors++;
+						numErrors.incrementAndGet();
 						for(Integer rn : comp.getTriggeringRecNums())
 						{
 							theData.getTasklistHandle().markComputationFailed(rn);
@@ -215,7 +216,7 @@ public final class ComputationExecution
 			comps.add(future);
 		}
 		CompletableFuture.allOf(comps.toArray(new CompletableFuture[0])).join();
-		return new CompResults(numErrors, computesTried);
+		return new CompResults(numErrors.get(), computesTried.get());
 	}
 
 	/**
@@ -254,7 +255,7 @@ public final class ComputationExecution
 				catch(Exception ex)
 				{
 					listener.onProgress("Error fetching input data.", Level.WARN, ex);
-					numErrors++;
+					numErrors.incrementAndGet();
 				}
 			}
 		}
@@ -262,12 +263,12 @@ public final class ComputationExecution
 		{
 			listener.onProgress("Unexpected error fetching input data.", Level.WARN, ex);
 		}
-		computesTried++;
+		computesTried.incrementAndGet();
 		try (var mdcComputation = MDC.putCloseable(COMPUTATION_KEY, computation.getName()))
 		{
 			executeSingleComp(computation, start, end, theData, false, listener);
 		}
-		return new CompResults(numErrors, computesTried);
+		return new CompResults(numErrors.get(), computesTried.get());
 	}
 
 	/**
@@ -343,7 +344,7 @@ public final class ComputationExecution
 								{
 									// Should not happen! We checked first.
 									listener.onProgress("Unexpected duplicate time series.", Level.ERROR, ex);
-									numErrors++;
+									numErrors.incrementAndGet();
 								}
 							}
 						}
@@ -356,7 +357,7 @@ public final class ComputationExecution
 			catch(DbCompException ex)
 			{
 				listener.onProgress(String.format("Cannot initialize computation '%s'", comp.getName()), Level.WARN, ex);
-				numErrors++;
+				numErrors.incrementAndGet();
 				for (Integer rn : comp.getTriggeringRecNums())
 				{
 					dataCollection.getTasklistHandle().markComputationFailed(rn);
@@ -371,7 +372,7 @@ public final class ComputationExecution
 				else
 					msg = msg + " -- TSID '" + parmRef.tsid.getUniqueString() + "' does not exist in db.";
 				listener.onProgress(msg, Level.WARN, ex);
-				numErrors++;
+				numErrors.incrementAndGet();
 			}
 		}
 		catch (Exception ex)

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
@@ -15,9 +15,14 @@
 
 package decodes.tsdb;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
 
 import ilex.var.TimedVariable;
 import opendcs.dai.TimeSeriesDAI;
@@ -26,16 +31,39 @@ import org.opendcs.utils.logging.MDCTimer;
 import org.slf4j.MDC;
 import org.slf4j.event.Level;
 
+import static org.opendcs.utils.logging.ThreadUtils.propegate;
+
 public final class ComputationExecution
 {
 	private static final String COMPUTATION_KEY = "computation";
 	private final OpenDcsDatabase db;
 	private int numErrors = 0;
 	private int computesTried = 0;
+	private final ExecutorService executor;
 
+	/**
+	 * Create instance of ComputationExecution using a new SingleThreadExeuctor
+	 * @param db
+	 */
 	public ComputationExecution(OpenDcsDatabase db)
 	{
+		this(db, Executors.newSingleThreadExecutor());
+	}
+
+
+	/**
+	 * Create instance of ComputationExecution using provided ExecutorService.
+	 *
+	 * NOTE: at this time we do not think the operations of DbComputation.apply are thread save.
+	 * This is being initially setup to provided chaining operations and too allow for that
+	 * follow on work.
+	 * @param db
+	 * @param executor
+	 */
+	public ComputationExecution(OpenDcsDatabase db, ExecutorService executor)
+	{
 		this.db = db;
+		this.executor = executor;
 	}
 
 	/**
@@ -54,54 +82,152 @@ public final class ComputationExecution
 		return tsdb;
 	}
 
+
+	/**
+	 * Execute computations with given input data.
+	 *
+	 * @param toRun
+	 * @param theData
+	 * @return
+	 */
 	public CompResults execute(List<DbComputation> toRun, DataCollection theData)
 	{
-		return execute(toRun, theData, null, null);
+		return execute(toRun, theData, null, null, dc -> dc);
 	}
 
+	/**
+	 * Execute computations with the given input data, after each computation run the afterComp handler
+	 * which recieves only the output timeseries for processing.
+	 * @param toRun
+	 * @param theData
+	 * @param afterComp
+	 * @return
+	 */
+	public CompResults execute(List<DbComputation> toRun, DataCollection theData, Function<DataCollection, DataCollection> afterComp)
+	{
+		return execute(toRun, theData, null, null, afterComp);
+	}
+
+	/**
+	 * Run computations using given data and date range, using default pass through afterComp handler
+	 * @param toRun
+	 * @param theData
+	 * @param start
+	 * @param end
+	 * @return
+	 */
 	public CompResults execute(List<DbComputation> toRun, DataCollection theData, Date start, Date end)
 	{
-		return execute(toRun, theData, start, end, new ProgressListener.LoggingProgressListener());
+		return execute(toRun, theData, start, end, dc -> dc);
 	}
 
+	/**
+	 * Run computations using the given data and date range using the given afterComp Handler.
+	 * @param toRun
+	 * @param theData
+	 * @param start
+	 * @param end
+	 * @param afterComp
+	 * @return
+	 */
+	public CompResults execute(List<DbComputation> toRun, DataCollection theData, Date start, Date end, Function<DataCollection, DataCollection> afterComp)
+	{
+		return execute(toRun, theData, start, end, new ProgressListener.LoggingProgressListener(), afterComp);
+	}
+
+	/**
+	 * Run computations using the given data, date rangge, and ProgressListener
+	 * @param toRun
+	 * @param theData
+	 * @param start
+	 * @param end
+	 * @param listener
+	 * @return
+	 */
 	public CompResults execute(List<DbComputation> toRun, DataCollection theData, Date start, Date end, ProgressListener listener)
 	{
+		return execute(toRun, theData, start, end, listener, dc -> dc);
+	}
+
+	/**
+	 * Run computations using the given data, date range, progress listener, and afterComp handler.
+	 * 
+	 *
+	 * 
+	 * @param toRun
+	 * @param theData
+	 * @param start
+	 * @param end
+	 * @param listener
+	 * @param afterComp run using CompletableFuture::thenApply, if you wish to run the task on a different ExecutorService your handler should pass the data along.
+	 * @return
+	 */
+	public CompResults execute(List<DbComputation> toRun, DataCollection theData, Date start, Date end, ProgressListener listener, Function<DataCollection, DataCollection> afterComp)
+	{
 		// Execute the computations
+		List<CompletableFuture<DataCollection>> comps = new ArrayList<>();
 		for(DbComputation comp : toRun)
 		{
-			try (var mdcComputation = MDC.putCloseable(COMPUTATION_KEY, comp.getName());
-				 var compTimer = MDCTimer.startTimer(comp.getName()))
-			{
-				listener.onProgress(String.format("Executing computation '%s' #trigs=%d",
-						comp.getName(), comp.getTriggeringRecNums().size()), Level.DEBUG, null);
-				computesTried++;
-				boolean ignoreTimeWindow = start == null && end == null;
-				executeSingleComp(comp, start, end, theData, ignoreTimeWindow, listener);
-			}
-			catch(DbIoException ex)
-			{
-				listener.onProgress(String.format("Computation '%s' failed.", comp.getName()), Level.WARN, ex);
-				numErrors++;
-				for (Integer rn : comp.getTriggeringRecNums())
+			var future = CompletableFuture.supplyAsync(
+				propegate(() ->
 				{
-					theData.getTasklistHandle().markComputationFailed(rn);
-				}
-			}
-			catch (Exception ex)
-			{
-				listener.onProgress(String.format("Unexpected error in computation %s", comp.getName()), Level.WARN, ex);
-				numErrors++;
-				for(Integer rn : comp.getTriggeringRecNums())
+					DataCollection ret = new DataCollection();
+					try (var mdcComputation = MDC.putCloseable(COMPUTATION_KEY, comp.getName());
+						var compTimer = MDCTimer.startTimer(comp.getName()))
+					{
+						listener.onProgress(String.format("Executing computation '%s' #trigs=%d",
+								comp.getName(), comp.getTriggeringRecNums().size()), Level.DEBUG, null);
+						computesTried++;
+						boolean ignoreTimeWindow = start == null && end == null;
+						ret = executeSingleComp(comp, start, end, theData, ignoreTimeWindow, listener);
+					}
+					catch(DbIoException ex)
+					{
+						listener.onProgress(String.format("Computation '%s' failed.", comp.getName()), Level.WARN, ex);
+						numErrors++;
+						for (Integer rn : comp.getTriggeringRecNums())
+						{
+							theData.getTasklistHandle().markComputationFailed(rn);
+						}
+					}
+					catch (Exception ex)
+					{
+						listener.onProgress(String.format("Unexpected error in computation %s", comp.getName()), Level.WARN, ex);
+						numErrors++;
+						for(Integer rn : comp.getTriggeringRecNums())
+						{
+							theData.getTasklistHandle().markComputationFailed(rn);
+						}
+					}
+					finally
+					{
+						comp.getTriggeringRecNums().clear();
+						listener.onProgress(String.format("End of computation '%s'", comp.getName()), Level.DEBUG, null);
+					}
+					return ret;
+				}), executor)
+				.thenApply(dc ->
 				{
-					theData.getTasklistHandle().markComputationFailed(rn);
-				}
-			}
-			comp.getTriggeringRecNums().clear();
-			listener.onProgress(String.format("End of computation '%s'", comp.getName()), Level.DEBUG, null);
+					listener.logEvent("will save " + dc.size() + " time series from comp", Level.INFO, null);
+					return dc;
+				})
+				.thenApply(afterComp);
+			comps.add(future);
 		}
+		CompletableFuture.allOf(comps.toArray(new CompletableFuture[0])).join();
 		return new CompResults(numErrors, computesTried);
 	}
 
+	/**
+	 * Execute a single computation with the provided inputs, date range, and progress listener.
+	 * @param computation
+	 * @param tsIds
+	 * @param start
+	 * @param end
+	 * @param listener
+	 * @return
+	 * @throws DbIoException
+	 */
 	public CompResults execute(DbComputation computation,
 			List<TimeSeriesIdentifier> tsIds, Date start, Date end, ProgressListener listener)
 		throws DbIoException
@@ -144,12 +270,32 @@ public final class ComputationExecution
 		return new CompResults(numErrors, computesTried);
 	}
 
+	/**
+	 * Run single computation using the provided data, date range and default LoggingProgressListener
+	 * @param comp
+	 * @param start
+	 * @param end
+	 * @param dataCollection
+	 * @return
+	 * @throws DbIoException
+	 */
 	public DataCollection executeSingleComp(DbComputation comp, Date start, Date end, DataCollection dataCollection)
 			throws DbIoException
 	{
 		return executeSingleComp(comp, start, end, dataCollection, false, new ProgressListener.LoggingProgressListener());
 	}
 
+	/**
+	 * Execute a single computation using a data collection.
+	 * @param comp
+	 * @param start
+	 * @param end
+	 * @param dataCollection
+	 * @param ignoreTimeWindow
+	 * @param listener
+	 * @return
+	 * @throws DbIoException
+	 */
 	private DataCollection executeSingleComp(DbComputation comp, Date start, Date end, DataCollection dataCollection, boolean ignoreTimeWindow, ProgressListener listener)
 			throws DbIoException
 	{

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
@@ -54,7 +54,7 @@ public final class ComputationExecution
 	/**
 	 * Create instance of ComputationExecution using provided ExecutorService.
 	 *
-	 * NOTE: at this time we do not think the operations of DbComputation.apply are thread save.
+	 * NOTE: at this time we do not think the operations of DbComputation.apply are thread safe.
 	 * This is being initially setup to provided chaining operations and too allow for that
 	 * follow on work.
 	 * @param db

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
@@ -144,15 +144,16 @@ public final class ComputationExecution
 		return new CompResults(numErrors, computesTried);
 	}
 
-	public void executeSingleComp(DbComputation comp, Date start, Date end, DataCollection dataCollection)
+	public DataCollection executeSingleComp(DbComputation comp, Date start, Date end, DataCollection dataCollection)
 			throws DbIoException
 	{
-		executeSingleComp(comp, start, end, dataCollection, false, new ProgressListener.LoggingProgressListener());
+		return executeSingleComp(comp, start, end, dataCollection, false, new ProgressListener.LoggingProgressListener());
 	}
 
-	private void executeSingleComp(DbComputation comp, Date start, Date end, DataCollection dataCollection, boolean ignoreTimeWindow, ProgressListener listener)
+	private DataCollection executeSingleComp(DbComputation comp, Date start, Date end, DataCollection dataCollection, boolean ignoreTimeWindow, ProgressListener listener)
 			throws DbIoException
 	{
+		DataCollection ret = new DataCollection();
 		try(MDC.MDCCloseable mdc = MDC.putCloseable(COMPUTATION_KEY, comp.getName());
 			var compTimer = MDCTimer.startTimer("executing single computation: " + comp.getName());
 			TimeSeriesDAI timeSeriesDAO = getTsDb().makeTimeSeriesDAO())
@@ -203,7 +204,7 @@ public final class ComputationExecution
 					}
 				}
 
-				comp.apply(dataCollection, getTsDb());
+				ret = comp.apply(dataCollection, getTsDb());
 				listener.onProgress("Successfully initiated computation", Level.INFO, null);
 			}
 			catch(DbCompException ex)
@@ -231,6 +232,7 @@ public final class ComputationExecution
 		{
 			listener.onProgress("Unexpected error in computation.", Level.WARN, ex);
 		}
+		return ret;
 	}
 
 	public record CompResults(int numErrors, int computesTried)

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,6 +30,8 @@ import ilex.var.TimedVariable;
 import opendcs.dai.TimeSeriesDAI;
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.utils.logging.MDCTimer;
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.slf4j.Logger;
 import org.slf4j.MDC;
 import org.slf4j.event.Level;
 
@@ -36,6 +39,7 @@ import static org.opendcs.utils.logging.ThreadUtils.propagate;
 
 public final class ComputationExecution
 {
+	private static final Logger log = OpenDcsLoggerFactory.getLogger();
 	private static final String COMPUTATION_KEY = "computation";
 	private final OpenDcsDatabase db;
 	private AtomicInteger numErrors = new AtomicInteger(0);
@@ -57,7 +61,8 @@ public final class ComputationExecution
 	 *
 	 * NOTE: at this time we do not think the operations of DbComputation.apply are thread safe.
 	 * This is being initially setup to provided chaining operations and too allow for that
-	 * follow on work.
+	 * follow on work. Experiment with a > 1 Thread pool at your own risk.
+	 *
 	 * @param db
 	 * @param executor
 	 */
@@ -212,10 +217,22 @@ public final class ComputationExecution
 					listener.logEvent("will save " + dc.size() + " time series from comp", Level.INFO, null);
 					return dc;
 				})
-				.thenApply(afterComp);
+				.thenApply(afterComp)
+				.exceptionally(ex -> {
+					log.atError().setCause(ex).log("Computation {} failed.", comp.getName());
+					return new DataCollection();
+				});
 			comps.add(future);
 		}
-		CompletableFuture.allOf(comps.toArray(new CompletableFuture[0])).join();
+
+		try
+		{
+			CompletableFuture.allOf(comps.toArray(new CompletableFuture[0])).join();
+		}
+		catch (CompletionException ex)
+		{
+			log.atError().setCause(ex).log("At least one computation in batch failed to complete.");
+		}
 		return new CompResults(numErrors.get(), computesTried.get());
 	}
 

--- a/java/opendcs/src/main/java/decodes/tsdb/DbAlgorithmExecutive.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/DbAlgorithmExecutive.java
@@ -303,9 +303,11 @@ public abstract class DbAlgorithmExecutive
 	 * @throws DbCompException on computation error.
 	 * @throws DbIoException on IO error to database.
 	 */
-	public void apply( DataCollection dc )
+	public DataCollection apply( DataCollection dc )
 		throws DbCompException, DbIoException
 	{
+		DataCollection savedData = new DataCollection();
+
 		try (MDCCloseable mdcAlgoClass = MDC.putCloseable("algorithmClass", this.getClass().getName()))
 		{
 			this.dc = dc;
@@ -322,6 +324,26 @@ public abstract class DbAlgorithmExecutive
 				addTsToParmRef(role, true);
 
 			applyAlgorithm();
+
+			for (String role: getOutputNames())
+			{
+				var parmRef = getParmRef(role);
+				try
+				{
+					savedData.addTimeSeries(parmRef.timeSeries);
+				}
+				catch (DuplicateTimeSeriesException ex)
+				{
+					log.atError()
+					   .setCause(ex)
+					   .log("""
+							Unable to add time series {} to output collection from role {}. It was already present, this should not happen. Please
+							check your computation configuration for duplicate output mappings
+						""", parmRef.tsid.getUniqueString(), parmRef.role);
+				}
+			}
+
+			return savedData;
 		}
 	}
 

--- a/java/opendcs/src/main/java/decodes/tsdb/DbComputation.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/DbComputation.java
@@ -369,16 +369,19 @@ public class DbComputation implements CompMetaData, CachableHasProperties
 	 * Delegates to the apply method of the DbAlgorithmExecutive.
 	 * @param msg the data collection
 	 * @param tsdb the database
+	 * @return Collection of time series that were output for this computation
 	 * @throws DbCompException if apply fails.
 	 * @throws DbIoException on IO error to database.
 	 */
-	public void apply( DataCollection msg, TimeSeriesDb tsdb )
+	public DataCollection apply( DataCollection msg, TimeSeriesDb tsdb )
 		throws DbCompException, DbIoException
 	{
 		if (executive == null)
+		{
 			throw new DbCompException("Computation '" + name
 				+ "' not initialized.");
-		executive.apply(msg);
+		}
+		return executive.apply(msg);
 	}
 
 	/**

--- a/java/opendcs/src/main/java/opendcs/dai/TimeSeriesDAI.java
+++ b/java/opendcs/src/main/java/opendcs/dai/TimeSeriesDAI.java
@@ -198,6 +198,9 @@ public interface TimeSeriesDAI extends DaiBase, OpenDcsDao
 
 	/**
 	 * Flush and reload the internal Time Series ID cache inside the DAO
+	 * While it is preferable to have the internal resource management have no static variables
+	 * existing implementations do so. Any implementation of this should likely synchronize on the
+	 * given class to avoid concurrent modification exceptions.
 	 * @throws DbIoException on error.
 	 */
 	public void reloadTsIdCache()

--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
@@ -34,7 +34,6 @@ import java.util.TimeZone;
 import org.opendcs.database.ExceptionHelpers;
 import org.opendcs.utils.FailableResult;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
-import org.python.modules.synchronize;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.spi.LoggingEventBuilder;

--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
@@ -34,6 +34,7 @@ import java.util.TimeZone;
 import org.opendcs.database.ExceptionHelpers;
 import org.opendcs.utils.FailableResult;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.python.modules.synchronize;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.spi.LoggingEventBuilder;
@@ -1311,30 +1312,33 @@ public class OpenTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 	@Override
 	public synchronized void reloadTsIdCache() throws DbIoException
 	{
-		cache.clear();
-		String q = "SELECT " + ts_spec_columns + " from TS_SPEC";
-
-		try (ResultSet rs = doQuery(q))
+		synchronized(OpenTimeSeriesDAO.class)
 		{
-			while (rs.next())
+			cache.clear();
+			String q = "SELECT " + ts_spec_columns + " from TS_SPEC";
+
+			try (ResultSet rs = doQuery(q))
 			{
-				try
+				while (rs.next())
 				{
-					cache.put(rs2TsId(rs, true));
-				}
-				catch(NoSuchObjectException ex)
-				{
-					log.atWarn()
-					   .setCause(ex)
-					   .log("Cannot create tsid for key={} -- skipped.", rs.getLong(1));
+					try
+					{
+						cache.put(rs2TsId(rs, true));
+					}
+					catch(NoSuchObjectException ex)
+					{
+						log.atWarn()
+						.setCause(ex)
+						.log("Cannot create tsid for key={} -- skipped.", rs.getLong(1));
+					}
 				}
 			}
+			catch(Exception ex)
+			{
+				throw new DbIoException("Error reading TS_SPEC table: ", ex);
+			}
+			lastCacheReload = System.currentTimeMillis();
 		}
-		catch(Exception ex)
-		{
-			throw new DbIoException("Error reading TS_SPEC table: ", ex);
-		}
-		lastCacheReload = System.currentTimeMillis();
 	}
 
 	@Override

--- a/java/opendcs/src/main/java/org/opendcs/utils/logging/MDCTimer.java
+++ b/java/opendcs/src/main/java/org/opendcs/utils/logging/MDCTimer.java
@@ -26,7 +26,7 @@ public final class MDCTimer implements AutoCloseable
     }
 
     @Override
-    public void close() throws Exception
+    public void close() // exception removed we know we don't/can't throw here.
     {
         long diff = System.currentTimeMillis() - start;
         log.info("Timer '{}' ended in {} ms", name, diff);

--- a/java/opendcs/src/main/java/org/opendcs/utils/logging/ThreadUtils.java
+++ b/java/opendcs/src/main/java/org/opendcs/utils/logging/ThreadUtils.java
@@ -1,0 +1,39 @@
+package org.opendcs.utils.logging;
+
+import java.util.function.Supplier;
+
+import org.slf4j.MDC;
+
+/**
+ * Utility functions to handling logging context in various Thread environments.
+ */
+public final class ThreadUtils
+{
+    private ThreadUtils()
+    {
+        /* utility class */
+    }
+
+    /**
+	 * Propgate the MDC context into the given task for things like the Trace ID.
+	 * @param <T>
+	 * @param task
+	 * @return
+	 */
+	public static <T> Supplier<T> propegate(Supplier<T> task)
+	{
+		final var currentContext = MDC.getCopyOfContextMap();
+		return () ->
+		{
+			MDC.setContextMap(currentContext);
+			try
+			{
+				return task.get();
+			}
+			finally
+			{
+				MDC.clear();
+			}
+		};
+	}
+}

--- a/java/opendcs/src/main/java/org/opendcs/utils/logging/ThreadUtils.java
+++ b/java/opendcs/src/main/java/org/opendcs/utils/logging/ThreadUtils.java
@@ -15,12 +15,12 @@ public final class ThreadUtils
     }
 
     /**
-	 * Propgate the MDC context into the given task for things like the Trace ID.
+	 * Propagate the MDC context into the given task for things like the Trace ID.
 	 * @param <T>
 	 * @param task
 	 * @return
 	 */
-	public static <T> Supplier<T> propegate(Supplier<T> task)
+	public static <T> Supplier<T> propagate(Supplier<T> task)
 	{
 		final var currentContext = MDC.getCopyOfContextMap();
 		return () ->


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Given that the saving of data happens after all computations are run, it's sometimes difficult to correlate log messages of data saved to which computation output the data.

Additionally we know we want to get to ThreadComproc (#291) eventually.

## Solution

Introduce an ExecutorService to allow for use of `CompleteableFuture`, which itself allows chaining operations. ThreadPool size is 1, comp still executes on a separate thread, but for the execution of computations no parallel work occurs.

Alter `DbComputation::apply` and all required to return a `DataCollection` of *only* the output time series.

Update `ComputationApp` to move the Save Time Series from after all computations to a provided handler to be called after every individual computation.

A follow up will allow the save to be on a separate thread, There should be no concurrency issues with saving data for one computation while another is processing.

`TimeSeriesDb::reloadTsIdCache` instances were modified to synchronize the full operation of the block on the class of each implementation after entries of `ConcurrentModificationException` were discovered in the logs.

## how you tested the change

No change in behavior except to timing of operations and log output.
Review logs to verify expected output was still present.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
