### PR TITLE
Feature/1236 sites dao stateless

### DIFF
--- a/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/configurations/cwms/CwmsOracleConfiguration.java
+++ b/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/configurations/cwms/CwmsOracleConfiguration.java
@@ -129,6 +129,9 @@ public class CwmsOracleConfiguration implements Configuration
                 insertDbType.bind("name", "sqlKeyGenerator")
                             .bind("value", OracleSequenceKeyGenerator.class.getName())
                             .execute();
+                insertDbType.bind("name", "writeCwmsLocations")
+                            .bind("value", "true")
+                            .execute();
             }
         }
 

--- a/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/configurations/opendcs/oracle/OpenDCSOracleConfiguration.java
+++ b/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/configurations/opendcs/oracle/OpenDCSOracleConfiguration.java
@@ -9,14 +9,16 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Duration;
+import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
@@ -30,7 +32,13 @@ import org.opendcs.database.impl.opendcs.OpenDcsOracleProvider;
 import org.opendcs.fixtures.UserPropertiesBuilder;
 import org.opendcs.fixtures.spi.Configuration;
 import org.opendcs.spi.database.MigrationProvider;
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.slf4j.Logger;
+import org.testcontainers.containers.startupcheck.StartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.oracle.OracleContainer;
+
+import com.github.dockerjava.api.model.HealthCheck;
 
 import decodes.db.Database;
 import decodes.launcher.Profile;
@@ -53,7 +61,7 @@ import uk.org.webcompere.systemstubs.security.SystemExit;
  */
 public class OpenDCSOracleConfiguration implements Configuration
 {
-    private static Logger log = Logger.getLogger(OpenDCSOracleConfiguration.class.getName());
+    private static Logger log = OpenDcsLoggerFactory.getLogger();
 
     public static final String NAME = "OpenDCS-Oracle";
 
@@ -113,7 +121,7 @@ public class OpenDCSOracleConfiguration implements Configuration
      * Actually setup the database
      * @throws Exception
     */
-    @SuppressWarnings("resource") // lives for life of tests, test containers cleans up for us
+    @SuppressWarnings({"resource", "java:S2696"}) // lives for life of tests, test containers cleans up for us
     private void installDb(SystemExit exit,EnvironmentVariables environment, SystemProperties properties, UserPropertiesBuilder configBuilder) throws Exception
     {
         // These should always be set.
@@ -125,20 +133,18 @@ public class OpenDCSOracleConfiguration implements Configuration
         {
             return;
         }
-        if(db == null)
+        if (db == null)
         {
-            db = new OracleContainer("gvenzl/oracle-free:full-faststart")
+            db = new OracleContainer("gvenzl/oracle-free:23-full-faststart")
                     .withCreateContainerCmdModifier(cmd ->
-                    {
                         cmd.getHostConfig()
-                            .withMemory(4L*1024*1024*1024)
-                            .withCpuPeriod(20000L)
-                            .withCpuQuota(25000L)
-                        ;
-                    })
+                           .withMemory(4L*1024*1024*1024)
+                           .withCpuCount(2L)
+                     )
+                    .withLogConsumer(lo -> log.trace(lo.getUtf8String()))
                     .withUsername(SCHEMA_OWNING_USER)
                     .withPassword(SCHEMA_OWNING_USER_PASSWORD)
-                    .withStartupTimeoutSeconds(300)
+                    .withStartupTimeout(Duration.ofMinutes(5))
                     ;
         }
 

--- a/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/configurations/opendcs/oracle/OpenDCSOracleConfiguration.java
+++ b/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/configurations/opendcs/oracle/OpenDCSOracleConfiguration.java
@@ -1,7 +1,5 @@
 package org.opendcs.fixtures.configurations.opendcs.oracle;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
@@ -10,14 +8,12 @@ import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
-import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.sql.DataSource;
@@ -34,11 +30,7 @@ import org.opendcs.fixtures.spi.Configuration;
 import org.opendcs.spi.database.MigrationProvider;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
-import org.testcontainers.containers.startupcheck.StartupCheckStrategy;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.oracle.OracleContainer;
-
-import com.github.dockerjava.api.model.HealthCheck;
 
 import decodes.db.Database;
 import decodes.launcher.Profile;
@@ -61,7 +53,7 @@ import uk.org.webcompere.systemstubs.security.SystemExit;
  */
 public class OpenDCSOracleConfiguration implements Configuration
 {
-    private static Logger log = OpenDcsLoggerFactory.getLogger();
+    private static final Logger log = OpenDcsLoggerFactory.getLogger();
 
     public static final String NAME = "OpenDCS-Oracle";
 

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -17,6 +17,7 @@ import org.opendcs.fixtures.annotations.EnableIfTsDb;
 
 import decodes.db.Site;
 import decodes.db.SiteName;
+import decodes.util.DecodesSettings;
 
 @EnableIfTsDb({"OpenDCS-Postgres", "OpenDCS-Oracle"})
 @DecodesConfigurationRequired({
@@ -44,21 +45,27 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             site.country = "US";
             site.setDescription("A test site");
             site.setActive(true);
-            site.nearestCity = "Bob's ville"; // we're specifically testing that '  here
-            site.setLastModifyTime(new Date());
+            site.nearestCity = "Bob's ville"; // we're specifically testing that ' here
+            // modify time set by Dao
             site.setPublicName("A site that exists to test the new DAO");
             site.setProperty("test_prop_1", "test_value_1");
             site.setProperty("test_prop_2", "test_value_2");
-
+            final var timeSaved = new Date();
             final var siteOut = dao.save(tx, site);
 
             assertNotNull(siteOut);
 
             assertEquals("Bob's ville", site.nearestCity);
-            assertEquals(site.getLastModifyTime(), siteOut.getLastModifyTime());
+            assertTrue(siteOut.getLastModifyTime().getTime() >= timeSaved.getTime());
 
             final var siteByName = dao.getBySiteName(tx, siteName2);
             assertTrue(siteByName.isPresent());
+
+            final var updateSiteIn = siteByName.get();
+            updateSiteIn.nearestCity = "Bob's Town"; // The place grew
+            final var updateSiteOut = dao.save(tx, updateSiteIn);
+            assertEquals("Bob's Town", updateSiteOut.nearestCity);
+            assertEquals(updateSiteIn.getDisplayName(), updateSiteOut.getDisplayName());
 
             
             dao.delete(tx, siteOut.getId());
@@ -78,7 +85,67 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
         {
             var sites =  dao.getAll(tx, -1, -1);
             assertFalse(sites.isEmpty());
+
+            final var numSites = 50;
+            for (int i = 0; i < numSites; i++)
+            {
+                var site = new Site();
+
+                var siteName = new SiteName(site, "CWMS", String.format("00AAAA-Test-Site-%02d", i));
+                site.addName(siteName);
+
+                if (i % 8 == 0)
+                {
+                    var siteName2 = new SiteName(site, "local", String.format("Local-Test-Site-%02d", i));
+                    site.addName(siteName2);
+                }
+
+                if (i % 7 == 0)
+                {
+                    site.setProperty("test-prop-" + i, "test-val-" + i);
+                    site.setProperty("test-prop-" + (i+1), "test-val-" + (i+1));
+                }
+
+                dao.save(tx, site);
+            }
+
+
+            final var siteNoPrefName = new Site();
+            siteNoPrefName.setDescription("A site that exist to not have a name matching the prefered type");
+            var settings = db.getSettings(DecodesSettings.class).orElseThrow();
+            var pref = settings.siteNameTypePreference;
+            var type = "local";
+            if (pref.equals("local"))
+            {
+                type = "CWMS";
+            }
+            var name = new SiteName(siteNoPrefName, type, String.format("00AAAA-Test-Site-%02d", numSites));
+            siteNoPrefName.addName(name);
+            dao.save(tx, siteNoPrefName); // should we even allow this?
+
+
+            var allSites = dao.getAll(tx, numSites+1, 0);
+            assertEquals(numSites+1, allSites.size());
+
+            var first10 = dao.getAll(tx, 10, 0);
+            assertEquals(10, first10.size());
+            assertEquals("00AAAA-Test-Site-00", first10.getFirst().getName("CWMS").getNameValue());
+            assertEquals("00AAAA-Test-Site-09", first10.getLast().getName("CWMS").getNameValue());
+
+            var seventh = first10.get(7);
+            assertEquals("test-val-7", seventh.getProperty("test-prop-7"));
+            assertEquals("test-val-8", seventh.getProperty("test-prop-8"));
+
+            var eigth = first10.get(8);
+            assertTrue(eigth.hasNameValue("Local-Test-Site-08"));
+
+            var second10 = dao.getAll(tx, 10, 10);
+            assertEquals(10, second10.size());
+            assertEquals("00AAAA-Test-Site-10", second10.getFirst().getName("CWMS").getNameValue());
+            assertEquals("00AAAA-Test-Site-19", second10.getLast().getName("CWMS").getNameValue());
+
+            var improperSite = dao.getBySiteName(tx, name);
+            assertTrue(improperSite.isPresent());
         }
-       
     }
 }

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -3,6 +3,7 @@ package org.opendcs.dao.opendcs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
@@ -10,6 +11,7 @@ import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.database.dai.SiteDao;
+import org.opendcs.database.exceptions.RequiredSiteNameMissingException;
 import org.opendcs.fixtures.AppTestBase;
 import org.opendcs.fixtures.annotations.ConfiguredField;
 import org.opendcs.fixtures.annotations.DecodesConfigurationRequired;
@@ -94,7 +96,7 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             {
                 var site = new Site();
 
-                var siteName = new SiteName(site, "CWMS", String.format("00AAAA-Test-Site-%02d", i));
+                var siteName = new SiteName(site, "CWMS", String.format("00AA_TestSite_%02d", i));
                 site.addName(siteName);
 
                 if (i % 8 == 0)
@@ -124,7 +126,7 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             }
             var name = new SiteName(siteNoPrefName, type, String.format("00AAAA-Test-Site-%02d", numSites));
             siteNoPrefName.addName(name);
-            dao.save(tx, siteNoPrefName); // should we even allow this?
+            assertThrows(RequiredSiteNameMissingException.class ,() -> dao.save(tx, siteNoPrefName));
 
 
             var allSites = dao.getAll(tx, numSites+1, 0);

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -42,12 +42,15 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             site.addName(siteName);
             var siteName2 = new SiteName(site, "local", "Local Test Name");
             site.addName(siteName2);
-            site.country = "US";
+            site.country = "US";            
             site.setDescription("A test site");
             site.setActive(true);
             site.nearestCity = "Bob's ville"; // we're specifically testing that ' here
             // modify time set by Dao
             site.setPublicName("A site that exists to test the new DAO");
+            site.setElevation(50.0);
+            site.setElevationUnits("ft");
+
             site.setProperty("test_prop_1", "test_value_1");
             site.setProperty("test_prop_2", "test_value_2");
             final var timeSaved = new Date();

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -1,0 +1,35 @@
+package org.opendcs.dao.opendcs;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.opendcs.database.api.OpenDcsDatabase;
+import org.opendcs.database.dai.SiteDao;
+import org.opendcs.fixtures.AppTestBase;
+import org.opendcs.fixtures.annotations.ConfiguredField;
+import org.opendcs.fixtures.annotations.DecodesConfigurationRequired;
+import org.opendcs.fixtures.annotations.EnableIfTsDb;
+
+@EnableIfTsDb({"OpenDCS-Postgres", "OpenDCS-Oracle"})
+@DecodesConfigurationRequired({
+    "shared/test-sites.xml",        
+    "SimpleDecodesTest/site-OKVI4.xml"
+})
+class OpenDcsSiteDaoTestIT extends AppTestBase
+{
+    @ConfiguredField
+    private OpenDcsDatabase db;
+  
+    @Test
+    void test_pagination() throws Exception
+    {
+        var dao = db.getDao(SiteDao.class).orElseThrow();
+
+        try (var tx = db.newTransaction())
+        {
+            var sites =  dao.getAll(tx, -1, -1);
+            assertFalse(sites.isEmpty());
+        }
+       
+    }
+}

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -19,9 +19,9 @@ import decodes.db.Site;
 import decodes.db.SiteName;
 import decodes.util.DecodesSettings;
 
-@EnableIfTsDb({"OpenDCS-Postgres", "OpenDCS-Oracle"})
+@EnableIfTsDb({"OpenDCS-Postgres", "OpenDCS-Oracle", "CWMS-Oracle"})
 @DecodesConfigurationRequired({
-    "shared/test-sites.xml",        
+    "shared/test-sites.xml",
     "SimpleDecodesTest/site-OKVI4.xml"
 })
 class OpenDcsSiteDaoTestIT extends AppTestBase

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -115,14 +115,11 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
 
             final var siteNoPrefName = new Site();
             siteNoPrefName.setDescription("A site that exist to not have a name matching the prefered type");
-            var settings = db.getSettings(DecodesSettings.class).orElseThrow();
-            var pref = settings.siteNameTypePreference;
-            var type = "local";
-            if (pref.equals("local"))
-            {
-                type = "CWMS";
-            }
-            siteNoPrefName.addName(type, String.format("00AAAA-Test-Site-%02d", numSites));
+            final var settings = db.getSettings(DecodesSettings.class).orElseThrow();
+            final var pref = settings.siteNameTypePreference;
+            final var type = pref.equals("local") ? "CWMS" : "local";
+            final var name = new SiteName(siteNoPrefName, type, String.format("00AAAA-Test-Site-%02d", numSites));
+            siteNoPrefName.addName(name);
             assertThrows(RequiredSiteNameMissingException.class ,() -> dao.save(tx, siteNoPrefName));
 
 

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -40,10 +40,8 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
         try (var tx = db.newTransaction())
         {
             var site = new Site();
-            var siteName = new SiteName(site, "CWMS", "SimpleTestSite");
-            site.addName(siteName);
-            var siteName2 = new SiteName(site, "local", "Local Test Name");
-            site.addName(siteName2);
+            var siteName = site.addName("CWMS", "SimpleTestSite");
+            var siteName2 = site.addName("local", "Local Test Name");
             site.country = "US";
             site.setDescription("A test site");
             site.setActive(true);
@@ -118,8 +116,7 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             final var settings = db.getSettings(DecodesSettings.class).orElseThrow();
             final var pref = settings.siteNameTypePreference;
             final var type = pref.equals("local") ? "CWMS" : "local";
-            final var name = new SiteName(siteNoPrefName, type, String.format("00AAAA-Test-Site-%02d", numSites));
-            siteNoPrefName.addName(name);
+            final var name = siteNoPrefName.addName(type, String.format("00AAAA-Test-Site-%02d", numSites));
             assertThrows(RequiredSiteNameMissingException.class ,() -> dao.save(tx, siteNoPrefName));
 
 

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -1,6 +1,11 @@
 package org.opendcs.dao.opendcs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
 
 import org.junit.jupiter.api.Test;
 import org.opendcs.database.api.OpenDcsDatabase;
@@ -9,6 +14,9 @@ import org.opendcs.fixtures.AppTestBase;
 import org.opendcs.fixtures.annotations.ConfiguredField;
 import org.opendcs.fixtures.annotations.DecodesConfigurationRequired;
 import org.opendcs.fixtures.annotations.EnableIfTsDb;
+
+import decodes.db.Site;
+import decodes.db.SiteName;
 
 @EnableIfTsDb({"OpenDCS-Postgres", "OpenDCS-Oracle"})
 @DecodesConfigurationRequired({
@@ -19,6 +27,47 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
 {
     @ConfiguredField
     private OpenDcsDatabase db;
+
+    @Test
+    void test_basic_operations() throws Exception
+    {
+        var dao = db.getDao(SiteDao.class).orElseThrow();
+
+
+        try (var tx = db.newTransaction())
+        {
+            var site = new Site();
+            var siteName = new SiteName(site, "CWMS", "SimpleTestSite");
+            site.addName(siteName);
+            var siteName2 = new SiteName(site, "local", "Local Test Name");
+            site.addName(siteName2);
+            site.country = "US";
+            site.setDescription("A test site");
+            site.setActive(true);
+            site.nearestCity = "Bob's ville"; // we're specifically testing that '  here
+            site.setLastModifyTime(new Date());
+            site.setPublicName("A site that exists to test the new DAO");
+            site.setProperty("test_prop_1", "test_value_1");
+            site.setProperty("test_prop_2", "test_value_2");
+
+            final var siteOut = dao.save(tx, site);
+
+            assertNotNull(siteOut);
+
+            assertEquals("Bob's ville", site.nearestCity);
+            assertEquals(site.getLastModifyTime(), siteOut.getLastModifyTime());
+
+            final var siteByName = dao.getBySiteName(tx, siteName2);
+            assertTrue(siteByName.isPresent());
+
+            
+            dao.delete(tx, siteOut.getId());
+            var siteByNameAfterDelete = dao.getBySiteName(tx, siteName2);
+            assertTrue(siteByNameAfterDelete.isEmpty());
+
+        }
+
+    }
   
     @Test
     void test_pagination() throws Exception

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -18,7 +18,6 @@ import org.opendcs.fixtures.annotations.DecodesConfigurationRequired;
 import org.opendcs.fixtures.annotations.EnableIfTsDb;
 
 import decodes.db.Site;
-import decodes.db.SiteName;
 import decodes.util.DecodesSettings;
 
 @EnableIfTsDb({"OpenDCS-Postgres", "OpenDCS-Oracle", "CWMS-Oracle"})
@@ -40,8 +39,8 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
         try (var tx = db.newTransaction())
         {
             var site = new Site();
-            var siteName = site.addName("CWMS", "SimpleTestSite");
-            var siteName2 = site.addName("local", "Local Test Name");
+            final var siteName = site.addName("CWMS", "SimpleTestSite");
+            final var siteName2 = site.addName("local", "Local Test Name");
             site.country = "US";
             site.setDescription("A test site");
             site.setActive(true);
@@ -61,10 +60,13 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             assertEquals("Bob's ville", site.nearestCity);
             assertTrue(siteOut.getLastModifyTime().getTime() >= timeSaved.getTime());
 
-            final var siteByName = dao.getBySiteName(tx, siteName2);
+            final var siteByName2 = dao.getBySiteName(tx, siteName);
+            assertTrue(siteByName2.isPresent());
+
+            final var siteByName = dao.getBySiteName(tx, siteName);
             assertTrue(siteByName.isPresent());
 
-            final var updateSiteIn = siteByName.get();
+            final var updateSiteIn = siteByName2.get();
             updateSiteIn.nearestCity = "Bob's Town"; // The place grew
             final var updateSiteOut = dao.save(tx, updateSiteIn);
             assertEquals("Bob's Town", updateSiteOut.nearestCity);

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -44,7 +44,7 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             site.addName(siteName);
             var siteName2 = new SiteName(site, "local", "Local Test Name");
             site.addName(siteName2);
-            site.country = "US";            
+            site.country = "US";
             site.setDescription("A test site");
             site.setActive(true);
             site.nearestCity = "Bob's ville"; // we're specifically testing that ' here
@@ -96,13 +96,11 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             {
                 var site = new Site();
 
-                var siteName = new SiteName(site, "CWMS", String.format("00AA_TestSite_%02d", i));
-                site.addName(siteName);
+                site.addName("CWMS", String.format("00AA_TestSite_%02d", i));
 
                 if (i % 8 == 0)
                 {
-                    var siteName2 = new SiteName(site, "local", String.format("Local-Test-Site-%02d", i));
-                    site.addName(siteName2);
+                    site.addName("local", String.format("Local-Test-Site-%02d", i));
                 }
 
                 if (i % 7 == 0)
@@ -124,8 +122,7 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             {
                 type = "CWMS";
             }
-            var name = new SiteName(siteNoPrefName, type, String.format("00AAAA-Test-Site-%02d", numSites));
-            siteNoPrefName.addName(name);
+            siteNoPrefName.addName(type, String.format("00AAAA-Test-Site-%02d", numSites));
             assertThrows(RequiredSiteNameMissingException.class ,() -> dao.save(tx, siteNoPrefName));
 
 

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -134,8 +134,8 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
 
             var first10 = dao.getAll(tx, 10, 0);
             assertEquals(10, first10.size());
-            assertEquals("00AAAA-Test-Site-00", first10.getFirst().getName("CWMS").getNameValue());
-            assertEquals("00AAAA-Test-Site-09", first10.getLast().getName("CWMS").getNameValue());
+            assertEquals("00AA_TestSite_00", first10.getFirst().getName("CWMS").getNameValue());
+            assertEquals("00AA_TestSite_09", first10.getLast().getName("CWMS").getNameValue());
 
             var seventh = first10.get(7);
             assertEquals("test-val-7", seventh.getProperty("test-prop-7"));
@@ -146,11 +146,11 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
 
             var second10 = dao.getAll(tx, 10, 10);
             assertEquals(10, second10.size());
-            assertEquals("00AAAA-Test-Site-10", second10.getFirst().getName("CWMS").getNameValue());
-            assertEquals("00AAAA-Test-Site-19", second10.getLast().getName("CWMS").getNameValue());
+            assertEquals("00AA_TestSite_10", second10.getFirst().getName("CWMS").getNameValue());
+            assertEquals("00AA_TestSite_19", second10.getLast().getName("CWMS").getNameValue());
 
             var improperSite = dao.getBySiteName(tx, name);
-            assertTrue(improperSite.isPresent());
+            assertFalse(improperSite.isPresent());
         }
     }
 }

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/BaseApiIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/BaseApiIT.java
@@ -44,6 +44,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import opendcs.dai.PlatformStatusDAI;
 import opendcs.dai.ScheduleEntryDAI;
+import opendcs.dai.SiteDAI;
 import opendcs.dai.TimeSeriesDAI;
 import org.apache.catalina.session.StandardSession;
 import org.junit.jupiter.api.Tag;
@@ -294,8 +295,10 @@ public class BaseApiIT extends AppTestBase
 	public TimeSeriesIdentifier storeTimeSeries(CTimeSeries ts) throws Exception
 	{
 		TimeSeriesIdentifier id;
-		try (TimeSeriesDAI dai = getTsdb().makeTimeSeriesDAO())
+		try (SiteDAI sdai = getTsdb().makeSiteDAO();
+			TimeSeriesDAI dai = getTsdb().makeTimeSeriesDAO())
 		{
+			sdai.fillCache();
 			dai.saveTimeSeries(ts);
 		}
 		catch (Throwable ex)

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/ComputationResourcesIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/ComputationResourcesIT.java
@@ -69,6 +69,7 @@ import org.opendcs.odcsapi.res.ComputationResources;
 import org.opendcs.odcsapi.util.ApiConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.security.SystemExit;
 
@@ -97,16 +98,19 @@ final class ComputationResourcesIT extends BaseApiIT
 	private final SystemExit exit = new SystemExit();
 	List<CTimeSeries> expectedTsList = new ArrayList<>();
 
+	private String traceId;
+
 	@BeforeEach
 	void init() throws Exception
 	{
+		traceId = UUID.randomUUID().toString();
+		MDC.put("traceID", traceId);
 		setUpCreds();
 		authenticate();
 
 		ApiComputation comp = getDtoFromResource("computation_insert_data.json", ApiComputation.class);
 
-		ApiSite site = getDtoFromResource("computation_site_data.json", ApiSite.class);
-		Site tsSite = mapSite(site);
+		final ApiSite site = getDtoFromResource("computation_site_data.json", ApiSite.class);
 
 		ApiLoadingApp app = getDtoFromResource("computation_app_data.json", ApiLoadingApp.class);
 		String appJson = MAPPER.writeValueAsString(app);
@@ -115,6 +119,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		var response = given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.contentType(MediaType.APPLICATION_JSON)
 			.body(appJson)
@@ -140,6 +145,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		response = given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.contentType(MediaType.APPLICATION_JSON)
 			.body(algJson)
@@ -159,9 +165,10 @@ final class ComputationResourcesIT extends BaseApiIT
 		String siteJson = MAPPER.writeValueAsString(site);
 
 		// Insert the site
-		response = given()
+		final var siteResponse = given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.contentType(MediaType.APPLICATION_JSON)
 			.body(siteJson)
@@ -175,9 +182,10 @@ final class ComputationResourcesIT extends BaseApiIT
 			.statusCode(is(Response.Status.CREATED.getStatusCode()))
 			.extract()
 		;
-
-		siteId = response.body().jsonPath().getLong("siteId");
-
+		log.atDebug().addArgument(() -> siteResponse.body().asPrettyString()).log("siteJson: {}");
+		// pull the siteId from the response as it changes every method call
+		siteId = siteResponse.body().jsonPath().getLong("siteId");
+		final Site tsSite = mapSite(siteResponse.body().as(ApiSite.class));
 		// Create an active time series
 		CwmsTsId identifier = new CwmsTsId();
 		identifier.setUniqueString(String.format("%s.%s.%s.%s.%s.%s", tsSite.getDisplayName(),
@@ -274,6 +282,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		response = given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.contentType(MediaType.APPLICATION_JSON)
 			.body(compJson)
@@ -298,6 +307,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("computationid", compId)
 		.when()
@@ -314,6 +324,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("appid", appId)
 		.when()
@@ -330,6 +341,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("algorithmid", algId)
 		.when()
@@ -347,6 +359,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		tearDownSite(siteId);
 
 		logout();
+		MDC.remove("traceId");
 	}
 
 	@Test
@@ -357,6 +370,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		var response = given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 		.when()
 			.redirects().follow(true)
@@ -391,6 +405,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		var response = given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("site", siteId)
 			.queryParam("datatype", comp.getParmList().getFirst().getDataTypeId())
@@ -429,6 +444,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("site", comp.getParmList().getFirst().getSiteId())
 			.queryParam("datatype", comp.getParmList().getFirst().getDataTypeId())
@@ -450,6 +466,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("site", comp.getParmList().getFirst().getSiteId())
 			.queryParam("datatype", comp.getParmList().getFirst().getDataTypeId())
@@ -472,6 +489,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("site", comp.getParmList().getFirst().getSiteId())
 			.queryParam("datatype", comp.getParmList().getFirst().getDataTypeId())
@@ -499,6 +517,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		var response = given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("computationid", compId)
 		.when()
@@ -546,6 +565,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		var response = given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.contentType(MediaType.APPLICATION_JSON)
 			.body(compJson)
@@ -566,6 +586,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		response = given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("computationid", newCompId)
 		.when()
@@ -601,6 +622,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("computationid", newCompId)
 		.when()
@@ -617,6 +639,7 @@ final class ComputationResourcesIT extends BaseApiIT
 		given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.spec(authSpec)
+			.header(LoggingFilter.HEADER_TRACE_ID, traceId)
 			.accept(MediaType.APPLICATION_JSON)
 			.queryParam("computationid", newCompId)
 		.when()

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/ComputationResourcesIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/ComputationResourcesIT.java
@@ -662,13 +662,13 @@ final class ComputationResourcesIT extends BaseApiIT
 		importData(Optional.of(Path.of("ResEvap", "Test1")));
 		assertFalse(expectedTsList.isEmpty(), "No time series found imported");
 
-		final var traceId = UUID.randomUUID().toString();
+		final var compTraceId = UUID.randomUUID().toString();
 
 		ClientRequestFilter auth = ctx ->
 		{
 			ctx.getHeaders().putSingle(ApiConstants.ORGANIZATION_HEADER, organization);
 			ctx.getHeaders().putSingle("Cookie", getCookie());
-			ctx.getHeaders().putSingle(LoggingFilter.HEADER_TRACE_ID, traceId);
+			ctx.getHeaders().putSingle(LoggingFilter.HEADER_TRACE_ID, compTraceId);
 		};
 
 		URI baseURI = URI.create(String.format("%s:%d/%s", RestAssured.baseURI, RestAssured.port, RestAssured.basePath));
@@ -759,13 +759,13 @@ final class ComputationResourcesIT extends BaseApiIT
 		importData(Optional.of(Path.of("CopyTest", "Test1")));
 		assertFalse(expectedTsList.isEmpty(), "No time series found imported");
 
-		final var traceId = UUID.randomUUID().toString();
-		log.info("Computation is being run with Trace ID '{}'", traceId);
+		final var compTraceId = UUID.randomUUID().toString();
+		log.info("Computation is being run with Trace ID '{}'", compTraceId);
 		ClientRequestFilter auth = ctx ->
 		{
 			ctx.getHeaders().putSingle(ApiConstants.ORGANIZATION_HEADER, organization);
 			ctx.getHeaders().putSingle("Cookie", getCookie());
-			ctx.getHeaders().putSingle(LoggingFilter.HEADER_TRACE_ID, traceId);
+			ctx.getHeaders().putSingle(LoggingFilter.HEADER_TRACE_ID, compTraceId);
 		};
 
 		URI baseURI = URI.create(String.format("%s:%d/%s", RestAssured.baseURI, RestAssured.port, RestAssured.basePath));

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/regression_tests/SiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/regression_tests/SiteDaoTestIT.java
@@ -54,8 +54,8 @@ public class SiteDaoTestIT extends AppTestBase
         try(SiteDAI dao = tsdb.makeSiteDAO();)
         {
             Site s = new Site();
-            s.addName(new SiteName(s,"CWMS","TestSite"));
-            s.addName(new SiteName(s, "local", "TestSite-local name"));
+            s.addName("CWMS","TestSite");
+            s.addName("local", "TestSite-local name");
             s.setActive(true);
             s.setDescription("A test site");
             dao.writeSite(s);

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/CWMS-Oracle/README.md
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/CWMS-Oracle/README.md
@@ -1,0 +1,8 @@
+*WARNING* about the country field.
+
+The CWMS "store_location2" method that is used to actually save or update a location (Site in OpenDCS)
+Will except either a full nation name OR a 2-letter nation code.
+
+However, the retrieval of the location will always return the full name.
+
+Whatever input data is used, make sure the output check is against the full name.

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/CWMS-Oracle/site_get_expected.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/CWMS-Oracle/site_get_expected.json
@@ -12,7 +12,7 @@
   "nearestCity" : "Albuquerque",
   "timezone" : "UTC",
   "state" : "NM",
-  "country" : "US",
+  "country" : "United States",
   "region" : null,
   "active" : true,
   "locationType" : "PUMP",

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/computation_site_data.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/computation_site_data.json
@@ -1,7 +1,7 @@
 {
   "siteId" : null,
   "sitenames" : {
-    "Site" : "Test Site"
+    "CWMS" : "Test Site"
   },
   "description" : "A site for computations",
   "latitude" : "40.8",

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/netlist_site_insert_data.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/netlist_site_insert_data.json
@@ -1,7 +1,7 @@
 {
   "siteId" : null,
   "sitenames" : {
-    "Stream" : "Stream test site"
+    "CWMS" : "Stream test site"
   },
   "description" : "A stream site",
   "latitude" : "38.575764",

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/odcsapi_site_dto.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/odcsapi_site_dto.json
@@ -1,7 +1,7 @@
 {
   "siteId" : null,
   "sitenames" : {
-    "locationtype" : "publicName"
+    "CWMS" : "publicName"
   },
   "description" : null,
   "latitude" : "38.6",

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/platform_site_data.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/platform_site_data.json
@@ -18,6 +18,6 @@
   "locationType": "stream",
   "lastModified": 1625140800000,
   "sitenames": {
-    "stream": "Platform 10"
+    "CWMS": "Platform 10"
   }
 }

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/platform_site_post_delete_data.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/platform_site_post_delete_data.json
@@ -6,7 +6,7 @@
   "elevation": 200.0,
   "elevUnits": "m",
   "state": "CA",
-  "country": "USA",
+  "country": "US",
   "nearestCity": "Sacramento",
   "timezone": "PST",
   "region": "Yolo County",
@@ -18,6 +18,6 @@
   "locationType": "river",
   "lastModified": 1625141800000,
   "sitenames": {
-    "stream": "Platform 20"
+    "CWMS": "Platform 20"
   }
 }

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/routing_site_insert.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/routing_site_insert.json
@@ -1,7 +1,7 @@
 {
   "siteId" : null,
   "sitenames" : {
-    "Stream" : "Platform 12 Test Site"
+    "CWMS" : "Platform 12 Test Site"
   },
   "description" : "Test site in Davis, CA",
   "latitude" : "38.55",

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/site_post_delete_dto.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/site_post_delete_dto.json
@@ -1,6 +1,7 @@
 {
   "siteId" : 18817,
   "sitenames" : {
+    "CWMS" : "Test Lock",
     "LOCK" : "Test Lock"
   },
   "description" : "LOCK Site",

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/site_setup_dto.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/site_setup_dto.json
@@ -1,7 +1,8 @@
 {
   "siteId" : null,
   "sitenames" : {
-    "PUMP" : "Pump Site"
+    "PUMP" : "Pump Site",
+    "CWMS" : "Pump Site"
   },
   "description" : "Pump located in NM, USA",
   "latitude" : "35.106766",

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/ts_group_insert_data.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/ts_group_insert_data.json
@@ -27,7 +27,7 @@
     {
       "siteId" : "[SITE_ID]",
       "sitenames" : {
-        "Stream" : "TS test site"
+        "CWMS" : "TS test site"
       },
       "description" : "A TS site",
       "publicName" : "TS test site"
@@ -35,7 +35,7 @@
     {
       "siteId" : "[SITE_ID_2]",
       "sitenames" : {
-        "Stream" : "TS test site 2"
+        "CWMS" : "TS test site 2"
       },
       "description" : "A second TS site",
       "publicName" : "TS test site 2"

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/ts_site_insert_data.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/ts_site_insert_data.json
@@ -1,7 +1,7 @@
 {
   "siteId" : null,
   "sitenames" : {
-    "Stream" : "TS test site"
+    "CWMS" : "TS test site"
   },
   "description" : "A TS site",
   "latitude" : "38.55",

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/ts_site_insert_data2.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/ts_site_insert_data2.json
@@ -1,7 +1,7 @@
 {
   "siteId" : null,
   "sitenames" : {
-    "Stream" : "TS test site 2"
+    "CWMS" : "TS test site 2"
   },
   "description" : "A second TS site",
   "latitude" : "38.55",

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/OpenDCS-Postgres/site_get_expected.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/OpenDCS-Postgres/site_get_expected.json
@@ -1,6 +1,7 @@
 {
   "siteId" : 1,
   "sitenames" : {
+    "CWMS" : "Pump Site",
     "PUMP" : "Pump Site"
   },
   "description" : "Pump located in NM, USA",

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/OpenDCS-Postgres/site_get_refs_expected.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/OpenDCS-Postgres/site_get_refs_expected.json
@@ -2,6 +2,7 @@
   "siteId": 4,
   "sitenames":
   {
+    "CWMS": "Pump Site",
     "PUMP": "Pump Site"
   },
   "publicName": "Pump Site",

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/SiteResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/SiteResources.java
@@ -24,13 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import decodes.db.DatabaseException;
 import decodes.db.Site;
-import decodes.db.SiteList;
 import decodes.db.SiteName;
 import decodes.sql.DbKey;
-import decodes.tsdb.DbIoException;
-import decodes.tsdb.NoSuchObjectException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -51,8 +47,9 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import opendcs.dai.PropertiesDAI;
-import opendcs.dai.SiteDAI;
+
+import org.opendcs.database.api.OpenDcsDataException;
+import org.opendcs.database.dai.SiteDao;
 import org.opendcs.odcsapi.beans.ApiSite;
 import org.opendcs.odcsapi.beans.ApiSiteRef;
 import org.opendcs.odcsapi.dao.DbException;
@@ -64,6 +61,7 @@ import org.opendcs.odcsapi.util.ApiConstants;
 @Path("/")
 public final class SiteResources extends OpenDcsResource
 {
+	private static final WebAppException UNABLE_TO_GET_SITE_DAO = new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "No Site DAO available.");
 	@Context HttpHeaders httpHeaders;
 
 	@GET
@@ -85,22 +83,25 @@ public final class SiteResources extends OpenDcsResource
 			}
 	)
 	public Response getSiteRefs()
-			throws DbException
+			throws WebAppException
 	{
-		try (SiteDAI dai = getLegacyTimeseriesDB().makeSiteDAO())
+		final var db = createDb();
+		try (var tx = db.newTransaction())
 		{
-			SiteList sites = new SiteList();
-			dai.read(sites);
+			var siteDao = db.getDao(SiteDao.class)
+							 .orElseThrow(() -> UNABLE_TO_GET_SITE_DAO);
+			var sites = siteDao.getAll(tx, -1, -1);
 			List<ApiSiteRef> siteRefs = map(sites);
 			return Response.ok().entity(siteRefs).build();
 		}
-		catch (DbIoException ex)
+		catch (OpenDcsDataException ex)
 		{
-			throw new DbException("Unable to retrieve sites", ex);
+			throw new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+						 			  "Unable to retrieve site list", ex);
 		}
 	}
 
-	static List<ApiSiteRef> map(SiteList sites)
+	static List<ApiSiteRef> map(List<Site> sites)
 	{
 		List<ApiSiteRef> retList = new ArrayList<>();
 		for(Iterator<Site> it = sites.iterator(); it.hasNext(); )
@@ -117,7 +118,7 @@ public final class SiteResources extends OpenDcsResource
 			}
 			siteRef.setPublicName(site.getPublicName());
 			siteRef.setDescription(site.getDescription());
-			siteRef.setSitenames(map(site));
+			siteRef.setSitenames(mapSiteNames(site));
 			retList.add(siteRef);
 		}
 		return retList;
@@ -160,23 +161,28 @@ public final class SiteResources extends OpenDcsResource
 			throw new MissingParameterException("Missing required siteid parameter.");
 		}
 
-		try (SiteDAI dai = getLegacyTimeseriesDB().makeSiteDAO();
-			 PropertiesDAI propsDai = getLegacyTimeseriesDB().makePropertiesDAO())
+		final var db = createDb();
+		try (var tx = db.newTransaction())
 		{
-			DbKey siteKey = DbKey.createDbKey(siteId);
-			Site returnedSite = dai.getSiteById(siteKey);
-			Properties props = new Properties();
-			propsDai.readProperties("SITE_PROPERTY", "SITE_ID", siteKey, props);
-			return Response.ok()
-					.entity(map(returnedSite, props)).build();
+			var siteDao = db.getDao(SiteDao.class)
+							 .orElseThrow(() -> UNABLE_TO_GET_SITE_DAO);
+			var site = siteDao.getById(tx, DbKey.createDbKey(siteId));
+			if (site.isPresent())
+			{
+				var theSite = site.get();
+				return Response.ok()
+							   .entity(map(theSite, theSite.getProperties()))
+							   .build();
+			}
+			else
+			{
+				throw new DatabaseItemNotFoundException(String.format("Requested site with matching ID: %d not found", siteId));
+			}
 		}
-		catch (NoSuchObjectException ex)
+		catch (OpenDcsDataException ex)
 		{
-			throw new DatabaseItemNotFoundException(String.format("Requested site with matching ID: %d not found", siteId), ex);
-		}
-		catch(DbIoException ex)
-		{
-			throw new DbException("Unable to retrieve site by ID", ex);
+			throw new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+						 			  "Unable to retrieve site ", ex);
 		}
 	}
 
@@ -206,11 +212,11 @@ public final class SiteResources extends OpenDcsResource
 		returnSite.setTimezone(site.timeZoneAbbr);
 		returnSite.setRegion(site.region);
 		returnSite.setPublicName(site.getPublicName());
-		returnSite.setSitenames(map(site));
+		returnSite.setSitenames(mapSiteNames(site));
 		return returnSite;
 	}
 
-	static HashMap<String, String> map(Site site)
+	static HashMap<String, String> mapSiteNames(Site site)
 	{
 		HashMap<String, String> siteNames = new LinkedHashMap<>();
 		for(Iterator<SiteName> iter = site.getNames(); iter.hasNext(); )
@@ -254,39 +260,42 @@ public final class SiteResources extends OpenDcsResource
 			)
 	)
 	public Response postSite(ApiSite site)
-			throws DbException, WebAppException
+			throws WebAppException
 	{
-		try (SiteDAI dai = getLegacyTimeseriesDB().makeSiteDAO();
-			 PropertiesDAI propsDai = getLegacyTimeseriesDB().makePropertiesDAO())
+		if (site == null)
 		{
-			if (site == null)
-			{
-				throw new MissingParameterException("Missing required site parameter.");
-			}
-			Site dbSite = map(site);
-			dai.writeSite(dbSite);
-			DbKey siteKey = dbSite.getId();
-			propsDai.writeProperties("SITE_PROPERTY", "SITE_ID", siteKey, site.getProperties());
-			site.setSiteId(siteKey.getValue());
-			return Response.status(Response.Status.CREATED)
-					.entity(site).build();
+			throw new MissingParameterException("Missing required site parameter.");
 		}
-		catch(DatabaseException | DbIoException ex)
+	
+		final var db = createDb();
+		try (var tx = db.newTransaction())
 		{
-			throw new DbException("Unable to store site", ex);
+			var siteDao = db.getDao(SiteDao.class)
+							.orElseThrow(() -> UNABLE_TO_GET_SITE_DAO);
+			final Site dbSite = map(site);
+			var savedSite = siteDao.save(tx, dbSite);
+			var apiSiteOut = map(savedSite, savedSite.getProperties());
+			return Response.status(Response.Status.CREATED)
+					.entity(apiSiteOut).build();
+
+		}
+		catch(OpenDcsDataException ex)
+		{
+			throw new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+						 			  "Unable to save site ", ex);
 		}
 	}
 
-	static Site map(ApiSite site) throws DatabaseException
+	static Site map(ApiSite site)
 	{
 		Site returnSite = new Site();
 		if (site.getSiteId() != null)
 		{
-			returnSite.setId(DbKey.createDbKey(site.getSiteId()));
+			returnSite.forceSetId(DbKey.createDbKey(site.getSiteId()));
 		}
 		else
 		{
-			returnSite.setId(DbKey.NullKey);
+			returnSite.forceSetId(DbKey.NullKey);
 		}
 		returnSite.setLocationType(site.getLocationType());
 		returnSite.setElevation(site.getElevation());
@@ -304,12 +313,12 @@ public final class SiteResources extends OpenDcsResource
 		returnSite.setPublicName(site.getPublicName());
 		for (Map.Entry<String, String> entry : site.getSitenames().entrySet())
 		{
-			Site newSite = new Site();
-			newSite.setLocationType(entry.getKey());
-			newSite.setPublicName(entry.getValue());
-			SiteName sn = new SiteName(newSite, entry.getKey());
-			sn.setNameValue(entry.getValue());
+			SiteName sn = new SiteName(returnSite, entry.getKey(), entry.getValue());
 			returnSite.addName(sn);
+		}
+		for (Map.Entry<Object,Object> entry: site.getProperties().entrySet())
+		{
+			returnSite.setProperty((String)entry.getKey(), (String)entry.getValue());
 		}
 		return returnSite;
 	}
@@ -332,21 +341,28 @@ public final class SiteResources extends OpenDcsResource
 	)
 	public Response deleteSite(@Parameter(description = "id to delete", required = true, 
 			example = "3", schema = @Schema(type = "long"))
-		@QueryParam("siteid") Long siteId) throws DbException
+		@QueryParam("siteid") Long siteId) throws WebAppException
 	{
-		try (SiteDAI dai = getLegacyTimeseriesDB().makeSiteDAO())
+		if (siteId == null)
 		{
-			if (siteId == null)
-			{
-				throw new MissingParameterException("Missing required siteid parameter.");
-			}
-			dai.deleteSite(DbKey.createDbKey(siteId));
+			throw new MissingParameterException("Missing required siteid parameter.");
+		}
+
+		final var db = createDb();
+		try (var tx = db.newTransaction())
+		{
+			var siteDao = db.getDao(SiteDao.class)
+							.orElseThrow(() -> UNABLE_TO_GET_SITE_DAO);
+			siteDao.delete(tx, DbKey.createDbKey(siteId));
 			return Response.noContent()
 					.entity("ID " + siteId + " deleted").build();
+
 		}
-		catch(DbIoException | WebAppException ex)
+		catch(OpenDcsDataException ex)
 		{
-			throw new DbException("Unable to delete site", ex);
+			throw new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+						 			  "Unable to delete site ", ex);
 		}
+
 	}
 }

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/SiteResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/SiteResources.java
@@ -52,7 +52,6 @@ import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.SiteDao;
 import org.opendcs.odcsapi.beans.ApiSite;
 import org.opendcs.odcsapi.beans.ApiSiteRef;
-import org.opendcs.odcsapi.dao.DbException;
 import org.opendcs.odcsapi.errorhandling.DatabaseItemNotFoundException;
 import org.opendcs.odcsapi.errorhandling.MissingParameterException;
 import org.opendcs.odcsapi.errorhandling.WebAppException;
@@ -154,7 +153,7 @@ public final class SiteResources extends OpenDcsResource
 	public Response getSiteFull(@Parameter(description = "id to fetch", required = true,
 			example = "3", schema = @Schema(type = "long"))
 		@QueryParam("siteid") Long siteId)
-	throws WebAppException, DbException
+	throws WebAppException
 	{
 		if (siteId == null)
 		{

--- a/java/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/SiteResourcesTest.java
+++ b/java/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/SiteResourcesTest.java
@@ -18,19 +18,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opendcs.odcsapi.res.SiteResources.map;
+import static org.opendcs.odcsapi.res.SiteResources.mapSiteNames;
 
 final class SiteResourcesTest
 {
 	@Test
 	void testMapSiteList()
 	{
-		SiteList sl = new SiteList();
+		
 		Site site1 = siteBuilder("Albuquerque");
 		Site site2 = siteBuilder("Santa Fe");
-		sl.addSite(site1);
-		sl.addSite(site2);
 
-		List<ApiSiteRef> siteRefs = map(sl);
+		List<ApiSiteRef> siteRefs = map(List.of(site1, site2));
 
 		assertNotNull(siteRefs);
 		assertNotNull(siteRefs.get(0));
@@ -132,7 +131,7 @@ final class SiteResourcesTest
 	void testSiteNamesMap()
 	{
 		Site site = siteBuilder("Albuquerque");
-		Map<String, String> names = map(site);
+		Map<String, String> names = mapSiteNames(site);
 		assertNotNull(names);
 		for (Iterator<SiteName> it = site.getNames(); it.hasNext(); )
 		{

--- a/java/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/SiteResourcesTest.java
+++ b/java/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/SiteResourcesTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import decodes.db.Site;
-import decodes.db.SiteList;
 import decodes.db.SiteName;
 import org.junit.jupiter.api.Test;
 import org.opendcs.odcsapi.beans.ApiSite;
@@ -59,7 +58,7 @@ final class SiteResourcesTest
 	}
 
 	@Test
-	void testMapSite() throws Exception
+	void testMapSite()
 	{
 		ApiSite apiSite = new ApiSite();
 		apiSite.setActive(true);

--- a/java/opendcs/src/main/java/decodes/cwms/database/CwmsOracleProvider.java
+++ b/java/opendcs/src/main/java/decodes/cwms/database/CwmsOracleProvider.java
@@ -114,7 +114,7 @@ public class CwmsOracleProvider implements MigrationProvider
         jdbi.registerArgument(new DatabaseKeyArgumentFactory())
             .registerColumnMapper(new DatabaseKeyColumnMapper())
             .registerArgument(new CwmsBooleanArgumentFactory())
-            .registerColumnMapper(new CwmsBoolean());
+            .registerColumnMapper(new CwmsBoolean())
         ;
     }
 

--- a/java/opendcs/src/main/java/decodes/cwms/database/CwmsOracleProvider.java
+++ b/java/opendcs/src/main/java/decodes/cwms/database/CwmsOracleProvider.java
@@ -38,6 +38,8 @@ import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.database.dai.UserManagementDao;
 import org.opendcs.database.impl.cwms.dao.CwmsUserManagementImpl;
+import org.opendcs.database.impl.cwms.jdbi.CwmsBoolean;
+import org.opendcs.database.impl.cwms.jdbi.CwmsBooleanArgumentFactory;
 import org.opendcs.database.impl.opendcs.jdbi.column.databasekey.DatabaseKeyArgumentFactory;
 import org.opendcs.database.impl.opendcs.jdbi.column.databasekey.DatabaseKeyColumnMapper;
 import org.opendcs.database.model.Role;
@@ -109,8 +111,11 @@ public class CwmsOracleProvider implements MigrationProvider
     @Override
     public void registerJdbiPlugins(Jdbi jdbi)
     {
-        jdbi.registerArgument(new DatabaseKeyArgumentFactory());
-        jdbi.registerColumnMapper(new DatabaseKeyColumnMapper());
+        jdbi.registerArgument(new DatabaseKeyArgumentFactory())
+            .registerColumnMapper(new DatabaseKeyColumnMapper())
+            .registerArgument(new CwmsBooleanArgumentFactory())
+            .registerColumnMapper(new CwmsBoolean());
+        ;
     }
 
     @Override

--- a/java/opendcs/src/main/java/decodes/db/Site.java
+++ b/java/opendcs/src/main/java/decodes/db/Site.java
@@ -251,10 +251,11 @@ public class Site extends IdDatabaseObject implements HasProperties, CachableDbO
 	 * @param nameType Site Name Type
 	 * @param nameValue Actual site Name
 	 */
-	public synchronized void addName(String nameType, String nameValue)
+	public synchronized SiteName addName(String nameType, String nameValue)
 	{
 		var sn = new SiteName(this, nameType, nameValue);
 		this.addName(sn);
+		return sn;
 	}
 
 	/**

--- a/java/opendcs/src/main/java/decodes/db/Site.java
+++ b/java/opendcs/src/main/java/decodes/db/Site.java
@@ -245,6 +245,19 @@ public class Site extends IdDatabaseObject implements HasProperties, CachableDbO
 	}
 
 	/**
+	 * More generic form of addName. Calls {@see addName(SiteName sn)} internally
+	 * so the same logic is fallowed.
+	 *
+	 * @param nameType Site Name Type
+	 * @param nameValue Actual site Name
+	 */
+	public synchronized void addName(String nameType, String nameValue)
+	{
+		var sn = new SiteName(this, nameType, nameValue);
+		this.addName(sn);
+	}
+
+	/**
 	 * Removes all names defined for this site (for use by editor).
 	 */
 	public synchronized void clearNames()

--- a/java/opendcs/src/main/java/decodes/db/Site.java
+++ b/java/opendcs/src/main/java/decodes/db/Site.java
@@ -246,7 +246,7 @@ public class Site extends IdDatabaseObject implements HasProperties, CachableDbO
 
 	/**
 	 * More generic form of addName. Calls {@see addName(SiteName sn)} internally
-	 * so the same logic is fallowed.
+	 * so the same logic is followed.
 	 *
 	 * @param nameType Site Name Type
 	 * @param nameValue Actual site Name

--- a/java/opendcs/src/main/java/org/opendcs/database/SimpleOpenDcsDatabaseWrapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/SimpleOpenDcsDatabaseWrapper.java
@@ -37,6 +37,8 @@ import org.opendcs.database.api.OpenDcsDao;
 import org.opendcs.database.api.OpenDcsDaoConfigurationException;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.api.OpenDcsDatabase;
+import org.opendcs.database.impl.opendcs.jdbi.column.chrono.OpenDcsTimeColumn;
+import org.opendcs.database.impl.opendcs.jdbi.column.chrono.OpenDcsTimeColumnArgumentFactory;
 import org.opendcs.database.impl.opendcs.jdbi.column.databasekey.DatabaseKeyArgumentFactory;
 import org.opendcs.database.impl.opendcs.jdbi.column.databasekey.DatabaseKeyColumnMapper;
 import org.opendcs.settings.api.OpenDcsSettings;
@@ -74,7 +76,10 @@ public class SimpleOpenDcsDatabaseWrapper implements OpenDcsDatabase
         this.dataSource = dataSource;
         this.jdbi = Jdbi.create(dataSource);
         jdbi.registerArgument(new DatabaseKeyArgumentFactory())
-            .registerColumnMapper(new DatabaseKeyColumnMapper());
+            .registerColumnMapper(new DatabaseKeyColumnMapper())
+            .registerArgument(new OpenDcsTimeColumnArgumentFactory())
+            .registerColumnMapper(new OpenDcsTimeColumn());
+
         if (this.timeSeriesDb != null)
         {
             this.timeSeriesDb.setDcsDatabase(this);

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/SiteDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/SiteDao.java
@@ -42,7 +42,13 @@ public interface SiteDao extends OpenDcsDao
     Optional<Site> getByAnySiteName(DataTransaction tx, Collection<SiteName> siteNames) throws OpenDcsDataException;
 
     /**
-     * Save (insert or update) a site to the database
+     * Save (insert or update) a site to the database.
+     *
+     * Implementations should fail if a required site name is not present. For example CWMS requires a "CWMS" SiteNameType to be present
+     * as it is used as the CWMS Location ID.
+     *
+     * The OpenDCS-Postgres and OpenDCS-Oracle implementation also require a CWMS Site name.
+     *
      * @param tx
      * @param site
      * @return

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/SiteDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/SiteDao.java
@@ -33,7 +33,7 @@ public interface SiteDao extends OpenDcsDao
     Optional<Site> getBySiteName(DataTransaction tx, SiteName siteName) throws OpenDcsDataException;
 
     /**
-     * Given a collection of NameTypes find by matching any one of them.
+     * Given a collection of SiteName find by matching any one of them.
      * @param tx
      * @param siteNames
      * @return
@@ -68,8 +68,8 @@ public interface SiteDao extends OpenDcsDao
     /**
      * Retrieve all sites with the given row and offset.
      *
-     * Data is sorted by prefered site name type first, then any others. While there *SHOULD* always
-     * be a prefered name entry existing database may not. This can lead to inconsistent shorting.
+     * Data is sorted by preferred site name type first, then any others. While there *SHOULD* always
+     * be a preferred name entry, an existing database may not. This can lead to inconsistent shorting.
      *
      * @param tx
      * @param limit

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/SiteDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/SiteDao.java
@@ -1,0 +1,27 @@
+package org.opendcs.database.dai;
+
+import decodes.db.Site;
+import decodes.db.SiteName;
+import decodes.sql.DbKey;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.opendcs.database.api.DataTransaction;
+import org.opendcs.database.api.OpenDcsDao;
+import org.opendcs.database.api.OpenDcsDataException;
+
+public interface SiteDao extends OpenDcsDao
+{
+    Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException;
+
+    Optional<Site> getBySiteName(DataTransaction tx, SiteName siteName) throws OpenDcsDataException;
+
+    Optional<Site> getByAnySiteName(DataTransaction tx, String siteName) throws OpenDcsDataException;
+
+    Site save(DataTransaction tx, Site site) throws OpenDcsDataException;
+
+    void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException;
+
+    List<Site> getAll(DataTransaction tx, int limit, int offset) throws OpenDcsDataException;
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/SiteDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/SiteDao.java
@@ -14,15 +14,62 @@ import org.opendcs.database.api.OpenDcsDataException;
 
 public interface SiteDao extends OpenDcsDao
 {
+    /**
+     * Retrieve site by specific ID.
+     * @param tx active transaction for this request.
+     * @param id it is safe to pass null or {@see DbKey.NullKey}, Optional.empty will be returned.
+     * @return
+     * @throws OpenDcsDataException
+     */
     Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException;
 
+    /**
+     * Retrieve a site by specific SiteName (type + name)
+     * @param tx active transaction for this request.
+     * @param siteName Single site name of any type, if NameType doesn't exist, empty will be returned.
+     * @return
+     * @throws OpenDcsDataException
+     */
     Optional<Site> getBySiteName(DataTransaction tx, SiteName siteName) throws OpenDcsDataException;
 
+    /**
+     * Given a collection of NameTypes find by matching any one of them.
+     * @param tx
+     * @param siteNames
+     * @return
+     * @throws OpenDcsDataException
+     */
     Optional<Site> getByAnySiteName(DataTransaction tx, Collection<SiteName> siteNames) throws OpenDcsDataException;
 
+    /**
+     * Save (insert or update) a site to the database
+     * @param tx
+     * @param site
+     * @return
+     * @throws OpenDcsDataException
+     */
     Site save(DataTransaction tx, Site site) throws OpenDcsDataException;
 
+    /**
+     * Delete a site from the database, will fail if anything, such as a time series, still
+     * depends on this site.
+     * @param tx
+     * @param id
+     * @throws OpenDcsDataException
+     */
     void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException;
 
+    /**
+     * Retrieve all sites with the given row and offset.
+     *
+     * Data is sorted by prefered site name type first, then any others. While there *SHOULD* always
+     * be a prefered name entry existing database may not. This can lead to inconsistent shorting.
+     *
+     * @param tx
+     * @param limit
+     * @param offset
+     * @return
+     * @throws OpenDcsDataException
+     */
     List<Site> getAll(DataTransaction tx, int limit, int offset) throws OpenDcsDataException;
 }

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/SiteDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/SiteDao.java
@@ -4,6 +4,7 @@ import decodes.db.Site;
 import decodes.db.SiteName;
 import decodes.sql.DbKey;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,7 +18,7 @@ public interface SiteDao extends OpenDcsDao
 
     Optional<Site> getBySiteName(DataTransaction tx, SiteName siteName) throws OpenDcsDataException;
 
-    Optional<Site> getByAnySiteName(DataTransaction tx, String siteName) throws OpenDcsDataException;
+    Optional<Site> getByAnySiteName(DataTransaction tx, Collection<SiteName> siteNames) throws OpenDcsDataException;
 
     Site save(DataTransaction tx, Site site) throws OpenDcsDataException;
 

--- a/java/opendcs/src/main/java/org/opendcs/database/exceptions/RequiredSiteNameMissingException.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/exceptions/RequiredSiteNameMissingException.java
@@ -1,0 +1,14 @@
+package org.opendcs.database.exceptions;
+
+import org.opendcs.database.api.OpenDcsDataException;
+
+public class RequiredSiteNameMissingException extends OpenDcsDataException
+{
+
+    public RequiredSiteNameMissingException(String siteNameType)
+    {
+        super(String.format("A Site name of type '%s' is required but one was not provided.", siteNameType));
+    
+    }
+    
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -11,6 +11,7 @@ import org.jdbi.v3.core.Handle;
 import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.SiteDao;
+import org.opendcs.database.exceptions.RequiredSiteNameMissingException;
 import org.opendcs.database.impl.opendcs.dao.OpenDcsSiteDaoImpl;
 import org.opendcs.database.impl.opendcs.jdbi.column.numeric.NullableDoubleArgumentFactory;
 import org.opendcs.database.model.mappers.properties.PropertiesMapper;
@@ -104,9 +105,8 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
-                 .define(SqlQueries.WHERE_CLAUSE, "")
+                 .define(SqlQueries.WHERE_CLAUSE, "and location_code = :id")
                  .define(SqlQueries.LIMIT_CLAUSE, "")
-                 .define("where", "and location_code = :id")
                  .bind(GenericColumns.ID, id);
 
             return query.registerRowMapper(OpenDcsSiteMapper.withPrefix("s"))
@@ -130,13 +130,13 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             select distinct siteid from 
                 (
                     select siteid, nametype, sitename from (
-                        select siteid, nametype, sitename from sitename
+                        select siteid, nametype, sitename from sitename where db_office_code = cwms_util.user_office_code()
                         union all
                         select location_code siteid, 
                                'CWMS' nametype,
                                location_id sitename
                           from cwms_v_loc
-                         where unit_system = 'SI'
+                         where unit_system = 'SI' and db_office_id = cwms_util.user_office_id()
                     )
                 <where>
                 )
@@ -193,7 +193,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
         final var cwmsName = site.getName(Constants.snt_CWMS);
         if (cwmsName == null)
         {
-            throw new OpenDcsDataException("CWMS SiteNameType was not provided CWMS Database requires a CWMS name to be present on any Site.");
+            throw new RequiredSiteNameMissingException(Constants.snt_CWMS);
         }
 
         var handle = tx.connection(Handle.class)
@@ -257,10 +257,6 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             {
                 country = "US"; // required
             }
-            System.out.println("Saving " + site.getDisplayName() + " with ");
-            System.out.println("\telev" + site.getElevation());
-            System.out.println("\tlat " + site.latitude);
-            System.out.println("\tlong " + site.longitude);
             store.registerArgument(new NullableDoubleArgumentFactory())
                  .bind(GenericColumns.ID, bindKey)
                  .bind(GenericColumns.NAME, cwmsName.getNameValue())
@@ -334,6 +330,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             deleteNames.bind(GenericColumns.ID, id).execute();
             deleteProps.bind(GenericColumns.ID, id).execute();
             deleteLoc.bind(GenericColumns.ID, id).invoke();
+            // as we don't have a foreign key we need to manually check everything within opendcs
         }
     }
 

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -49,7 +49,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                   from cwms_v_loc
                   where unit_system='SI'
                   <where>
-                  and db_office_id = 'SPK'
+                  and db_office_id = ':officeId'
                 order by location_id COLLATE BINARY asc
                 <limit>
             )
@@ -75,8 +75,6 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                 select site_id, prop_name, prop_value from site_property
                 union all
                 select location_code siteid, 'horizontal_datum' prop_name, horizontal_datum prop_value from cwms_v_loc where unit_system = 'SI'
-                union all
-                select location_code siteid, 'vertical_datum' prop_name, vertical_datum prop_value from cwms_v_loc where unit_system = 'SI'
                 union all
                 select location_code siteid, 'vertical_datum' prop_name, vertical_datum prop_value from cwms_v_loc where unit_system = 'SI'
                 union all

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -238,7 +238,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
 					country = "US"; // required
             }
             store.bind(GenericColumns.ID, bindKey)
-                 .bind(GenericColumns.NAME, cwmsName)
+                 .bind(GenericColumns.NAME, cwmsName.getNameValue())
                  .bind("elevation", site.getElevation())
                  .bind("elevation_units", site.getElevationUnits())
                  .bind("vertical_datum", "NAVD88") // TODO : from props

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -99,6 +99,10 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
     @Override
     public Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException
     {
+    if (id == null)
+    {
+      return Optional.empty(); 
+    }
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -2,6 +2,7 @@ package org.opendcs.database.impl.cwms.dao;
 
 import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
 
+import java.sql.Types;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -18,6 +19,7 @@ import org.opendcs.database.model.mappers.properties.PropertiesMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteNameMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteReducer;
+import org.opendcs.model.cwms.CwmsSite;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
@@ -53,7 +55,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             select site.location_code s_id, site.location_id cwms_id , site.latitude s_latitude, site.longitude s_longitude,
                    site.nearest_city s_nearestcity, site.state_initial s_state, site.county_name s_region,
                    site.time_zone_name s_timezone, site.nation_id s_country, site.elevation s_elevation,
-                   site.unit_system s_elevunitabbr, site.description s_description, site.active_flag s_active_flag,
+                   'm' s_elevunitabbr, site.description s_description, site.active_flag s_active_flag,
                    site.location_type s_location_type, systimestamp s_modify_time, site.public_name s_public_name,
 
                    sn.nametype sn_nametype, sn.sitename sn_sitename, sn.dbnum sn_dbnum, sn.agency_cd sn_agency_cd,
@@ -87,7 +89,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                     when sn_nametype = 'CWMS' then 0
                     else 1
                 end, sn_nametype COLLATE BINARY asc
-             
+
             """;
 
     private static final String DELETE_NAMES = "delete from sitename where siteid = :id";
@@ -125,22 +127,26 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var officeId = ctx.getSettings(DecodesSettings.class)
+                          .orElseThrow(() -> new OpenDcsDataException("DecodesSettings are not available."))
+                          .CwmsOfficeId;
 
         try (var query = handle.createQuery("""
-            select distinct siteid from 
+            select distinct siteid from
                 (
                     select siteid, nametype, sitename from (
-                        select siteid, nametype, sitename from sitename where db_office_code = cwms_util.user_office_code()
+                        select siteid, nametype, sitename from sitename where db_office_code = cwms_util.get_office_code(:officeId)
                         union all
-                        select location_code siteid, 
+                        select location_code siteid,
                                'CWMS' nametype,
                                location_id sitename
                           from cwms_v_loc
-                         where unit_system = 'SI' and db_office_id = cwms_util.user_office_id()
+                         where unit_system = 'SI' and db_office_id = :officeId
                     )
                 <where>
                 )
-            """))
+            """).bind("officeId", officeId))
         {
             final StringBuilder whereClause = new StringBuilder();
             siteNames.forEach(sn ->
@@ -177,14 +183,10 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
     public Site save(DataTransaction tx, Site site) throws OpenDcsDataException
     {
         var ctx = tx.getContext();
-        var canWrite = ctx.getSettings(DecodesSettings.class)
-                          .orElseGet(() ->
-                          {
-                              var ret = new DecodesSettings();
-                              ret.writeCwmsLocations = false;
-                              return ret;
-                          })
-                          .writeCwmsLocations;
+        var settings = ctx.getSettings(DecodesSettings.class)
+                          .orElseThrow(() -> new OpenDcsDataException("No DecodesSettings are available?"));
+        var canWrite = settings.writeCwmsLocations;
+        var officeId = settings.CwmsOfficeId;
         if (!canWrite)
         {
             throw new OpenDcsDataException("The Current profile does not allow writing CWMS locations.");
@@ -198,7 +200,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
 
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
-        
+
 
         final var storeSql = """
                 {call cwms_loc.store_location2(
@@ -232,6 +234,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                 """;
 
          try (var store = handle.createCall(storeSql);
+            var getCode = handle.createQuery("select cwms_loc.get_location_code(:officeId, :name) id from dual");
             var deleteProps = handle.createUpdate(DELETE_PROPS);
             var insertProps = handle.prepareBatch("insert into site_property(site_id, prop_name, prop_value) values (:id, :name, :value)");
             var deleteNames = handle.createUpdate(DELETE_NAMES);
@@ -239,34 +242,30 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             )
         {
             var ignoreNulls = 'F';
-            DbKey id = site.getId();
             var existing = getByAnySiteName(tx, site.getNames());
             if (existing.isPresent())
             {
                 // If there's an existing app with this name, we'll just assume the provided id, if any, was in error
                 ignoreNulls = 'T';
-                id = existing.get().getId();
                 log.trace("""
-                    Using ID from existing Site, id={}, that was found. Provided ID was {}.
-                    """,
-                    id, site.getId());
+                    Updating an existing site. For Cwms Site update ignore nulls will be set to true,
+                    Generally CWMS doesn't want values removed, just updated.
+                    """);
             }
-            final var bindKey = id;
             var country = site.country;
             if (country == null || country.isBlank() || country.trim().toLowerCase().startsWith("us"))
             {
                 country = "US"; // required
             }
             store.registerArgument(new NullableDoubleArgumentFactory())
-                 .bind(GenericColumns.ID, bindKey)
                  .bind(GenericColumns.NAME, cwmsName.getNameValue())
                  .bind("type", site.getLocationType())
                  .bind("elevation", site.getElevation())
                  .bind("elevation_units", site.getElevationUnits())
-                 .bind("vertical_datum", site.getProperty("vertical_datum"))
+                 .bind(CwmsSite.VERTICAL_DATUM, site.getProperty(CwmsSite.VERTICAL_DATUM))
                  .bind("latitude", site.latitude != null ? Double.parseDouble(site.latitude) : null)
                  .bind("longitude", site.longitude != null ? Double.parseDouble(site.longitude) : null)
-                 .bind("horizontal_datum", site.getProperty("horizontal_datum"))
+                 .bind(CwmsSite.HORIZONTAL_DATUM, site.getProperty(CwmsSite.HORIZONTAL_DATUM))
                  .bind("public_name", site.getPublicName())
                  .bind("description", site.getDescription())
                  .bind("time_zone", site.timeZoneAbbr)
@@ -277,17 +276,24 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                  .bind("long_name", site.getBriefDescription())
                  .bind("nearest_city", site.nearestCity)
                  .bind("ignore_nulls", ignoreNulls)
-                 .bind("bounding_office", site.getProperty("bounding_office"))
+                 .bind(CwmsSite.BOUNDING_OFFICE, site.getProperty(CwmsSite.BOUNDING_OFFICE))
                  .invoke();
 
-            deleteProps.bind(GenericColumns.ID, bindKey).execute();
-            deleteNames.bind(GenericColumns.ID, bindKey).execute();
+            final var idOut = getCode.bind("officeId", officeId)
+                                     .bind(GenericColumns.NAME, cwmsName.getNameValue())
+                                     .mapTo(DbKey.class)
+                                     .findOne()
+                                     .orElseThrow(() -> new OpenDcsDataException("Unable to retrieve location code for the CWMS Location we just saved."))
+                                     ;
+
+            deleteProps.bind(GenericColumns.ID, idOut).execute();
+            deleteNames.bind(GenericColumns.ID, idOut).execute();
 
             site.getNames().forEachRemaining(name ->
             {
                 if (!Constants.snt_CWMS.equals(name.getNameType()))
                 {
-                    insertNames.bind(GenericColumns.ID, bindKey)
+                    insertNames.bind(GenericColumns.ID, idOut)
                                .bind("nametype", name.getNameType())
                                .bind("sitename", name.getNameValue())
                                .bind("dbnum", name.getUsgsDbno())
@@ -299,13 +305,11 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
 
             site.getProperties().forEach((k,v) ->
             {
-                if (k.equals("horizontal_datum") ||
-                    k.equals("vertical_datum") ||
-                    k.equals("bounding_office"))
+                if (CwmsSite.CWMS_SITE_PROPERTIES.contains(k))
                 {
                     return;
                 }
-                insertProps.bind(GenericColumns.ID, bindKey);
+                insertProps.bind(GenericColumns.ID, idOut);
                 insertProps.bind(GenericColumns.NAME, k.toString());
                 var toSave = v != null ? v.toString() : "";
                 insertProps.bind("value", toSave);
@@ -314,7 +318,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             insertProps.execute();
 
             // we don't directly get the ID so we'll just look up by the well defined CWMS name instead.
-            return getBySiteName(tx, cwmsName).orElseThrow(() -> new OpenDcsDataException("Unable to retrieve site we just saved."));
+            return getById(tx, idOut).orElseThrow(() -> new OpenDcsDataException("Unable to retrieve site we just saved."));
         }
     }
 
@@ -325,7 +329,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         try (var deleteNames = handle.createUpdate(DELETE_NAMES);
              var deleteProps = handle.createUpdate(DELETE_PROPS);
-             var deleteLoc = handle.createCall("{call cwms_loc.delete_loc(cwms_loc.get_location_id(:id))}"))
+             var deleteLoc = handle.createCall("{call cwms_loc.delete_location(cwms_loc.get_location_id(:id))}"))
         {
             deleteNames.bind(GenericColumns.ID, id).execute();
             deleteProps.bind(GenericColumns.ID, id).execute();
@@ -361,10 +365,8 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                         .registerRowMapper(OpenDcsSiteNameMapper.withPrefix("sn"))
                         .registerColumnMapper(Date.class, (r, columnNumber, stmtCtx) -> new Date())
                         .reduceRows(new OpenDcsSiteReducer("s"))
-                        
-                        .map(s -> s)
                         .toList();
         }
     }
-    
+
 }

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -12,6 +12,7 @@ import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.SiteDao;
 import org.opendcs.database.impl.opendcs.dao.OpenDcsSiteDaoImpl;
+import org.opendcs.database.impl.opendcs.jdbi.column.numeric.NullableDoubleArgumentFactory;
 import org.opendcs.database.model.mappers.properties.PropertiesMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteNameMapper;
@@ -25,11 +26,9 @@ import org.openide.util.lookup.ServiceProvider;
 import org.slf4j.Logger;
 
 import decodes.db.Constants;
-import decodes.db.DatabaseException;
 import decodes.db.Site;
 import decodes.db.SiteName;
 import decodes.sql.DbKey;
-import decodes.sql.KeyGenerator;
 import decodes.util.DecodesSettings;
 
 @ServiceProvider(service = SiteDao.class, path = "dao/CWMS-Oracle")
@@ -51,7 +50,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                 <limit>
             )
             select site.location_code s_id, site.location_id cwms_id , site.latitude s_latitude, site.longitude s_longitude,
-                   site.nearest_city s_nearestcity, site.state_initial s_state, '' s_region,
+                   site.nearest_city s_nearestcity, site.state_initial s_state, site.county_name s_region,
                    site.time_zone_name s_timezone, site.nation_id s_country, site.elevation s_elevation,
                    site.unit_system s_elevunitabbr, site.description s_description, site.active_flag s_active_flag,
                    site.location_type s_location_type, systimestamp s_modify_time, site.public_name s_public_name,
@@ -67,7 +66,20 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                 union all
                 select location_code siteid, 'CWMS' nametype, location_id sitename, null dbnum, null agency_cd from sites
              ) sn on sn.siteid = sites.location_code
-             left outer join site_property prop on prop.site_id = site.location_code
+
+             left outer join (
+                select site_id, prop_name, prop_value from site_property
+                union all
+                select location_code siteid, 'horizontal_datum' prop_name, horizontal_datum prop_value from cwms_v_loc where unit_system = 'SI'
+                union all
+                select location_code siteid, 'vertical_datum' prop_name, vertical_datum prop_value from cwms_v_loc where unit_system = 'SI'
+                union all
+                select location_code siteid, 'vertical_datum' prop_name, vertical_datum prop_value from cwms_v_loc where unit_system = 'SI'
+                union all
+                select location_code siteid, 'bounding_office' prop_name, bounding_office_id prop_value from cwms_v_loc where unit_system = 'SI'
+            ) prop on prop.site_id = site.location_code
+
+
              order by
                 cwms_id COLLATE BINARY asc,
                 case
@@ -117,11 +129,17 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
         try (var query = handle.createQuery("""
             select distinct siteid from 
                 (
-                select siteid, nametype, sitename from sitename
-                union all
-                select location_code siteid, 'CWMS' nametype, location_id sitename from cwms_v_loc where unit_system='SI'
+                    select siteid, nametype, sitename from (
+                        select siteid, nametype, sitename from sitename
+                        union all
+                        select location_code siteid, 
+                               'CWMS' nametype,
+                               location_id sitename
+                          from cwms_v_loc
+                         where unit_system = 'SI'
+                    )
+                <where>
                 )
-            <where>
             """))
         {
             final StringBuilder whereClause = new StringBuilder();
@@ -141,7 +159,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                 whereClause.append(" (")
                            .append("nametype = :").append(bindName)
                            .append(" and ")
-                           .append("sitename =:").append(bindValue)
+                           .append("sitename = :").append(bindValue)
                            .append(")");
 
                 query.bind(bindName, sn.getNameType())
@@ -181,33 +199,33 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         
-        var keyGen = ctx.getGenerator(KeyGenerator.class)
-                        .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
 
         final var storeSql = """
-                {cwms_loc.store_location2(
+                {call cwms_loc.store_location2(
                     p_location_id => :name,
+                    p_location_type => :type,
                     p_elevation => :elevation,
-                    P_elev_unit_id => :elevation_unit,
+                    P_elev_unit_id => :elevation_units,
                     p_vertical_datum => :vertical_datum,
                     p_latitude => :latitude,
-                    p_longtidue => :longitude,
+                    p_longitude => :longitude,
                     p_horizontal_datum => :horizontal_datum,
                     p_public_name => :public_name,
                     p_long_name => :long_name,
                     p_description => :description,
                     p_time_zone_id => :time_zone,
-                    p_county_name => NULL,
+                    p_county_name => :county,
                     p_state_initial => :state_initial,
                     p_active => :active,
                     p_location_kind_id => NULL,
                     p_map_label => NULL,
                     p_published_latitude => NULL,
                     p_published_longitude => NULL,
+                    p_bounding_office_id => :bounding_office,
                     p_nation_id => :country,
                     p_nearest_city => :nearest_city,
 
-                    p_ignore_nulls => 'T',
+                    p_ignorenulls => :ignore_nulls,
                     p_db_office_id => NULL
 
                 )}
@@ -220,11 +238,13 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             var insertNames = handle.prepareBatch("insert into sitename(siteid, nametype, sitename, dbnum, agency_cd) values (:id, :nametype, :sitename, :dbnum, :agency_code)")
             )
         {
+            var ignoreNulls = 'F';
             DbKey id = site.getId();
             var existing = getByAnySiteName(tx, site.getNames());
             if (existing.isPresent())
             {
                 // If there's an existing app with this name, we'll just assume the provided id, if any, was in error
+                ignoreNulls = 'T';
                 id = existing.get().getId();
                 log.trace("""
                     Using ID from existing Site, id={}, that was found. Provided ID was {}.
@@ -235,23 +255,33 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             var country = site.country;
             if (country == null || country.isBlank() || country.trim().toLowerCase().startsWith("us"))
             {
-					country = "US"; // required
+                country = "US"; // required
             }
-            store.bind(GenericColumns.ID, bindKey)
+            System.out.println("Saving " + site.getDisplayName() + " with ");
+            System.out.println("\telev" + site.getElevation());
+            System.out.println("\tlat " + site.latitude);
+            System.out.println("\tlong " + site.longitude);
+            store.registerArgument(new NullableDoubleArgumentFactory())
+                 .bind(GenericColumns.ID, bindKey)
                  .bind(GenericColumns.NAME, cwmsName.getNameValue())
+                 .bind("type", site.getLocationType())
                  .bind("elevation", site.getElevation())
                  .bind("elevation_units", site.getElevationUnits())
-                 .bind("vertical_datum", "NAVD88") // TODO : from props
-                 .bind("latitude", site.latitude)
-                 .bind("longitude", site.longitude)
-                 .bind("horizontal_datum", "WGS84") // TODO: also from props
+                 .bind("vertical_datum", site.getProperty("vertical_datum"))
+                 .bind("latitude", site.latitude != null ? Double.parseDouble(site.latitude) : null)
+                 .bind("longitude", site.longitude != null ? Double.parseDouble(site.longitude) : null)
+                 .bind("horizontal_datum", site.getProperty("horizontal_datum"))
                  .bind("public_name", site.getPublicName())
                  .bind("description", site.getDescription())
                  .bind("time_zone", site.timeZoneAbbr)
+                 .bind("county", site.region)
                  .bind("state_initial", site.state)
                  .bind("country", country)
+                 .bind("active", "T")
                  .bind("long_name", site.getBriefDescription())
                  .bind("nearest_city", site.nearestCity)
+                 .bind("ignore_nulls", ignoreNulls)
+                 .bind("bounding_office", site.getProperty("bounding_office"))
                  .invoke();
 
             deleteProps.bind(GenericColumns.ID, bindKey).execute();
@@ -264,16 +294,21 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                     insertNames.bind(GenericColumns.ID, bindKey)
                                .bind("nametype", name.getNameType())
                                .bind("sitename", name.getNameValue())
-                               .bind("db_num", name.getUsgsDbno())
+                               .bind("dbnum", name.getUsgsDbno())
                                .bind("agency_code", name.getAgencyCode())
                                .add();
                 }
             });
             insertNames.execute();
 
-            // TODO: exclude values that would be defined above in the store
             site.getProperties().forEach((k,v) ->
             {
+                if (k.equals("horizontal_datum") ||
+                    k.equals("vertical_datum") ||
+                    k.equals("bounding_office"))
+                {
+                    return;
+                }
                 insertProps.bind(GenericColumns.ID, bindKey);
                 insertProps.bind(GenericColumns.NAME, k.toString());
                 var toSave = v != null ? v.toString() : "";
@@ -290,8 +325,16 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
     @Override
     public void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException
     {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        try (var deleteNames = handle.createUpdate(DELETE_NAMES);
+             var deleteProps = handle.createUpdate(DELETE_PROPS);
+             var deleteLoc = handle.createCall("{call cwms_loc.delete_loc(cwms_loc.get_location_id(:id))}"))
+        {
+            deleteNames.bind(GenericColumns.ID, id).execute();
+            deleteProps.bind(GenericColumns.ID, id).execute();
+            deleteLoc.bind(GenericColumns.ID, id).invoke();
+        }
     }
 
     @Override

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -1,0 +1,141 @@
+package org.opendcs.database.impl.cwms.dao;
+
+import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.jdbi.v3.core.Handle;
+import org.opendcs.database.api.DataTransaction;
+import org.opendcs.database.api.OpenDcsDataException;
+import org.opendcs.database.dai.SiteDao;
+import org.opendcs.database.model.mappers.properties.PropertiesMapper;
+import org.opendcs.database.model.mappers.sites.OpenDcsSiteMapper;
+import org.opendcs.database.model.mappers.sites.OpenDcsSiteNameMapper;
+import org.opendcs.database.model.mappers.sites.OpenDcsSiteReducer;
+import org.opendcs.utils.sql.SqlErrorMessages;
+import org.opendcs.utils.sql.SqlKeywords;
+import org.opendcs.utils.sql.SqlQueries;
+import org.openide.util.lookup.ServiceProvider;
+
+import decodes.db.Site;
+import decodes.db.SiteName;
+import decodes.sql.DbKey;
+import decodes.util.DecodesSettings;
+
+@ServiceProvider(service = SiteDao.class, path = "dao/CWMS-Oracle")
+public final class CwmsSiteDaoImpl implements SiteDao
+{
+    /**
+     * Use of systimestamp for modify_time is not ideal; however it allows for the OpenDCS
+     * data flow to behave and have a value without a bunch of downstream null checks.
+     */
+    private static final String SELECT_QUERY = """
+            with sites (location_code, location_id) as (
+                select location_code, location_id
+                  from cwms_v_loc
+                  where unit_system='SI'
+                  <where>
+                  and db_office_id = 'SPK'
+                order by location_id COLLATE BINARY asc
+                <limit>
+            )
+            select site.location_code s_id, site.location_id cwms_id , site.latitude s_latitude, site.longitude s_longitude,
+                   site.nearest_city s_nearestcity, site.state_initial s_state, '' s_region,
+                   site.time_zone_name s_timezone, site.nation_id s_country, site.elevation s_elevation,
+                   site.unit_system s_elevunitabbr, site.description s_description, site.active_flag s_active_flag,
+                   site.location_type s_location_type, systimestamp s_modify_time, site.public_name s_public_name,
+
+                   sn.nametype sn_nametype, sn.sitename sn_sitename, sn.dbnum sn_dbnum, sn.agency_cd sn_agency_cd,
+
+                   prop.prop_name p_prop_name, prop.prop_value p_prop_value
+
+             from sites sites
+             left outer join cwms_v_loc site on sites.location_code = site.location_code and site.unit_system = 'SI'
+             left outer join (
+                select siteid, nametype, sitename, dbnum, agency_cd from sitename
+                union all
+                select location_code siteid, 'CWMS' nametype, location_id sitename, null dbnum, null agency_cd from sites
+             ) sn on sn.siteid = sites.location_code
+             left outer join site_property prop on prop.site_id = site.location_code
+             order by
+                cwms_id COLLATE BINARY asc,
+                case
+                    when sn_nametype = 'CWMS' then 0
+                    else 1
+                end, sn_nametype COLLATE BINARY asc
+             
+            """;
+
+    private static final String DELETE_NAMES = "delete from sitename where siteid = :id";
+    private static final String DELETE_PROPS = "delete from site_property where site_id = :id";
+
+
+    @Override
+    public Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getById'");
+    }
+
+    @Override
+    public Optional<Site> getBySiteName(DataTransaction tx, SiteName siteName) throws OpenDcsDataException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getBySiteName'");
+    }
+
+    @Override
+    public Optional<Site> getByAnySiteName(DataTransaction tx, Collection<SiteName> siteNames)
+            throws OpenDcsDataException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getByAnySiteName'");
+    }
+
+    @Override
+    public Site save(DataTransaction tx, Site site) throws OpenDcsDataException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'save'");
+    }
+
+    @Override
+    public void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+    }
+
+    @Override
+    public List<Site> getAll(DataTransaction tx, int limit, int offset) throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var dbEngine = ctx.getDatabase();
+
+        try (var query = handle.createQuery(SELECT_QUERY))
+        {
+            query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
+                 .define(SqlQueries.WHERE_CLAUSE, "")
+                 .define(SqlQueries.LIMIT_CLAUSE, addLimitOffset(limit, offset));
+                 //.bind("preferredType", preferredType);
+            if (limit >= 0)
+            {
+                query.bind(SqlKeywords.LIMIT, limit);
+            }
+            if (offset >= 0)
+            {
+                query.bind(SqlKeywords.OFFSET, offset);
+            }
+
+            return query.registerRowMapper(OpenDcsSiteMapper.withPrefix("s"))
+                        .registerRowMapper(PropertiesMapper.withPrefix("p", true))
+                        .registerRowMapper(OpenDcsSiteNameMapper.withPrefix("sn"))
+                        .registerColumnMapper(Date.class, (r, columnNumber, stmtCtx) -> new Date())
+                        .reduceRows(new OpenDcsSiteReducer("s"))
+                        
+                        .map(s -> s)
+                        .toList();
+        }
+    }
+    
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -29,6 +29,7 @@ import org.opendcs.utils.sql.SqlQueries;
 import org.openide.util.lookup.ServiceProvider;
 import org.slf4j.Logger;
 
+import decodes.cwms.CwmsConstants;
 import decodes.db.Constants;
 import decodes.db.Site;
 import decodes.db.SiteName;
@@ -49,7 +50,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                   from cwms_v_loc
                   where unit_system='SI'
                   <where>
-                  and db_office_id = :officeId
+                  and db_office_id = :cwmsofficeid
                 order by location_id COLLATE BINARY asc
                 <limit>
             )
@@ -110,7 +111,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
                  .define(SqlQueries.WHERE_CLAUSE, "and location_code = :id")
                  .define(SqlQueries.LIMIT_CLAUSE, "")
-                 .bind("officeId", officeId)
+                 .bind(CwmsConstants.CWMS_OFFICE_ID, officeId)
                  .bind(GenericColumns.ID, id);
 
             return query.registerRowMapper(OpenDcsSiteMapper.withPrefix("s"))
@@ -138,17 +139,17 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             select distinct siteid from
                 (
                     select siteid, nametype, sitename from (
-                        select siteid, nametype, sitename from sitename where db_office_code = cwms_util.get_office_code(:officeId)
+                        select siteid, nametype, sitename from sitename where db_office_code = cwms_util.get_office_code(:cwmsofficeid)
                         union all
                         select location_code siteid,
                                'CWMS' nametype,
                                location_id sitename
                           from cwms_v_loc
-                         where unit_system = 'SI' and db_office_id = :officeId
+                         where unit_system = 'SI' and db_office_id = :cwmsofficeid
                     )
                 <where>
                 )
-            """).bind("officeId", officeId))
+            """).bind(CwmsConstants.CWMS_OFFICE_ID, officeId))
         {
             final StringBuilder whereClause = new StringBuilder();
             siteNames.forEach(sn ->
@@ -236,7 +237,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                 """;
 
          try (var store = handle.createCall(storeSql);
-            var getCode = handle.createQuery("select cwms_loc.get_location_code(:officeId, :name) id from dual");
+            var getCode = handle.createQuery("select cwms_loc.get_location_code(:cwmsofficeid, :name) id from dual");
             var deleteProps = handle.createUpdate(DELETE_PROPS);
             var insertProps = handle.prepareBatch("insert into site_property(site_id, prop_name, prop_value) values (:id, :name, :value)");
             var deleteNames = handle.createUpdate(DELETE_NAMES);
@@ -278,7 +279,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                  .bind(CwmsSite.BOUNDING_OFFICE, site.getProperty(CwmsSite.BOUNDING_OFFICE))
                  .invoke();
 
-            final var idOut = getCode.bind("officeId", officeId)
+            final var idOut = getCode.bind(CwmsConstants.CWMS_OFFICE_ID, officeId)
                                      .bind(GenericColumns.NAME, cwmsName.getNameValue())
                                      .mapTo(DbKey.class)
                                      .findOne()
@@ -362,7 +363,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
                  .define(SqlQueries.WHERE_CLAUSE, "")
                  .define(SqlQueries.LIMIT_CLAUSE, addLimitOffset(limit, offset))
-                 .bind("officeId", officeId);
+                 .bind(CwmsConstants.CWMS_OFFICE_ID, officeId);
             if (limit >= 0)
             {
                 query.bind(SqlKeywords.LIMIT, limit);

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -2,6 +2,7 @@ package org.opendcs.database.impl.cwms.dao;
 
 import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
 
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
 import java.util.Date;
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.SiteDao;
@@ -185,9 +187,8 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
         var ctx = tx.getContext();
         var settings = ctx.getSettings(DecodesSettings.class)
                           .orElseThrow(() -> new OpenDcsDataException("No DecodesSettings are available?"));
-        var canWrite = settings.writeCwmsLocations;
-        var officeId = settings.CwmsOfficeId;
-        if (!canWrite)
+        final var officeId = settings.CwmsOfficeId;
+        if (!settings.writeCwmsLocations)
         {
             throw new OpenDcsDataException("The Current profile does not allow writing CWMS locations.");
         }
@@ -252,11 +253,8 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                     Generally CWMS doesn't want values removed, just updated.
                     """);
             }
-            var country = site.country;
-            if (country == null || country.isBlank() || country.trim().toLowerCase().startsWith("us"))
-            {
-                country = "US"; // required
-            }
+            var country = site.country == null ? "US" : site.country.trim();
+
             store.registerArgument(new NullableDoubleArgumentFactory())
                  .bind(GenericColumns.NAME, cwmsName.getNameValue())
                  .bind("type", site.getLocationType())
@@ -335,6 +333,14 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
             deleteProps.bind(GenericColumns.ID, id).execute();
             deleteLoc.bind(GenericColumns.ID, id).invoke();
             // as we don't have a foreign key we need to manually check everything within opendcs
+        }
+        catch (UnableToExecuteStatementException ex)
+        {
+            if (ex.getCause() instanceof SQLException sqlEx && sqlEx.getErrorCode() == 1403 /* ora-01403 no data found  */)
+            {
+                return; // No data, quietly return.
+            }
+            throw ex;
         }
     }
 

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -3,7 +3,6 @@ package org.opendcs.database.impl.cwms.dao;
 import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
 
 import java.sql.SQLException;
-import java.sql.Types;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -182,6 +181,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
     }
 
     @Override
+    @SuppressWarnings("java:S138") // this is really only long because the SQL and Binds are vertical for clarity.
     public Site save(DataTransaction tx, Site site) throws OpenDcsDataException
     {
         var ctx = tx.getContext();

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -49,7 +49,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                   from cwms_v_loc
                   where unit_system='SI'
                   <where>
-                  and db_office_id = ':officeId'
+                  and db_office_id = :officeId
                 order by location_id COLLATE BINARY asc
                 <limit>
             )
@@ -102,12 +102,15 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
         var dbEngine = ctx.getDatabase();
-
+        var officeId = ctx.getSettings(DecodesSettings.class)
+                          .orElseThrow(() -> new OpenDcsDataException("DecodesSettings are not available."))
+                          .CwmsOfficeId;
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
                  .define(SqlQueries.WHERE_CLAUSE, "and location_code = :id")
                  .define(SqlQueries.LIMIT_CLAUSE, "")
+                 .bind("officeId", officeId)
                  .bind(GenericColumns.ID, id);
 
             return query.registerRowMapper(OpenDcsSiteMapper.withPrefix("s"))
@@ -323,6 +326,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+
         try (var deleteNames = handle.createUpdate(DELETE_NAMES);
              var deleteProps = handle.createUpdate(DELETE_PROPS);
              var deleteLoc = handle.createCall("{call cwms_loc.delete_location(cwms_loc.get_location_id(:id))}"))
@@ -349,12 +353,16 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
         var dbEngine = ctx.getDatabase();
+        var settings = ctx.getSettings(DecodesSettings.class)
+                          .orElseThrow(() -> new OpenDcsDataException("No DecodesSettings are available?"));
+        final var officeId = settings.CwmsOfficeId;
 
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
                  .define(SqlQueries.WHERE_CLAUSE, "")
-                 .define(SqlQueries.LIMIT_CLAUSE, addLimitOffset(limit, offset));
+                 .define(SqlQueries.LIMIT_CLAUSE, addLimitOffset(limit, offset))
+                 .bind("officeId", officeId);
             if (limit >= 0)
             {
                 query.bind(SqlKeywords.LIMIT, limit);

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -11,23 +11,31 @@ import org.jdbi.v3.core.Handle;
 import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.SiteDao;
+import org.opendcs.database.impl.opendcs.dao.OpenDcsSiteDaoImpl;
 import org.opendcs.database.model.mappers.properties.PropertiesMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteNameMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteReducer;
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
 import org.opendcs.utils.sql.SqlKeywords;
 import org.opendcs.utils.sql.SqlQueries;
 import org.openide.util.lookup.ServiceProvider;
+import org.slf4j.Logger;
 
+import decodes.db.Constants;
+import decodes.db.DatabaseException;
 import decodes.db.Site;
 import decodes.db.SiteName;
 import decodes.sql.DbKey;
+import decodes.sql.KeyGenerator;
 import decodes.util.DecodesSettings;
 
 @ServiceProvider(service = SiteDao.class, path = "dao/CWMS-Oracle")
-public final class CwmsSiteDaoImpl implements SiteDao
+public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
 {
+    private static final Logger log = OpenDcsLoggerFactory.getLogger();
     /**
      * Use of systimestamp for modify_time is not ideal; however it allows for the OpenDCS
      * data flow to behave and have a value without a bunch of downstream null checks.
@@ -74,32 +82,214 @@ public final class CwmsSiteDaoImpl implements SiteDao
 
 
     @Override
-    public Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getById'");
+    public Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var dbEngine = ctx.getDatabase();
+
+        try (var query = handle.createQuery(SELECT_QUERY))
+        {
+            query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
+                 .define(SqlQueries.WHERE_CLAUSE, "")
+                 .define(SqlQueries.LIMIT_CLAUSE, "")
+                 .define("where", "and location_code = :id")
+                 .bind(GenericColumns.ID, id);
+
+            return query.registerRowMapper(OpenDcsSiteMapper.withPrefix("s"))
+                        .registerRowMapper(PropertiesMapper.withPrefix("p", true))
+                        .registerRowMapper(OpenDcsSiteNameMapper.withPrefix("sn"))
+                        .registerColumnMapper(Date.class, (r, columnNumber, stmtCtx) -> new Date())
+                        .reduceRows(new OpenDcsSiteReducer("s"))
+                        .findFirst();
+        }
     }
 
-    @Override
-    public Optional<Site> getBySiteName(DataTransaction tx, SiteName siteName) throws OpenDcsDataException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getBySiteName'");
-    }
 
     @Override
     public Optional<Site> getByAnySiteName(DataTransaction tx, Collection<SiteName> siteNames)
-            throws OpenDcsDataException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getByAnySiteName'");
+            throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+
+        try (var query = handle.createQuery("""
+            select distinct siteid from 
+                (
+                select siteid, nametype, sitename from sitename
+                union all
+                select location_code siteid, 'CWMS' nametype, location_id sitename from cwms_v_loc where unit_system='SI'
+                )
+            <where>
+            """))
+        {
+            final StringBuilder whereClause = new StringBuilder();
+            siteNames.forEach(sn ->
+            {
+                final var bindName = OpenDcsSiteDaoImpl.WHITE_SPACE.matcher(sn.getNameType()).replaceAll("_");
+                final var bindValue = bindName + "Value";
+
+                if (!whereClause.isEmpty())
+                {
+                    whereClause.append(" or ");
+                }
+                else
+                {
+                    whereClause.append(" where ");
+                }
+                whereClause.append(" (")
+                           .append("nametype = :").append(bindName)
+                           .append(" and ")
+                           .append("sitename =:").append(bindValue)
+                           .append(")");
+
+                query.bind(bindName, sn.getNameType())
+                     .bind(bindValue, sn.getNameValue());
+            });
+            var id = query.define("where", whereClause)
+                          .mapTo(DbKey.class)
+                          .findOne()
+                          .orElse(DbKey.NullKey);
+            return getById(tx, id);
+        }
     }
 
     @Override
-    public Site save(DataTransaction tx, Site site) throws OpenDcsDataException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'save'");
+    public Site save(DataTransaction tx, Site site) throws OpenDcsDataException
+    {
+        var ctx = tx.getContext();
+        var canWrite = ctx.getSettings(DecodesSettings.class)
+                          .orElseGet(() ->
+                          {
+                              var ret = new DecodesSettings();
+                              ret.writeCwmsLocations = false;
+                              return ret;
+                          })
+                          .writeCwmsLocations;
+        if (!canWrite)
+        {
+            throw new OpenDcsDataException("The Current profile does not allow writing CWMS locations.");
+        }
+
+        final var cwmsName = site.getName(Constants.snt_CWMS);
+        if (cwmsName == null)
+        {
+            throw new OpenDcsDataException("CWMS SiteNameType was not provided CWMS Database requires a CWMS name to be present on any Site.");
+        }
+
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        
+        var keyGen = ctx.getGenerator(KeyGenerator.class)
+                        .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
+
+        final var storeSql = """
+                {cwms_loc.store_location2(
+                    p_location_id => :name,
+                    p_elevation => :elevation,
+                    P_elev_unit_id => :elevation_unit,
+                    p_vertical_datum => :vertical_datum,
+                    p_latitude => :latitude,
+                    p_longtidue => :longitude,
+                    p_horizontal_datum => :horizontal_datum,
+                    p_public_name => :public_name,
+                    p_long_name => :long_name,
+                    p_description => :description,
+                    p_time_zone_id => :time_zone,
+                    p_county_name => NULL,
+                    p_state_initial => :state_initial,
+                    p_active => :active,
+                    p_location_kind_id => NULL,
+                    p_map_label => NULL,
+                    p_published_latitude => NULL,
+                    p_published_longitude => NULL,
+                    p_nation_id => :country,
+                    p_nearest_city => :nearest_city,
+
+                    p_ignore_nulls => 'T',
+                    p_db_office_id => NULL
+
+                )}
+                """;
+
+         try (var store = handle.createCall(storeSql);
+            var deleteProps = handle.createUpdate(DELETE_PROPS);
+            var insertProps = handle.prepareBatch("insert into site_property(site_id, prop_name, prop_value) values (:id, :name, :value)");
+            var deleteNames = handle.createUpdate(DELETE_NAMES);
+            var insertNames = handle.prepareBatch("insert into sitename(siteid, nametype, sitename, dbnum, agency_cd) values (:id, :nametype, :sitename, :dbnum, :agency_code)")
+            )
+        {
+            DbKey id = site.getId();
+            var existing = getByAnySiteName(tx, site.getNames());
+            if (existing.isPresent())
+            {
+                // If there's an existing app with this name, we'll just assume the provided id, if any, was in error
+                id = existing.get().getId();
+                log.trace("""
+                    Using ID from existing Site, id={}, that was found. Provided ID was {}.
+                    """,
+                    id, site.getId());
+            }
+            final var bindKey = id;
+            var country = site.country;
+            if (country == null || country.isBlank() || country.trim().toLowerCase().startsWith("us"))
+            {
+					country = "US"; // required
+            }
+            store.bind(GenericColumns.ID, bindKey)
+                 .bind(GenericColumns.NAME, cwmsName)
+                 .bind("elevation", site.getElevation())
+                 .bind("elevation_units", site.getElevationUnits())
+                 .bind("vertical_datum", "NAVD88") // TODO : from props
+                 .bind("latitude", site.latitude)
+                 .bind("longitude", site.longitude)
+                 .bind("horizontal_datum", "WGS84") // TODO: also from props
+                 .bind("public_name", site.getPublicName())
+                 .bind("description", site.getDescription())
+                 .bind("time_zone", site.timeZoneAbbr)
+                 .bind("state_initial", site.state)
+                 .bind("country", country)
+                 .bind("long_name", site.getBriefDescription())
+                 .bind("nearest_city", site.nearestCity)
+                 .invoke();
+
+            deleteProps.bind(GenericColumns.ID, bindKey).execute();
+            deleteNames.bind(GenericColumns.ID, bindKey).execute();
+
+            site.getNames().forEachRemaining(name ->
+            {
+                if (!Constants.snt_CWMS.equals(name.getNameType()))
+                {
+                    insertNames.bind(GenericColumns.ID, bindKey)
+                               .bind("nametype", name.getNameType())
+                               .bind("sitename", name.getNameValue())
+                               .bind("db_num", name.getUsgsDbno())
+                               .bind("agency_code", name.getAgencyCode())
+                               .add();
+                }
+            });
+            insertNames.execute();
+
+            // TODO: exclude values that would be defined above in the store
+            site.getProperties().forEach((k,v) ->
+            {
+                insertProps.bind(GenericColumns.ID, bindKey);
+                insertProps.bind(GenericColumns.NAME, k.toString());
+                var toSave = v != null ? v.toString() : "";
+                insertProps.bind("value", toSave);
+                insertProps.add();
+            });
+            insertProps.execute();
+
+            // we don't directly get the ID so we'll just look up by the well defined CWMS name instead.
+            return getBySiteName(tx, cwmsName).orElseThrow(() -> new OpenDcsDataException("Unable to retrieve site we just saved."));
+        }
     }
 
     @Override
-    public void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException {
+    public void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException
+    {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'delete'");
     }
@@ -117,7 +307,6 @@ public final class CwmsSiteDaoImpl implements SiteDao
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
                  .define(SqlQueries.WHERE_CLAUSE, "")
                  .define(SqlQueries.LIMIT_CLAUSE, addLimitOffset(limit, offset));
-                 //.bind("preferredType", preferredType);
             if (limit >= 0)
             {
                 query.bind(SqlKeywords.LIMIT, limit);

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBoolean.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBoolean.java
@@ -6,7 +6,11 @@ import java.sql.SQLException;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
-public class CwmsBoolean implements ColumnMapper<Boolean> {
+/**
+ * Maps CWMS 'T'/'F' column to Java Boolean
+ */
+public class CwmsBoolean implements ColumnMapper<Boolean>
+{
 
     @Override
     public Boolean map(ResultSet rs, int columnNumber, StatementContext ctx) throws SQLException

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBoolean.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBoolean.java
@@ -1,0 +1,24 @@
+package org.opendcs.database.impl.cwms.jdbi;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class CwmsBoolean implements ColumnMapper<Boolean> {
+
+    @Override
+    public Boolean map(ResultSet rs, int columnNumber, StatementContext ctx) throws SQLException
+    {
+        boolean ret = false;
+        final var dbValue = rs.getString(columnNumber);
+        if (!rs.wasNull())
+        {
+            ret = Boolean.parseBoolean(dbValue.toLowerCase());
+        }
+
+        return ret;
+    }
+    
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBoolean.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBoolean.java
@@ -6,6 +6,8 @@ import java.sql.SQLException;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
+import ilex.util.TextUtil;
+
 /**
  * Maps CWMS 'T'/'F' column to Java Boolean
  */
@@ -19,10 +21,10 @@ public class CwmsBoolean implements ColumnMapper<Boolean>
         final var dbValue = rs.getString(columnNumber);
         if (!rs.wasNull())
         {
-            ret = Boolean.parseBoolean(dbValue.toLowerCase());
+            // str2boolean works with true/false and yes/no, only comparing the the first character.
+            ret = TextUtil.str2boolean(dbValue);
         }
 
         return ret;
     }
-    
 }

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBooleanArgumentFactory.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBooleanArgumentFactory.java
@@ -39,7 +39,7 @@ public class CwmsBooleanArgumentFactory implements ArgumentFactory.Preparable
     @Override
     public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config)
     {
-        if (type == boolen.class || type == Boolean.class)
+        if (type == boolean.class || type == Boolean.class)
         {
             return Optional.of(value -> build(type, value, config).get());
         }

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBooleanArgumentFactory.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBooleanArgumentFactory.java
@@ -20,7 +20,6 @@ public class CwmsBooleanArgumentFactory implements ArgumentFactory.Preparable
     {
         if (type == boolean.class || type == Boolean.class)
         {
-            final var val = (boolean) value;
             return Optional.of((position, statement, ctx) ->
             {
                 if (value == null)
@@ -29,6 +28,7 @@ public class CwmsBooleanArgumentFactory implements ArgumentFactory.Preparable
                 }
                 else
                 {
+            final var val = (boolean) value;
                     statement.setString(position, val ? "T" : "F");
                 }
             });
@@ -39,7 +39,7 @@ public class CwmsBooleanArgumentFactory implements ArgumentFactory.Preparable
     @Override
     public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config)
     {
-        if (type == double.class || type == Double.class)
+        if (type == boolen.class || type == Boolean.class)
         {
             return Optional.of(value -> build(type, value, config).get());
         }

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBooleanArgumentFactory.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBooleanArgumentFactory.java
@@ -1,0 +1,38 @@
+package org.opendcs.database.impl.cwms.jdbi;
+
+import java.lang.reflect.Type;
+import java.sql.Types;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.argument.ArgumentFactory;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+public class CwmsBooleanArgumentFactory implements ArgumentFactory.Preparable
+{
+
+    @Override
+    public Optional<Argument> build(Type type, Object value, ConfigRegistry config)
+    {
+        if (type == boolean.class || type == Boolean.class) {
+            final var val = (boolean) value;
+            return Optional.of((position, statement, ctx) -> {
+                if (value == null) {
+                    statement.setNull(position, Types.VARCHAR);
+                } else {
+                    statement.setString(position, val ? "T" : "F");
+                }
+            });
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+        if (type == double.class || type == Double.class) {
+            return Optional.of(value -> build(type, value, config).get());
+        }
+        return Optional.empty();
+    }
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBooleanArgumentFactory.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/cwms/jdbi/CwmsBooleanArgumentFactory.java
@@ -9,18 +9,26 @@ import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.config.ConfigRegistry;
 
+/**
+ * Maps java boolean and Boolean to CWMS Database 'T'/'F' character.
+ */
 public class CwmsBooleanArgumentFactory implements ArgumentFactory.Preparable
 {
 
     @Override
     public Optional<Argument> build(Type type, Object value, ConfigRegistry config)
     {
-        if (type == boolean.class || type == Boolean.class) {
+        if (type == boolean.class || type == Boolean.class)
+        {
             final var val = (boolean) value;
-            return Optional.of((position, statement, ctx) -> {
-                if (value == null) {
+            return Optional.of((position, statement, ctx) ->
+            {
+                if (value == null)
+                {
                     statement.setNull(position, Types.VARCHAR);
-                } else {
+                }
+                else
+                {
                     statement.setString(position, val ? "T" : "F");
                 }
             });
@@ -29,8 +37,10 @@ public class CwmsBooleanArgumentFactory implements ArgumentFactory.Preparable
     }
 
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
-        if (type == double.class || type == Double.class) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config)
+    {
+        if (type == double.class || type == Double.class)
+        {
             return Optional.of(value -> build(type, value, config).get());
         }
         return Optional.empty();

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -14,6 +14,7 @@ import org.jdbi.v3.core.Handle;
 import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.SiteDao;
+import org.opendcs.database.impl.opendcs.jdbi.column.numeric.NullableDoubleArgumentFactory;
 import org.opendcs.database.model.mappers.properties.PropertiesMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteNameMapper;
@@ -53,7 +54,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
      * just to cover edge cases in existing databases.
      */
     private static final String SELECT_QUERY = """
-            with sites (siteid) as (
+            with sites (siteid, sitename) as (
                 select siteid, sitename
                   from (
                     select  siteid, nametype, min(sitename) sitename
@@ -64,7 +65,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                             when nametype = :preferredType then 0
                             else 1
                         end, nametype <collate> asc
-                     
+
                   ) sorted_sitenames
                 <where>
                 order by sitename <collate> asc
@@ -132,8 +133,8 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
     public Optional<Site> getByAnySiteName(DataTransaction tx, Collection<SiteName> siteNames) throws OpenDcsDataException
     {
         var handle = tx.connection(Handle.class)
-                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));        
-                              
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+
         try (var query = handle.createQuery("select distinct siteid from sitename where <where>"))
         {
             final StringBuilder whereClause = new StringBuilder();
@@ -150,7 +151,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                            .append(" and ")
                            .append("sitename =:").append(bindValue)
                            .append(")");
-                
+
                 query.bind(bindName, sn.getNameType())
                      .bind(bindValue, sn.getNameValue());
             });
@@ -162,7 +163,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
         }
     }
 
-    
+
     private Optional<Site> getByAnySiteName(DataTransaction tx, Iterator<SiteName> siteNames) throws OpenDcsDataException
     {
         final List<SiteName> names = new ArrayList<>();
@@ -181,7 +182,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
         final var mergeSql = """
                     merge into site
                     using (
-                        select 
+                        select
                             :id id, :latitude latitude, :longitude longitude, :nearestcity nearestcity,
                             :state state, :region region, :timezone timezone, :country country,
                             :elevation elevation, :elevunitabbr elevunitabbr, :description description,
@@ -190,8 +191,8 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                         ) input
                     on (site.id = input.id)
                     when matched then
-                        update set 
-                            id = input.id, latitude = input.latitude, longitude = input.longitude,
+                        update set
+                            latitude = input.latitude, longitude = input.longitude,
                             nearestcity = input.nearestcity, state = input.state, region = input.region,
                             timezone = input.timezone, country = input.country, elevation = input.elevation,
                             elevunitabbr = input.elevunitabbr, description = input.description,
@@ -212,7 +213,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
             var insertProps = handle.prepareBatch("insert into site_property(site_id, prop_name, prop_value) values (:id, :name, :value)");
             var deleteNames = handle.createUpdate(DELETE_NAMES);
             var insertNames = handle.prepareBatch("insert into sitename(siteid, nametype, sitename, dbnum, agency_cd) values (:id, :nametype, :sitename, :dbnum, :agency_code)")
-            )        
+            )
         {
             DbKey id = site.getId();
             var existing = getByAnySiteName(tx, site.getNames());
@@ -226,8 +227,9 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                     id, site.getId());
             }
             final var bindKey = !DbKey.isNull(id) ? id : keyGen.getKey("site", handle.getConnection());
-            
+
             merge.define("numeric_date", true)
+                 .registerArgument(new NullableDoubleArgumentFactory())
                  .bind(GenericColumns.ID, bindKey)
                  .bind("latitude", site.latitude)
                  .bind("longitude", site.longitude)

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -27,7 +27,6 @@ import org.opendcs.utils.sql.SqlQueries;
 
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
-import org.python.util.Generic;
 import org.slf4j.Logger;
 
 import decodes.db.DatabaseException;
@@ -85,6 +84,11 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
              left outer join site on sites.siteid = site.id
              left outer join sitename sn on sn.siteid = sites.siteid
              left outer join site_property prop on prop.site_id = site.id
+             order by
+                case
+                    when sn_nametype = :preferredType then 0
+                    else 1
+                end, sn_nametype <collate> asc, sn_sitename <collate> asc
             """;
 
     private static final String DELETE_NAMES = "delete from sitename where siteid = :id";

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -117,14 +117,35 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
     @Override
     public Optional<Site> getBySiteName(DataTransaction tx, SiteName siteName) throws OpenDcsDataException
     {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getBySiteName'");
+        return getByAnySiteName(tx, List.of(siteName));
     }
 
     @Override
     public Optional<Site> getByAnySiteName(DataTransaction tx, Collection<SiteName> siteNames) throws OpenDcsDataException
     {
-        
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));        
+                              
+        try (var query = handle.createQuery("select siteid from sitename where <where>"))
+        {
+            final StringBuilder whereClause = new StringBuilder();
+            siteNames.forEach(sn ->
+            {
+                final var bindName = sn.getNameType().replaceAll("\\s\\t\\w", "_");
+                if (!whereClause.isEmpty())
+                {
+                    whereClause.append(" or ");
+                }
+                whereClause.append(" ").append("nametype = :").append(bindName);
+                
+                query.bind(sn.getNameType(), sn.getNameValue());
+            });
+            var id = query.define("where", whereClause)
+                          .mapTo(DbKey.class)
+                          .findOne()
+                          .orElse(DbKey.NullKey);
+            return getById(tx, id);
+        }
     }
 
     

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -14,6 +14,7 @@ import org.jdbi.v3.core.Handle;
 import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.SiteDao;
+import org.opendcs.database.exceptions.RequiredSiteNameMissingException;
 import org.opendcs.database.impl.opendcs.jdbi.column.numeric.NullableDoubleArgumentFactory;
 import org.opendcs.database.model.mappers.properties.PropertiesMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteMapper;
@@ -29,6 +30,7 @@ import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
 import org.slf4j.Logger;
 
+import decodes.db.Constants;
 import decodes.db.DatabaseException;
 import decodes.db.Site;
 import decodes.db.SiteName;
@@ -177,6 +179,12 @@ public class OpenDcsSiteDaoImpl implements SiteDao
     @Override
     public Site save(DataTransaction tx, Site site) throws OpenDcsDataException
     {
+        final var cwmsName = site.getName(Constants.snt_CWMS);
+        if (cwmsName == null)
+        {
+            throw new RequiredSiteNameMissingException(Constants.snt_CWMS);
+        }
+
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -2,7 +2,9 @@ package org.opendcs.database.impl.opendcs.dao;
 
 import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
 
-import java.util.LinkedHashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +16,7 @@ import org.opendcs.database.model.mappers.properties.PropertiesMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteNameMapper;
 import org.opendcs.database.model.mappers.sites.OpenDcsSiteReducer;
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
 import org.opendcs.utils.sql.SqlKeywords;
@@ -21,10 +24,13 @@ import org.opendcs.utils.sql.SqlQueries;
 
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
+import org.slf4j.Logger;
 
+import decodes.db.DatabaseException;
 import decodes.db.Site;
 import decodes.db.SiteName;
 import decodes.sql.DbKey;
+import decodes.sql.KeyGenerator;
 import decodes.util.DecodesSettings;
 
 // This uses Postgres specific features and is not compatible with Oracle
@@ -38,6 +44,7 @@ import decodes.util.DecodesSettings;
 })
 public final class OpenDcsSiteDaoImpl implements SiteDao
 {
+    private static final Logger log = OpenDcsLoggerFactory.getLogger();
     /**
      * order asc on the inner nametype is to keep the general output predicatable.
      * There <b>shouldn't</b> be any Sites without a Preferred SiteName so this is
@@ -80,8 +87,28 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
     @Override
     public Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException
     {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getById'");
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var dbEngine = ctx.getDatabase();
+        var preferredType = ctx.getSettings(DecodesSettings.class)
+                              .map(ds -> ds.siteNameTypePreference)
+                              .orElseGet(() -> "CWMS");
+        try (var query = handle.createQuery(SELECT_QUERY))
+        {
+            query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
+                 .define(SqlQueries.WHERE_CLAUSE, "where siteid = :id")
+                 .define(SqlQueries.LIMIT_CLAUSE, "")
+                 .bind("preferredType", preferredType)
+                 .bind(GenericColumns.ID, id);
+
+            return query.registerRowMapper(OpenDcsSiteMapper.withPrefix("s"))
+                        .registerRowMapper(PropertiesMapper.withPrefix("p", true))
+                        .registerRowMapper(OpenDcsSiteNameMapper.withPrefix("sn"))
+                        .reduceRows(new OpenDcsSiteReducer("s"))
+                        .map(s -> s)
+                        .findFirst();
+        }
     }
 
     @Override
@@ -92,16 +119,57 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
     }
 
     @Override
-    public Optional<Site> getByAnySiteName(DataTransaction tx, String siteName) throws OpenDcsDataException
+    public Optional<Site> getByAnySiteName(DataTransaction tx, Collection<SiteName> siteNames) throws OpenDcsDataException
     {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getByAnySiteName'");
     }
 
+    
+    private Optional<Site> getByAnySiteName(DataTransaction tx, Iterator<SiteName> siteNames) throws OpenDcsDataException
+    {
+        final List<SiteName> names = new ArrayList<>();
+        siteNames.forEachRemaining(names::add);
+        return getByAnySiteName(tx, names);
+    }
+
     @Override
-    public Site save(DataTransaction tx, Site site) throws OpenDcsDataException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'save'");
+    public Site save(DataTransaction tx, Site site) throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var keyGen = ctx.getGenerator(KeyGenerator.class)
+                        .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
+        final var mergeSql = """
+                    merge into site
+                """;
+        try (var merge = handle.createUpdate(mergeSql);
+            var deleteProps = handle.createUpdate("delete from site_property where site_id = :id");
+            var insertProps = handle.prepareBatch("insert into site_property(site_id, prop_name, prop_value) values (:id, :name, :value)");
+            var deleteNames = handle.createUpdate("delete from sitename where siteid = :id");
+            var insertNames = handle.prepareBatch("insert into sitename(siteid, nametype, sitename, dbnum, agency_cd) values (:id, :nametype, :sitename, :dbnum, :agency_code)");
+            )        
+        {
+            DbKey id = site.getId();
+            var existing = getByAnySiteName(tx, site.getNames());
+            if (existing.isPresent())
+            {
+                // If there's an existing app with this name, we'll just assume the provided id, if any, was in error
+                id = existing.get().getId();
+                log.trace("""
+                    Using ID from existing Site, id={}, that was found. Provided ID was {}.
+                    Existing Name is {}. New Name is {}.
+                    """,
+                    id, site.getId());
+            }
+            final var bindKey = !DbKey.isNull(id) ? id : keyGen.getKey("site", handle.getConnection());
+        }
+        catch (DatabaseException ex)
+        {
+            throw new OpenDcsDataException("Unable to generate key to save site", ex);
+        }
+        return null;
     }
 
     @Override

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -4,9 +4,11 @@ import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.jdbi.v3.core.Handle;
 import org.opendcs.database.api.DataTransaction;
@@ -24,6 +26,7 @@ import org.opendcs.utils.sql.SqlQueries;
 
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
+import org.python.util.Generic;
 import org.slf4j.Logger;
 
 import decodes.db.DatabaseException;
@@ -33,7 +36,6 @@ import decodes.sql.DbKey;
 import decodes.sql.KeyGenerator;
 import decodes.util.DecodesSettings;
 
-// This uses Postgres specific features and is not compatible with Oracle
 @ServiceProviders({
     @ServiceProvider(service = SiteDao.class, path = "dao/OpenDCS-Postgres"),
     @ServiceProvider(service = SiteDao.class, path = "dao/OpenDCS-Oracle"),
@@ -87,9 +89,15 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
     private static final String DELETE_NAMES = "delete from sitename where siteid = :id";
     private static final String DELETE_PROPS = "delete from site_property where site_id = :id";
 
+    private static final Pattern WHITE_SPACE = Pattern.compile("[\\h\\v\\p{IsWhite_Space}]+");
+
     @Override
     public Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException
     {
+        if (DbKey.isNull(id))
+        {
+            return Optional.empty();
+        }
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
@@ -126,19 +134,25 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));        
                               
-        try (var query = handle.createQuery("select siteid from sitename where <where>"))
+        try (var query = handle.createQuery("select distinct siteid from sitename where <where>"))
         {
             final StringBuilder whereClause = new StringBuilder();
             siteNames.forEach(sn ->
             {
-                final var bindName = sn.getNameType().replaceAll("\\s\\t\\w", "_");
+                final var bindName = WHITE_SPACE.matcher(sn.getNameType()).replaceAll("_");
+                final var bindValue = bindName + "Value";
                 if (!whereClause.isEmpty())
                 {
                     whereClause.append(" or ");
                 }
-                whereClause.append(" ").append("nametype = :").append(bindName);
+                whereClause.append(" (")
+                           .append("nametype = :").append(bindName)
+                           .append(" and ")
+                           .append("sitename =:").append(bindValue)
+                           .append(")");
                 
-                query.bind(sn.getNameType(), sn.getNameValue());
+                query.bind(bindName, sn.getNameType())
+                     .bind(bindValue, sn.getNameValue());
             });
             var id = query.define("where", whereClause)
                           .mapTo(DbKey.class)
@@ -174,6 +188,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                             :active_flag active_flag, :location_type location_type, :modify_time modify_time,
                             :public_name public_name
                         ) input
+                    on (site.id = input.id)
                     when matched then
                         update set 
                             id = input.id, latitude = input.latitude, longitude = input.longitude,
@@ -191,15 +206,12 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                                input.region, input.timezone, input.country, input.elevation, input.elevunitabbr,
                                input.description, input.active_flag, input.location_type, input.modify_time,
                                input.public_name)
-                    
-                    
-                    on (site.id = input.id)
                 """;
         try (var merge = handle.createUpdate(mergeSql);
             var deleteProps = handle.createUpdate(DELETE_PROPS);
             var insertProps = handle.prepareBatch("insert into site_property(site_id, prop_name, prop_value) values (:id, :name, :value)");
             var deleteNames = handle.createUpdate(DELETE_NAMES);
-            var insertNames = handle.prepareBatch("insert into sitename(siteid, nametype, sitename, dbnum, agency_cd) values (:id, :nametype, :sitename, :dbnum, :agency_code)");
+            var insertNames = handle.prepareBatch("insert into sitename(siteid, nametype, sitename, dbnum, agency_cd) values (:id, :nametype, :sitename, :dbnum, :agency_code)")
             )        
         {
             DbKey id = site.getId();
@@ -210,7 +222,6 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                 id = existing.get().getId();
                 log.trace("""
                     Using ID from existing Site, id={}, that was found. Provided ID was {}.
-                    Existing Name is {}. New Name is {}.
                     """,
                     id, site.getId());
             }
@@ -218,7 +229,21 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
             
             merge.define("numeric_date", true)
                  .bind(GenericColumns.ID, bindKey)
-                 
+                 .bind("latitude", site.latitude)
+                 .bind("longitude", site.longitude)
+                 .bind("nearestcity", site.nearestCity)
+                 .bind("state", site.state)
+                 .bind("region", site.region)
+                 .bind("timezone", site.timeZoneAbbr)
+                 .bind("country", site.country)
+                 .bind("elevation", site.getElevation())
+                 .bind("elevunitabbr", site.getElevationUnits())
+                 .bind("description", site.getDescription())
+                 .bind("active_flag", site.isActive() ? "TRUE" : "FALSE")
+                 .bind("location_type", site.getLocationType())
+                 .bind("modify_time", new Date())
+                 .bind("public_name", site.getPublicName())
+
                  // bind the rest
                  .execute();
 
@@ -230,7 +255,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                            .bind("nametype", name.getNameType())
                            .bind("sitename", name.getNameValue())
                            .bind("dbnum", name.getUsgsDbno())
-                           .bind("agency_cd", name.getAgencyCode())
+                           .bind("agency_code", name.getAgencyCode())
                            .add()
             );
             insertNames.execute();
@@ -238,7 +263,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
 
             site.getProperties().forEach((k,v) ->
             {
-                insertProps.bind("site_id", bindKey);
+                insertProps.bind(GenericColumns.ID, bindKey);
                 insertProps.bind(GenericColumns.NAME, k.toString());
                 var toSave = v != null ? v.toString() : "";
                 insertProps.bind("value", toSave);

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -88,9 +88,9 @@ public class OpenDcsSiteDaoImpl implements SiteDao
              left outer join site_property prop on prop.site_id = site.id
              order by
                 case
-                    when sn_nametype = :preferredType then 0
+                    when sn.nametype = :preferredType then 0
                     else 1
-                end, sn_nametype <collate> asc, sn_sitename <collate> asc
+                end, sn.nametype <collate> asc, sn.sitename <collate> asc
             """;
 
     private static final String DELETE_NAMES = "delete from sitename where siteid = :id";

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -84,6 +84,9 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
              left outer join site_property prop on prop.site_id = site.id
             """;
 
+    private static final String DELETE_NAMES = "delete from sitename where siteid = :id";
+    private static final String DELETE_PROPS = "delete from site_property where site_id = :id";
+
     @Override
     public Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException
     {
@@ -121,8 +124,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
     @Override
     public Optional<Site> getByAnySiteName(DataTransaction tx, Collection<SiteName> siteNames) throws OpenDcsDataException
     {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getByAnySiteName'");
+        
     }
 
     
@@ -143,11 +145,39 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                         .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
         final var mergeSql = """
                     merge into site
+                    using (
+                        select 
+                            :id id, :latitude latitude, :longitude longitude, :nearestcity nearestcity,
+                            :state state, :region region, :timezone timezone, :country country,
+                            :elevation elevation, :elevunitabbr elevunitabbr, :description description,
+                            :active_flag active_flag, :location_type location_type, :modify_time modify_time,
+                            :public_name public_name
+                        ) input
+                    when matched then
+                        update set 
+                            id = input.id, latitude = input.latitude, longitude = input.longitude,
+                            nearestcity = input.nearestcity, state = input.state, region = input.region,
+                            timezone = input.timezone, country = input.country, elevation = input.elevation,
+                            elevunitabbr = input.elevunitabbr, description = input.description,
+                            active_flag = input.active_flag, location_type = input.location_type,
+                            modify_time = input.modify_time, public_name = input.public_name
+                    when not matched then
+                        insert(
+                            id, latitude, longitude, nearestcity,state, region, timezone, country,
+                            elevation, elevunitabbr, description, active_flag, location_type, modify_time,
+                            public_name)
+                        values(input.id, input.latitude, input.longitude, input.nearestcity,input.state,
+                               input.region, input.timezone, input.country, input.elevation, input.elevunitabbr,
+                               input.description, input.active_flag, input.location_type, input.modify_time,
+                               input.public_name)
+                    
+                    
+                    on (site.id = input.id)
                 """;
         try (var merge = handle.createUpdate(mergeSql);
-            var deleteProps = handle.createUpdate("delete from site_property where site_id = :id");
+            var deleteProps = handle.createUpdate(DELETE_PROPS);
             var insertProps = handle.prepareBatch("insert into site_property(site_id, prop_name, prop_value) values (:id, :name, :value)");
-            var deleteNames = handle.createUpdate("delete from sitename where siteid = :id");
+            var deleteNames = handle.createUpdate(DELETE_NAMES);
             var insertNames = handle.prepareBatch("insert into sitename(siteid, nametype, sitename, dbnum, agency_cd) values (:id, :nametype, :sitename, :dbnum, :agency_code)");
             )        
         {
@@ -164,18 +194,57 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                     id, site.getId());
             }
             final var bindKey = !DbKey.isNull(id) ? id : keyGen.getKey("site", handle.getConnection());
+            
+            merge.define("numeric_date", true)
+                 .bind(GenericColumns.ID, bindKey)
+                 
+                 // bind the rest
+                 .execute();
+
+            deleteProps.bind(GenericColumns.ID, bindKey).execute();
+            deleteNames.bind(GenericColumns.ID, bindKey).execute();
+
+            site.getNames().forEachRemaining(name ->
+                insertNames.bind(GenericColumns.ID, bindKey)
+                           .bind("nametype", name.getNameType())
+                           .bind("sitename", name.getNameValue())
+                           .bind("dbnum", name.getUsgsDbno())
+                           .bind("agency_cd", name.getAgencyCode())
+                           .add()
+            );
+            insertNames.execute();
+
+
+            site.getProperties().forEach((k,v) ->
+            {
+                insertProps.bind("site_id", bindKey);
+                insertProps.bind(GenericColumns.NAME, k.toString());
+                var toSave = v != null ? v.toString() : "";
+                insertProps.bind("value", toSave);
+                insertProps.add();
+            });
+            insertProps.execute();
+            return getById(tx, bindKey).orElseThrow(() -> new OpenDcsDataException("Unable to retrieve site we just saved."));
         }
         catch (DatabaseException ex)
         {
             throw new OpenDcsDataException("Unable to generate key to save site", ex);
         }
-        return null;
     }
 
     @Override
-    public void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+    public void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        try (var deleteNames = handle.createUpdate(DELETE_NAMES);
+             var deleteProps = handle.createUpdate(DELETE_PROPS);
+             var deleteSite = handle.createUpdate("delete from site where id = :id"))
+        {
+            deleteNames.bind(GenericColumns.ID, id).execute();
+            deleteProps.bind(GenericColumns.ID, id).execute();
+            deleteSite.bind(GenericColumns.ID, id).execute();
+        }
     }
 
     @Override

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -44,7 +44,7 @@ import decodes.util.DecodesSettings;
     // This will be done in a follow up PR.
     @ServiceProvider(service = SiteDao.class, path = "dao/OPENTSDB")
 })
-public final class OpenDcsSiteDaoImpl implements SiteDao
+public class OpenDcsSiteDaoImpl implements SiteDao
 {
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
     /**
@@ -94,7 +94,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
     private static final String DELETE_NAMES = "delete from sitename where siteid = :id";
     private static final String DELETE_PROPS = "delete from site_property where site_id = :id";
 
-    private static final Pattern WHITE_SPACE = Pattern.compile("[\\h\\v\\p{IsWhite_Space}]+");
+    public static final Pattern WHITE_SPACE = Pattern.compile("[\\h\\v\\p{IsWhite_Space}]+");
 
     @Override
     public Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException
@@ -122,7 +122,6 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                         .registerRowMapper(PropertiesMapper.withPrefix("p", true))
                         .registerRowMapper(OpenDcsSiteNameMapper.withPrefix("sn"))
                         .reduceRows(new OpenDcsSiteReducer("s"))
-                        .map(s -> s)
                         .findFirst();
         }
     }
@@ -168,7 +167,7 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
     }
 
 
-    private Optional<Site> getByAnySiteName(DataTransaction tx, Iterator<SiteName> siteNames) throws OpenDcsDataException
+    protected Optional<Site> getByAnySiteName(DataTransaction tx, Iterator<SiteName> siteNames) throws OpenDcsDataException
     {
         final List<SiteName> names = new ArrayList<>();
         siteNames.forEachRemaining(names::add);

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -41,7 +41,7 @@ import decodes.util.DecodesSettings;
 @ServiceProviders({
     @ServiceProvider(service = SiteDao.class, path = "dao/OpenDCS-Postgres"),
     @ServiceProvider(service = SiteDao.class, path = "dao/OpenDCS-Oracle"),
-    // deprecated and also implies supported by the Oracle impl which is false.
+    // deprecated
     // Unfortunately correct behavior requires eliminating the use of the editDatabaseCode so the names are used.
     // This will be done in a follow up PR.
     @ServiceProvider(service = SiteDao.class, path = "dao/OPENTSDB")

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -1,0 +1,132 @@
+package org.opendcs.database.impl.opendcs.dao;
+
+import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+
+import org.jdbi.v3.core.Handle;
+import org.opendcs.database.api.DataTransaction;
+import org.opendcs.database.api.OpenDcsDataException;
+import org.opendcs.database.dai.SiteDao;
+import org.opendcs.database.model.mappers.properties.PropertiesMapper;
+
+import org.opendcs.utils.sql.GenericColumns;
+import org.opendcs.utils.sql.SqlErrorMessages;
+import org.opendcs.utils.sql.SqlKeywords;
+import org.opendcs.utils.sql.SqlQueries;
+
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.util.lookup.ServiceProviders;
+
+import decodes.db.Site;
+import decodes.db.SiteName;
+import decodes.sql.DbKey;
+
+// This uses Postgres specific features and is not compatible with Oracle
+@ServiceProviders({
+    @ServiceProvider(service = SiteDao.class, path = "dao/OpenDCS-Postgres"),
+    @ServiceProvider(service = SiteDao.class, path = "dao/OpenDCS-Oracle"),
+    // deprecated and also implies supported by the Oracle impl which is false.
+    // Unfortunately correct behavior requires eliminating the use of the editDatabaseCode so the names are used.
+    // This will be done in a follow up PR.
+    @ServiceProvider(service = SiteDao.class, path = "dao/OPENTSDB")
+})
+public final class OpenDcsSiteDaoImpl implements SiteDao
+{
+    private static final String SELECT_QUERY = """
+            with sitenames (siteid, sitename) as (
+                select  siteid, min(sitename)
+                order by case
+                    when nametype = :prefered_type then 0
+                    else 1
+                end, sitename <collate> asc
+            )
+            with sites (siteid) as (
+                select siteid, sitename
+                  from sitenames
+                <where>
+                order by sitename
+                <limit>
+            )
+
+            select site.id s_id, site.latitude s_latitude, site.longitude s_longitude,
+                   site.nearestcity s_nearestcity, site.state s_state, site.region s_region,
+                   site.timezone s_timezone, site.country s_country, site.elevation s_elevation,
+                   site.elvunitabbr s_elevunitabbr, site.description s_description, site.active_flag s_active_flag,
+                   site.location_type s_location_type, site.modify_type s_modify_time, site.public_name s_public_name
+
+                   sn.nametype sn_nametype, sn.sitename sn_sitename, sn.dbnum sn_dbnum, sn.agency_cd sn_agency_cd
+
+                   prop.prop_name p_prop_name, prop.prop_value p_prop_value
+
+             from sites sites
+             left outer join site on sites.siteid = site.id
+             left outer join sitename sn on sn.siteid = sites.siteid
+             left outer join site_property prop on props.site_id = site.id
+            """;
+
+    @Override
+    public Optional<Site> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException
+    {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getById'");
+    }
+
+    @Override
+    public Optional<Site> getBySiteName(DataTransaction tx, SiteName siteName) throws OpenDcsDataException
+    {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getBySiteName'");
+    }
+
+    @Override
+    public Optional<Site> getByAnySiteName(DataTransaction tx, String siteName) throws OpenDcsDataException
+    {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getByAnySiteName'");
+    }
+
+    @Override
+    public Site save(DataTransaction tx, Site site) throws OpenDcsDataException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'save'");
+    }
+
+    @Override
+    public void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+    }
+
+    @Override
+    public List<Site> getAll(DataTransaction tx, int limit, int offset) throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var dbEngine = ctx.getDatabase();
+        try (var query = handle.createQuery(SELECT_QUERY))
+        {
+            query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
+                 .define(SqlQueries.WHERE_CLAUSE, "")
+                 .define(SqlQueries.LIMIT_CLAUSE, addLimitOffset(limit, offset));
+            if (limit >= 0)
+            {
+                query.bind(SqlKeywords.LIMIT, limit);
+            }
+            if (offset >= 0)
+            {
+                query.bind(SqlKeywords.OFFSET, offset);
+            }
+
+            return query.registerRowMapper(SiteRowMapper.withPrefix("s"))
+                        .registerRowMapper(PropertiesMapper.withPrefix("p", true))
+                        .registerRowMapper(SiteNameMapper.writhPrefix("sn"))
+                        .values()
+                        .stream()
+                        .toList();
+        }
+    }
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -11,7 +11,9 @@ import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.SiteDao;
 import org.opendcs.database.model.mappers.properties.PropertiesMapper;
-
+import org.opendcs.database.model.mappers.sites.OpenDcsSiteMapper;
+import org.opendcs.database.model.mappers.sites.OpenDcsSiteNameMapper;
+import org.opendcs.database.model.mappers.sites.OpenDcsSiteReducer;
 import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
 import org.opendcs.utils.sql.SqlKeywords;
@@ -23,6 +25,7 @@ import org.openide.util.lookup.ServiceProviders;
 import decodes.db.Site;
 import decodes.db.SiteName;
 import decodes.sql.DbKey;
+import decodes.util.DecodesSettings;
 
 // This uses Postgres specific features and is not compatible with Oracle
 @ServiceProviders({
@@ -35,36 +38,43 @@ import decodes.sql.DbKey;
 })
 public final class OpenDcsSiteDaoImpl implements SiteDao
 {
+    /**
+     * order asc on the inner nametype is to keep the general output predicatable.
+     * There <b>shouldn't</b> be any Sites without a Preferred SiteName so this is
+     * just to cover edge cases in existing databases.
+     */
     private static final String SELECT_QUERY = """
-            with sitenames (siteid, sitename) as (
-                select  siteid, min(sitename)
-                order by case
-                    when nametype = :prefered_type then 0
-                    else 1
-                end, sitename <collate> asc
-            )
             with sites (siteid) as (
                 select siteid, sitename
-                  from sitenames
+                  from (
+                    select  siteid, nametype, min(sitename) sitename
+                      from sitename
+                     group by siteid, nametype
+                     order by
+                        case
+                            when nametype = :preferredType then 0
+                            else 1
+                        end, nametype <collate> asc
+                     
+                  ) sorted_sitenames
                 <where>
-                order by sitename
+                order by sitename <collate> asc
                 <limit>
             )
-
             select site.id s_id, site.latitude s_latitude, site.longitude s_longitude,
                    site.nearestcity s_nearestcity, site.state s_state, site.region s_region,
                    site.timezone s_timezone, site.country s_country, site.elevation s_elevation,
-                   site.elvunitabbr s_elevunitabbr, site.description s_description, site.active_flag s_active_flag,
-                   site.location_type s_location_type, site.modify_type s_modify_time, site.public_name s_public_name
+                   site.elevunitabbr s_elevunitabbr, site.description s_description, site.active_flag s_active_flag,
+                   site.location_type s_location_type, site.modify_time s_modify_time, site.public_name s_public_name,
 
-                   sn.nametype sn_nametype, sn.sitename sn_sitename, sn.dbnum sn_dbnum, sn.agency_cd sn_agency_cd
+                   sn.nametype sn_nametype, sn.sitename sn_sitename, sn.dbnum sn_dbnum, sn.agency_cd sn_agency_cd,
 
                    prop.prop_name p_prop_name, prop.prop_value p_prop_value
 
              from sites sites
              left outer join site on sites.siteid = site.id
              left outer join sitename sn on sn.siteid = sites.siteid
-             left outer join site_property prop on props.site_id = site.id
+             left outer join site_property prop on prop.site_id = site.id
             """;
 
     @Override
@@ -107,11 +117,16 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
         var dbEngine = ctx.getDatabase();
+        var preferredType = ctx.getSettings(DecodesSettings.class)
+                              .map(ds -> ds.siteNameTypePreference)
+                              .orElseGet(() -> "CWMS");
+
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
                  .define(SqlQueries.WHERE_CLAUSE, "")
-                 .define(SqlQueries.LIMIT_CLAUSE, addLimitOffset(limit, offset));
+                 .define(SqlQueries.LIMIT_CLAUSE, addLimitOffset(limit, offset))
+                 .bind("preferredType", preferredType);
             if (limit >= 0)
             {
                 query.bind(SqlKeywords.LIMIT, limit);
@@ -121,11 +136,11 @@ public final class OpenDcsSiteDaoImpl implements SiteDao
                 query.bind(SqlKeywords.OFFSET, offset);
             }
 
-            return query.registerRowMapper(SiteRowMapper.withPrefix("s"))
+            return query.registerRowMapper(OpenDcsSiteMapper.withPrefix("s"))
                         .registerRowMapper(PropertiesMapper.withPrefix("p", true))
-                        .registerRowMapper(SiteNameMapper.writhPrefix("sn"))
-                        .values()
-                        .stream()
+                        .registerRowMapper(OpenDcsSiteNameMapper.withPrefix("sn"))
+                        .reduceRows(new OpenDcsSiteReducer("s"))
+                        .map(s -> s)
                         .toList();
         }
     }

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/jdbi/column/chrono/OpenDcsTimeColumn.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/jdbi/column/chrono/OpenDcsTimeColumn.java
@@ -1,0 +1,46 @@
+package org.opendcs.database.impl.opendcs.jdbi.column.chrono;
+
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.sql.SQLException;
+import java.util.Date;
+
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public final class OpenDcsTimeColumn implements ColumnMapper<Date>
+{
+
+    @Override
+    public Date map(ResultSet rs, int columnNumber, StatementContext ctx) throws SQLException
+    {
+        var meta = rs.getMetaData();
+        int type = meta.getColumnType(columnNumber);
+        Date ret = null;
+        switch (type) 
+        {
+            case Types.DATE, Types.TIMESTAMP:
+            {
+                var tmp = rs.getTimestamp(columnNumber);
+                if (!rs.wasNull())
+                {
+                    ret = new Date(tmp.getTime());
+                }
+                break;
+            }
+            case Types.NUMERIC, Types.BIGINT:
+            {
+                var tmp = rs.getLong(columnNumber);
+                if (!rs.wasNull())
+                {
+                    ret = new Date(tmp);
+                }
+                break;
+            }
+            
+            default: throw new SQLException("Unable to determine how to convert column " + meta.getColumnName(columnNumber) + " to a Date");
+        }
+        return ret;
+    }
+    
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/jdbi/column/chrono/OpenDcsTimeColumnArgumentFactory.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/jdbi/column/chrono/OpenDcsTimeColumnArgumentFactory.java
@@ -1,0 +1,51 @@
+package org.opendcs.database.impl.opendcs.jdbi.column.chrono;
+
+import java.lang.reflect.Type;
+import java.util.Date;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.argument.ArgumentFactory;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+public class OpenDcsTimeColumnArgumentFactory implements ArgumentFactory.Preparable
+{
+
+    @Override
+    public Optional<Argument> build(Type type, Object value, ConfigRegistry config)
+    {
+        if (type == Date.class)
+        {
+            return Optional.of(
+                (position, statement, ctx) ->
+                {
+                    final var tmp = (Boolean)ctx.getAttribute("numeric_date");                    
+                    final var datesAreInt =  tmp != null && tmp;
+                    if (datesAreInt)
+                    {
+                        statement.setLong(position, ((Date)value).getTime());
+                    }
+                    else
+                    {
+                        statement.setDate(position, new java.sql.Date(((Date)value).getTime()));
+                    }
+                });
+        }
+        else
+        {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config)
+    {
+        if (type == Date.class)
+        {
+            return Optional.of(value -> build(type, value, config).get());
+        }
+        return Optional.empty();
+    }
+    
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/jdbi/column/numeric/NullableDoubleArgumentFactory.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/impl/opendcs/jdbi/column/numeric/NullableDoubleArgumentFactory.java
@@ -39,16 +39,15 @@ public class NullableDoubleArgumentFactory implements ArgumentFactory.Preparable
     {
         if (type == double.class || type == Double.class)
         {
-            final double val = (double)value;
             return Optional.of((position, statement, ctx) ->
             {
-                if (val == undefinedValue)
+                if (value == null || (double)value == undefinedValue)
                 {
                     statement.setNull(position, Types.DOUBLE);
                 }
                 else
                 {
-                    statement.setDouble(position, val);
+                    statement.setDouble(position, (double)value);
                 }
             });
         }

--- a/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteMapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteMapper.java
@@ -2,9 +2,11 @@ package org.opendcs.database.model.mappers.sites;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Date;
 
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.opendcs.database.impl.opendcs.jdbi.column.numeric.NullableDouble;
 import org.opendcs.database.model.mappers.PrefixRowMapper;
 import org.opendcs.utils.sql.SqlErrorMessages;
 
@@ -31,6 +33,9 @@ public class OpenDcsSiteMapper extends PrefixRowMapper<Site>
     {
         ColumnMapper<DbKey> columnMapperForKey = ctx.findColumnMapperFor(DbKey.class)
                                                     .orElseThrow(() -> new SQLException(SqlErrorMessages.DBKEY_MAPPER_NOT_FOUND));
+        ColumnMapper<Double> doubleMapper = new NullableDouble();
+        ColumnMapper<Date> dateMapper = ctx.findColumnMapperFor(Date.class)
+                                .orElseThrow(() -> new SQLException(SqlErrorMessages.TIME_MAPPER_NOT_FOUND));
         var ret = new Site();
 
         var id = columnMapperForKey.map(rs, prefix + "id", ctx);
@@ -38,6 +43,22 @@ public class OpenDcsSiteMapper extends PrefixRowMapper<Site>
         
         ret.setPublicName(rs.getString(prefix + "public_name"));        
         ret.setDescription(rs.getString(prefix + "description"));
+
+        ret.latitude = rs.getString(prefix + "latitude");
+        ret.longitude = rs.getString(prefix + "longitude");
+
+        ret.setElevation(doubleMapper.map(rs, prefix + "elevation", ctx));
+        ret.setElevationUnits(rs.getString(prefix + "elevunitabbr"));
+
+        ret.nearestCity = rs.getString(prefix + "nearestcity");
+        ret.state = rs.getString(prefix + "state");
+        ret.region = rs.getString(prefix + "region");
+        ret.timeZoneAbbr = rs.getString(prefix + "timezone");
+        ret.country = rs.getString(prefix + "country");
+        ret.setActive(rs.getBoolean(prefix + "active_flag"));
+        ret.setLocationType(rs.getString(prefix + "location_type"));
+        ret.setLastModifyTime(dateMapper.map(rs, prefix + "modify_time", ctx));
+
 
         return ret;
     }

--- a/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteMapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteMapper.java
@@ -1,0 +1,45 @@
+package org.opendcs.database.model.mappers.sites;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.opendcs.database.model.mappers.PrefixRowMapper;
+import org.opendcs.utils.sql.SqlErrorMessages;
+
+import decodes.db.Site;
+import decodes.sql.DbKey;
+
+public class OpenDcsSiteMapper extends PrefixRowMapper<Site>
+{
+
+
+    
+    protected OpenDcsSiteMapper(String prefix)
+    {
+        super(prefix);
+    }
+
+    public static OpenDcsSiteMapper withPrefix(String prefix)
+    {
+        return new OpenDcsSiteMapper(prefix);
+    }
+
+    @Override
+    public Site map(ResultSet rs, StatementContext ctx) throws SQLException
+    {
+        ColumnMapper<DbKey> columnMapperForKey = ctx.findColumnMapperFor(DbKey.class)
+                                                    .orElseThrow(() -> new SQLException(SqlErrorMessages.DBKEY_MAPPER_NOT_FOUND));
+        var ret = new Site();
+
+        var id = columnMapperForKey.map(rs, prefix + "id", ctx);
+        ret.forceSetId(id);
+        
+        ret.setPublicName(rs.getString(prefix + "public_name"));        
+        ret.setDescription(rs.getString(prefix + "description"));
+
+        return ret;
+    }
+    
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteMapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteMapper.java
@@ -17,7 +17,7 @@ public class OpenDcsSiteMapper extends PrefixRowMapper<Site>
 {
 
 
-    
+
     protected OpenDcsSiteMapper(String prefix)
     {
         super(prefix);
@@ -40,8 +40,8 @@ public class OpenDcsSiteMapper extends PrefixRowMapper<Site>
 
         var id = columnMapperForKey.map(rs, prefix + "id", ctx);
         ret.forceSetId(id);
-        
-        ret.setPublicName(rs.getString(prefix + "public_name"));        
+
+        ret.setPublicName(rs.getString(prefix + "public_name"));
         ret.setDescription(rs.getString(prefix + "description"));
 
         ret.latitude = rs.getString(prefix + "latitude");
@@ -62,5 +62,5 @@ public class OpenDcsSiteMapper extends PrefixRowMapper<Site>
 
         return ret;
     }
-    
+
 }

--- a/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteNameMapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteNameMapper.java
@@ -1,0 +1,39 @@
+package org.opendcs.database.model.mappers.sites;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.statement.StatementContext;
+import org.opendcs.database.model.mappers.PrefixRowMapper;
+
+import decodes.db.SiteName;
+
+public class OpenDcsSiteNameMapper extends PrefixRowMapper<SiteName>
+{
+
+    protected OpenDcsSiteNameMapper(String prefix)
+    {
+        super(prefix);
+    }
+
+    public static OpenDcsSiteNameMapper withPrefix(String prefix)
+    {
+        return new OpenDcsSiteNameMapper(prefix);
+    }
+
+    @Override
+    public SiteName map(ResultSet rs, StatementContext ctx) throws SQLException
+    {
+        var type = rs.getString(prefix + "nametype");
+        var name = rs.getString(prefix + "sitename");
+        if (type == null)
+        {
+            return null;
+        }
+        var ret = new SiteName(null, type, name);
+        ret.setAgencyCode(rs.getString(prefix + "agency_cd"));
+        ret.setUsgsDbno(rs.getString(prefix + "dbnum"));
+        return ret;
+    }
+    
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteReducer.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteReducer.java
@@ -32,7 +32,7 @@ public class OpenDcsSiteReducer implements BiConsumer<Map<Long, Site>, RowView>
                 qid -> rowView.getRow(Site.class)
         );
         var prop = rowView.getRow(PropertiesMapper.PAIR_STRING_STRING);
-        if (prop.first != null)
+        if (prop.first != null && prop.second != null)
         {
             site.setProperty(prop.first, prop.second);
         }

--- a/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteReducer.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteReducer.java
@@ -1,0 +1,48 @@
+package org.opendcs.database.model.mappers.sites;
+
+import static org.opendcs.database.model.mappers.PrefixRowMapper.addUnderscoreIfMissing;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.jdbi.v3.core.result.RowView;
+import org.opendcs.database.model.mappers.properties.PropertiesMapper;
+
+import decodes.db.Site;
+import decodes.db.SiteName;
+
+public class OpenDcsSiteReducer implements BiConsumer<Map<Long, Site>, RowView>
+{
+    private String prefixSite;
+
+    public OpenDcsSiteReducer()
+    {
+        this("s");
+    }
+
+    public OpenDcsSiteReducer(String prefixSite)
+    {
+        this.prefixSite = addUnderscoreIfMissing(prefixSite);
+    }
+
+    @Override
+    public void accept(Map<Long, Site> map, RowView rowView)
+    {
+        var site = map.computeIfAbsent(rowView.getColumn(prefixSite + "id", Long.class),
+                qid -> rowView.getRow(Site.class)
+        );
+        var prop = rowView.getRow(PropertiesMapper.PAIR_STRING_STRING);
+        if (prop.first != null)
+        {
+            site.setProperty(prop.first, prop.second);
+        }
+
+        var siteName = rowView.getRow(SiteName.class);
+        if (siteName != null)
+        {
+            siteName.setSite(site);
+            site.addName(siteName);
+        }
+    }
+    
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteReducer.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/model/mappers/sites/OpenDcsSiteReducer.java
@@ -44,5 +44,5 @@ public class OpenDcsSiteReducer implements BiConsumer<Map<Long, Site>, RowView>
             site.addName(siteName);
         }
     }
-    
+
 }

--- a/java/opendcs/src/main/java/org/opendcs/model/cwms/CwmsSite.java
+++ b/java/opendcs/src/main/java/org/opendcs/model/cwms/CwmsSite.java
@@ -1,0 +1,22 @@
+package org.opendcs.model.cwms;
+
+import java.util.List;
+
+import decodes.db.Site;
+
+public final class CwmsSite extends Site
+{
+    public static final String HORIZONTAL_DATUM = "horizontal_datum";
+    public static final String VERTICAL_DATUM = "vertical_datum";
+    public static final String BOUNDING_OFFICE = "bounding_office";
+
+    public static final List<String> CWMS_SITE_PROPERTIES = 
+        List.of(HORIZONTAL_DATUM, VERTICAL_DATUM, BOUNDING_OFFICE);
+
+    private CwmsSite()
+    {
+        super();
+        /* class is for future expansion and for the moment, to hold some constants. */
+    }
+    
+}

--- a/java/opendcs/src/main/java/org/opendcs/model/cwms/CwmsSite.java
+++ b/java/opendcs/src/main/java/org/opendcs/model/cwms/CwmsSite.java
@@ -15,7 +15,6 @@ public final class CwmsSite extends Site
 
     private CwmsSite()
     {
-        super();
         /* class is for future expansion and for the moment, to hold some constants. */
     }
     

--- a/java/opendcs/src/main/java/org/opendcs/model/cwms/CwmsSite.java
+++ b/java/opendcs/src/main/java/org/opendcs/model/cwms/CwmsSite.java
@@ -4,18 +4,22 @@ import java.util.List;
 
 import decodes.db.Site;
 
+/**
+ * Holds property names that are used by the CWMS Sites (Locations) table but would
+ * otherwise go into site_property within the OpenDCS Schema.
+ */
 public final class CwmsSite extends Site
 {
     public static final String HORIZONTAL_DATUM = "horizontal_datum";
     public static final String VERTICAL_DATUM = "vertical_datum";
     public static final String BOUNDING_OFFICE = "bounding_office";
 
-    public static final List<String> CWMS_SITE_PROPERTIES = 
+    public static final List<String> CWMS_SITE_PROPERTIES =
         List.of(HORIZONTAL_DATUM, VERTICAL_DATUM, BOUNDING_OFFICE);
 
     private CwmsSite()
     {
         /* class is for future expansion and for the moment, to hold some constants. */
     }
-    
+
 }

--- a/java/opendcs/src/main/java/org/opendcs/utils/sql/SqlErrorMessages.java
+++ b/java/opendcs/src/main/java/org/opendcs/utils/sql/SqlErrorMessages.java
@@ -2,6 +2,7 @@ package org.opendcs.utils.sql;
 
 public final class SqlErrorMessages
 {
+    public static final String TIME_MAPPER_NOT_FOUND = "No Mapper for Date was found.";
     public static final String ZDT_MAPPER_NOT_FOUND = "No Mapper for ZonedDateTime was found.";
     public static final String DBKEY_MAPPER_NOT_FOUND = "No Mapper for DbKey was found.";
     public static final String CONFIG_MAPPER_NOT_FOUND = "No Mapper for JSON Config was found.";


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #1236. 

## Solution

Create DAO in the new style for retrieving sites.

NOTE: will also create a separate DAO for CWMS.

Previously the SiteDAO chain tried to share things and it often got rather awkward. Will build each in isolation except for the OpenDCS-Postgres/Oracle as the structure of the data is the same.

## how you tested the change

- [x] new integration test (just a basic smoke test of the somewhat complex query)
- [x] Integrate into REST API

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
