### PR TITLE
Use End-of-life logback 1.3.16 for Java 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ jsch="0.1.55"
 aspectj="1.8.10"
 json="20231013"
 slf4j-api= { strictly = "2.0.17" }
-logback = "1.3.15" 
+logback = "1.3.16" 
 jetty = "9.4.56.v20240826"
 jetty-jsp = "9.2.30.v20200428"
 jersey = "2.40"


### PR DESCRIPTION
Resolves #1827 

Revert not needed, but updating to latest on the 1.3.x line.

https://logback.qos.ch/download.html