### PR TITLE
Set different project name for the UI analysis.

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -102,4 +102,5 @@ jobs:
             -Dsonar.test.exclusions=**/*.java \
             -Dsonar.projectBaseDir=javascript/opendcs-web-ui-react \
             -PUI=true \
-            -Dsonar.projectKey=opendcs_opendcs_ui
+            -Dsonar.projectKey=opendcs_opendcs_ui \
+            -Dsonar.projectName="OpenDCS UI"


### PR DESCRIPTION
## Problem Description

It was getting really confusing seeing two "OpenDCS Toolkit" Sonar analysis results with different values. Also made the sonarcloud interface have the same name for each.

## Solution

Set specific name during the UI analysis.

## how you tested the change

Testing a bit of a pain, worst we might not see the next PR analysis at all and we adjust.


## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
