### PR TITLE
PlatformConfig/Decodes Script DAO

### DIFF
--- a/install/src/main/dist/edit-db/presentation/CWMS-English.xml
+++ b/install/src/main/dist/edit-db/presentation/CWMS-English.xml
@@ -164,6 +164,12 @@
     <MaxDecimals>2</MaxDecimals>
   </DataPresentation>
   <DataPresentation>
+    <DataType Standard="CWMS" Code="Elev">
+    </DataType>
+    <UnitsAbbr>ft</UnitsAbbr>
+    <MaxDecimals>2</MaxDecimals>
+  </DataPresentation>
+  <DataPresentation>
     <DataType Standard="CWMS" Code="Elev-Pool">
     </DataType>
     <UnitsAbbr>ft</UnitsAbbr>

--- a/install/src/main/dist/edit-db/presentation/CWMS-Metric.xml
+++ b/install/src/main/dist/edit-db/presentation/CWMS-Metric.xml
@@ -158,6 +158,12 @@
     <MaxDecimals>3</MaxDecimals>
   </DataPresentation>
   <DataPresentation>
+    <DataType Standard="CWMS" Code="Elev">
+    </DataType>
+    <UnitsAbbr>m</UnitsAbbr>
+    <MaxDecimals>3</MaxDecimals>
+  </DataPresentation>
+  <DataPresentation>
     <DataType Standard="CWMS" Code="Elev-Pool">
     </DataType>
     <UnitsAbbr>m</UnitsAbbr>

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
@@ -11,7 +11,9 @@ import java.util.ArrayList;
 import java.util.Random;
 
 import org.junit.jupiter.api.Test;
+import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.OpenDcsDatabase;
+import org.opendcs.database.dai.DataTypeDao;
 import org.opendcs.database.dai.DecodesConfigDao;
 import org.opendcs.fixtures.AppTestBase;
 import org.opendcs.fixtures.annotations.ConfiguredField;
@@ -20,7 +22,6 @@ import org.opendcs.fixtures.annotations.EnableIfTsDb;
 
 import decodes.db.ConfigSensor;
 import decodes.db.Constants;
-import decodes.db.DataType;
 import decodes.db.DecodesScript;
 import decodes.db.FormatStatement;
 import decodes.db.PlatformConfig;
@@ -35,6 +36,10 @@ import decodes.db.UnitConverterDb;
 })
 class DecodesConfigDaoTestIT extends AppTestBase
 {
+
+    private static final String[] SENSORS = new String[]{"Stage", "Elev", "Flow"};
+    private static final String[] UNTIS = new String[]{"in", "ft", "cfs"};
+
     @ConfiguredField
     OpenDcsDatabase db;
 
@@ -80,6 +85,9 @@ class DecodesConfigDaoTestIT extends AppTestBase
         var decodesConfigDao = db.getDao(DecodesConfigDao.class)
                                  .orElseThrow();
 
+        var dataTypeDao = db.getDao(DataTypeDao.class)
+                            .orElseThrow();
+
         try (var tx = db.newTransaction())
         {
             final var pcIn = new PlatformConfig("TestConfig-1");
@@ -89,7 +97,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
             sensor1.recordingInterval = 0;
             sensor1.recordingMode = Constants.recordingModeFixed;
             sensor1.setProperty("cwmsInterval", "15Minutes");
-            sensor1.addDataType(DataType.getDataType("CWMS", "Stage"));
+            sensor1.addDataType(dataTypeDao.lookup(tx, "Stage").orElseThrow());
             pcIn.addSensor(sensor1);
             final var script = DecodesScript.empty()
                                             .platformConfig(pcIn)
@@ -119,6 +127,9 @@ class DecodesConfigDaoTestIT extends AppTestBase
         var decodesConfigDao = db.getDao(DecodesConfigDao.class)
                                  .orElseThrow();
 
+        var dataTypeDao = db.getDao(DataTypeDao.class)
+                            .orElseThrow();
+
         try (var tx = db.newTransaction())
         {
             var all = decodesConfigDao.getAll(tx, -1, -1);
@@ -137,7 +148,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
             {
                 final var name = String.format("0000-Config-%02d", i);
 
-                var pc = createConfig(name, RANDOM.nextInt(3), RANDOM.nextInt(2), RANDOM.nextInt(3), (i % 7) == 0);
+                var pc = createConfig(name, RANDOM.nextInt(3), RANDOM.nextInt(2), RANDOM.nextInt(3), (i % 7) == 0, tx, dataTypeDao);
                 var pcOut = decodesConfigDao.save(tx, pc);
                 savedConfigs.add(pcOut);
             }
@@ -159,10 +170,9 @@ class DecodesConfigDaoTestIT extends AppTestBase
     }
 
 
-    private PlatformConfig createConfig(String name, int numScripts, int numStatements, int numSensors, boolean sensorProperties) throws Exception
+    private PlatformConfig createConfig(String name, int numScripts, int numStatements, int numSensors, boolean sensorProperties, DataTransaction tx, DataTypeDao dataTypeDao) throws Exception
     {
-        final var SENSORS = new String[]{"Stage", "Elev", "Flow"};
-        final var UNTIS = new String[]{"in", "ft", "cfs"};
+        
 
         var pc = new PlatformConfig(name);
 
@@ -173,7 +183,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
             sensor.recordingInterval = 900;
             sensor.recordingMode = 'F';
             sensor.timeOfFirstSample = 0;
-            sensor.addDataType(DataType.getDataType("CWMS", sensor.sensorName));
+            sensor.addDataType(dataTypeDao.lookup(tx, sensor.sensorName).orElseThrow());
             if (sensorProperties)
             {
                 sensor.setProperty("CwmsInterval", "15Minutes");

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
@@ -7,6 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.ArrayList;
+import java.util.Random;
+
 import org.junit.jupiter.api.Test;
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.database.dai.DecodesConfigDao;
@@ -21,6 +24,8 @@ import decodes.db.DataType;
 import decodes.db.DecodesScript;
 import decodes.db.FormatStatement;
 import decodes.db.PlatformConfig;
+import decodes.db.ScriptSensor;
+import decodes.db.UnitConverterDb;
 
 @EnableIfTsDb
 @DecodesConfigurationRequired({
@@ -33,6 +38,8 @@ class DecodesConfigDaoTestIT extends AppTestBase
     @ConfiguredField
     OpenDcsDatabase db;
 
+    // this random sources needs to be repeatable, hence static seed.
+    private static final Random RANDOM = new Random(30); // NOSONAR
 
 
     @Test
@@ -121,6 +128,100 @@ class DecodesConfigDaoTestIT extends AppTestBase
             assertEquals(1, onlyOne.size());
             assertEquals("OKVI4", onlyOne.getFirst().getName());
             assertEquals("ST", onlyOne.getFirst().decodesScripts.getFirst().scriptName);
+
+            final var numConfigs = 30;
+
+            final var savedConfigs = new ArrayList<PlatformConfig>();
+
+            for (var i = 0; i < numConfigs; i++)
+            {
+                final var name = String.format("0000-Config-%02d", i);
+
+                var pc = createConfig(name, RANDOM.nextInt(3), RANDOM.nextInt(2), RANDOM.nextInt(3), (i % 7) == 0);
+                var pcOut = decodesConfigDao.save(tx, pc);
+                savedConfigs.add(pcOut);
+            }
+
+            final var allSaved = decodesConfigDao.getAll(tx, numConfigs, 0);
+            assertEquals(numConfigs, allSaved.size());
+
+
+            final var first10 = decodesConfigDao.getAll(tx, 10, 0);
+            assertEquals(savedConfigs.getFirst().configName, first10.getFirst().configName);
+            assertEquals(savedConfigs.get(9).configName, first10.getLast().configName);
+
+            final var second10 = decodesConfigDao.getAll(tx, 10, 10);
+            assertEquals(savedConfigs.get(10).configName, second10.getFirst().configName);
+            assertEquals(savedConfigs.get(19).configName, second10.getLast().configName);
+
+            tx.rollback();
         }
+    }
+
+
+    private PlatformConfig createConfig(String name, int numScripts, int numStatements, int numSensors, boolean sensorProperties) throws Exception
+    {
+        final var SENSORS = new String[]{"Stage", "Elev", "Flow"};
+        final var UNTIS = new String[]{"in", "ft", "cfs"};
+
+        var pc = new PlatformConfig(name);
+
+        for (var i = 0; i < numSensors; i++)
+        {
+            var sensor = new ConfigSensor(pc, i + 1);
+            sensor.sensorName = SENSORS[RANDOM.nextInt(SENSORS.length)];
+            sensor.recordingInterval = 900;
+            sensor.recordingMode = 'F';
+            sensor.timeOfFirstSample = 0;
+            sensor.addDataType(DataType.getDataType("CWMS", sensor.sensorName));
+            if (sensorProperties)
+            {
+                sensor.setProperty("CwmsInterval", "15Minutes");
+            }
+        }
+
+        for (var i = 0; i < numScripts; i++)
+        {
+            var script = DecodesScript.empty()
+                                      .platformConfig(pc)
+                                      .scriptName(String.format("S-%d", i))
+                                      .withDataOrder('A')
+                                      .build();
+            for (var j = 0; j < numStatements; j++)
+            {
+                var fs = new FormatStatement(script, j + 1);
+                fs.label = "STMT" + j;
+                fs.format = String.format("/%dx", j);
+                script.getFormatStatements().add(fs);
+            }
+
+            for (var k = 0; k < numSensors; k++)
+            {
+                var scriptSensor = new ScriptSensor(script, k + 1);
+
+                final var sensorName = pc.getSensor(k + 1);
+                int idx = 0;
+                for (var sensorIdx = 0; sensorIdx < SENSORS.length; sensorIdx++)
+                {
+                    if (SENSORS[sensorIdx].equals(sensorName))
+                    {
+                        idx = sensorIdx;
+                        break;
+                    }
+                }
+                var toUnits = UNTIS[idx];
+
+                scriptSensor.rawConverter = new UnitConverterDb("raw", toUnits);
+                scriptSensor.rawConverter.algorithm = Constants.eucvt_none;
+
+                script.addScriptSensor(scriptSensor);
+            }
+
+
+
+            pc.addScript(script);
+        }
+
+        return pc;
     }
 }

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
@@ -189,6 +189,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
             {
                 sensor.setProperty("CwmsInterval", "15Minutes");
             }
+            pc.addSensor(sensor);
         }
 
         for (var i = 0; i < numScripts; i++)
@@ -210,7 +211,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
             {
                 var scriptSensor = new ScriptSensor(script, k + 1);
 
-                final var sensorName = pc.getSensor(k + 1);
+                final var sensorName = pc.getSensor(k + 1).sensorName;
                 int idx = 0;
                 for (var sensorIdx = 0; sensorIdx < SENSORS.length; sensorIdx++)
                 {

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
@@ -38,7 +38,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
 {
 
     private static final String[] SENSORS = new String[]{"Stage", "Elev", "Flow"};
-    private static final String[] UNTIS = new String[]{"in", "ft", "cfs"};
+    private static final String[] UNITS = new String[]{"in", "ft", "cfs"};
 
     @ConfiguredField
     OpenDcsDatabase db;
@@ -220,7 +220,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
                         break;
                     }
                 }
-                var toUnits = UNTIS[idx];
+                var toUnits = UNITS[idx];
 
                 scriptSensor.rawConverter = new UnitConverterDb("raw", toUnits);
                 scriptSensor.rawConverter.algorithm = Constants.eucvt_none;

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
@@ -97,7 +97,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
             sensor1.recordingInterval = 0;
             sensor1.recordingMode = Constants.recordingModeFixed;
             sensor1.setProperty("cwmsInterval", "15Minutes");
-            sensor1.addDataType(dataTypeDao.lookup(tx, "Stage").orElseThrow());
+            sensor1.addDataType(dataTypeDao.lookup(tx, "CWMS", "Stage").orElseThrow());
             pcIn.addSensor(sensor1);
             final var script = DecodesScript.empty()
                                             .platformConfig(pcIn)
@@ -183,7 +183,8 @@ class DecodesConfigDaoTestIT extends AppTestBase
             sensor.recordingInterval = 900;
             sensor.recordingMode = 'F';
             sensor.timeOfFirstSample = 0;
-            sensor.addDataType(dataTypeDao.lookup(tx, sensor.sensorName).orElseThrow());
+            sensor.addDataType(dataTypeDao.lookup(tx, "CWMS", sensor.sensorName)
+                                          .orElseGet(() -> fail("DataType for " + sensor.sensorName + " doesn't exist.")));
             if (sensorProperties)
             {
                 sensor.setProperty("CwmsInterval", "15Minutes");

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
@@ -19,7 +19,6 @@ import decodes.db.ConfigSensor;
 import decodes.db.Constants;
 import decodes.db.DataType;
 import decodes.db.DecodesScript;
-import decodes.db.DecodesScriptReader;
 import decodes.db.FormatStatement;
 import decodes.db.PlatformConfig;
 
@@ -29,7 +28,7 @@ import decodes.db.PlatformConfig;
     "SimpleDecodesTest/site-OKVI4.xml",
     "SimpleDecodesTest/OKVI4-decodes.xml"
 })
-class DecodesDaoTestIT extends AppTestBase
+class DecodesConfigDaoTestIT extends AppTestBase
 {
     @ConfiguredField
     OpenDcsDatabase db;
@@ -104,6 +103,24 @@ class DecodesDaoTestIT extends AppTestBase
 
             final var pcNotExist = decodesConfigDao.getByName(tx, "TestConfig-1");
             assertTrue(pcNotExist.isEmpty());
+        }
+    }
+
+    @Test
+    void test_pagination() throws Exception
+    {
+        var decodesConfigDao = db.getDao(DecodesConfigDao.class)
+                                 .orElseThrow();
+
+        try (var tx = db.newTransaction())
+        {
+            var all = decodesConfigDao.getAll(tx, -1, -1);
+            assertFalse(all.isEmpty());
+
+            var onlyOne = decodesConfigDao.getAll(tx, 1, 1);
+            assertEquals(1, onlyOne.size());
+            assertEquals("OKVI4", onlyOne.getFirst().getName());
+            assertEquals("ST", onlyOne.getFirst().decodesScripts.getFirst().scriptName);
         }
     }
 }

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesDaoTestIT.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,12 @@ import org.opendcs.fixtures.annotations.ConfiguredField;
 import org.opendcs.fixtures.annotations.DecodesConfigurationRequired;
 import org.opendcs.fixtures.annotations.EnableIfTsDb;
 
+import decodes.db.ConfigSensor;
+import decodes.db.Constants;
+import decodes.db.DataType;
+import decodes.db.DecodesScript;
+import decodes.db.DecodesScriptReader;
+import decodes.db.FormatStatement;
 import decodes.db.PlatformConfig;
 
 @EnableIfTsDb
@@ -26,7 +33,7 @@ class DecodesDaoTestIT extends AppTestBase
 {
     @ConfiguredField
     OpenDcsDatabase db;
-    
+
 
 
     @Test
@@ -39,7 +46,7 @@ class DecodesDaoTestIT extends AppTestBase
         {
             final var config = decodesConfigDao.getByName(tx, "OKVI4")
                                                .orElseGet(() -> fail("Config not retrieved."));
-            
+
             assertEquals("OKVI4", config.configName);
             assertFalse(config.decodesScripts.isEmpty());
             final var script = config.getScript("ST");
@@ -70,9 +77,33 @@ class DecodesDaoTestIT extends AppTestBase
         try (var tx = db.newTransaction())
         {
             final var pcIn = new PlatformConfig("TestConfig-1");
+
+            var sensor1 = new ConfigSensor(pcIn, 1);
+            sensor1.sensorName = "Stage";
+            sensor1.recordingInterval = 0;
+            sensor1.recordingMode = Constants.recordingModeFixed;
+            sensor1.setProperty("cwmsInterval", "15Minutes");
+            sensor1.addDataType(DataType.getDataType("CWMS", "Stage"));
+            pcIn.addSensor(sensor1);
+            final var script = DecodesScript.empty()
+                                            .platformConfig(pcIn)
+                                            .addDefaultSensors()
+                                            .scriptName("ST")
+                                            .build();
+            var fs = new FormatStatement(script, 1);
+            fs.label = "ST";
+            fs.format = "/,1f(s,a,5D' ', 1";
+            script.getFormatStatements().add(fs);
+
             pcIn.description = "A simple test configuration.";
             final var pcOut = decodesConfigDao.save(tx, pcIn);
             assertEquals("TestConfig-1", pcOut.getName());
+
+
+            decodesConfigDao.delete(tx, pcOut.getId());
+
+            final var pcNotExist = decodesConfigDao.getByName(tx, "TestConfig-1");
+            assertTrue(pcNotExist.isEmpty());
         }
     }
 }

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesDaoTestIT.java
@@ -14,6 +14,8 @@ import org.opendcs.fixtures.annotations.ConfiguredField;
 import org.opendcs.fixtures.annotations.DecodesConfigurationRequired;
 import org.opendcs.fixtures.annotations.EnableIfTsDb;
 
+import decodes.db.PlatformConfig;
+
 @EnableIfTsDb
 @DecodesConfigurationRequired({
     "shared/test-sites.xml",
@@ -28,7 +30,7 @@ class DecodesDaoTestIT extends AppTestBase
 
 
     @Test
-    void test_basic_operations() throws Exception
+    void test_existing_config() throws Exception
     {
         var decodesConfigDao = db.getDao(DecodesConfigDao.class)
                                  .orElseThrow();
@@ -56,6 +58,21 @@ class DecodesDaoTestIT extends AppTestBase
             assertEquals("usgs-standard", scriptSensor1.rawConverter.algorithm);
             assertArrayEquals(new double[]{0.01, 0, 1.0, 0.0, 0.0, 0.0}, scriptSensor1.rawConverter.coefficients);
         }
+    }
 
+
+    @Test
+    void test_basic_operations() throws Exception
+    {
+        var decodesConfigDao = db.getDao(DecodesConfigDao.class)
+                                 .orElseThrow();
+
+        try (var tx = db.newTransaction())
+        {
+            final var pcIn = new PlatformConfig("TestConfig-1");
+            pcIn.description = "A simple test configuration.";
+            final var pcOut = decodesConfigDao.save(tx, pcIn);
+            assertEquals("TestConfig-1", pcOut.getName());
+        }
     }
 }

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesDaoTestIT.java
@@ -1,0 +1,61 @@
+package org.opendcs.dao;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.opendcs.database.api.OpenDcsDatabase;
+import org.opendcs.database.dai.DecodesConfigDao;
+import org.opendcs.fixtures.AppTestBase;
+import org.opendcs.fixtures.annotations.ConfiguredField;
+import org.opendcs.fixtures.annotations.DecodesConfigurationRequired;
+import org.opendcs.fixtures.annotations.EnableIfTsDb;
+
+@EnableIfTsDb
+@DecodesConfigurationRequired({
+    "shared/test-sites.xml",
+    "SimpleDecodesTest/site-OKVI4.xml",
+    "SimpleDecodesTest/OKVI4-decodes.xml"
+})
+class DecodesDaoTestIT extends AppTestBase
+{
+    @ConfiguredField
+    OpenDcsDatabase db;
+    
+
+
+    @Test
+    void test_basic_operations() throws Exception
+    {
+        var decodesConfigDao = db.getDao(DecodesConfigDao.class)
+                                 .orElseThrow();
+
+        try (var tx = db.newTransaction())
+        {
+            final var config = decodesConfigDao.getByName(tx, "OKVI4")
+                                               .orElseGet(() -> fail("Config not retrieved."));
+            
+            assertEquals("OKVI4", config.configName);
+            assertFalse(config.decodesScripts.isEmpty());
+            final var script = config.getScript("ST");
+            assertNotNull(script);
+            assertEquals("Decodes", script.scriptType);
+            assertEquals(config, script.platformConfig);
+            assertEquals(1, script.getFormatStatements().size());
+            assertEquals("4x,4(f(s,b,3,1),f(s,b,3,2)),24x,f(s,b,1,3)", script.getFormatStatement("st").format);
+
+            var scriptSensor1 = script.getScriptSensor(1);
+            assertNotNull(scriptSensor1);
+            assertNotNull(scriptSensor1.rawConverter);
+
+            assertEquals("raw", scriptSensor1.rawConverter.fromAbbr);
+            assertEquals("ft", scriptSensor1.rawConverter.toAbbr);
+            assertEquals("usgs-standard", scriptSensor1.rawConverter.algorithm);
+            assertArrayEquals(new double[]{0.01, 0, 1.0, 0.0, 0.0, 0.0}, scriptSensor1.rawConverter.coefficients);
+        }
+
+    }
+}

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DataTypeDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DataTypeDaoImpl.java
@@ -57,7 +57,7 @@ public class DataTypeDaoImpl implements DataTypeDao
                 using (select :id id, :standard standard, :code code, :display_name display_name <dual>) input
                 on (dt.id = input.id)
                 when matched then
-                    update set standard = input.standard, code = input.code, display_name = input.display_name                               
+                    update set standard = input.standard, code = input.code, display_name = input.display_name
                 when not matched then
                     insert(id, standard, code, display_name)
                     values(input.id, input.standard, input.code, input.display_name)
@@ -91,7 +91,7 @@ public class DataTypeDaoImpl implements DataTypeDao
                                             .orElseThrow(() -> new OpenDcsDataException("No Decodes Settings?"))
                                             .dataTypeStdPreference;
         final String querySql = """
-                    select id, standard, code, display_name 
+                    select id, standard, code, display_name
                       from datatype
                      where upper(code) = upper(:code)
 
@@ -120,6 +120,31 @@ public class DataTypeDaoImpl implements DataTypeDao
             }
         }
         return ret;
+    }
+
+    @Override
+    public Optional<DataType> lookup(DataTransaction tx, String standard, String dataTypeCode) throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+
+        final String querySql = """
+                    select id, standard, code, display_name
+                      from datatype
+                     where
+                        upper(standard) = upper(:standard) and
+                        upper(code) = upper(:code)
+
+                """;
+        try (var query = handle.createQuery(querySql))
+        {
+            return query.bind("code", dataTypeCode)
+                        .bind("standard", standard)
+                        .registerRowMapper(DataType.class,
+                                           DataTypeMapper.withPrefix(""))
+                        .mapTo(DataType.class)
+                        .findOne();
+        }
     }
 
     @Override

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
@@ -1,0 +1,175 @@
+package org.opendcs.database.impl.opendcs.dao;
+
+import org.jdbi.v3.core.Handle;
+import org.opendcs.database.api.DataTransaction;
+import org.opendcs.database.api.OpenDcsDataException;
+import org.opendcs.database.dai.DecodesConfigDao;
+import org.opendcs.database.model.mappers.datatype.DataTypeMapper;
+import org.opendcs.database.model.mappers.equipmentmodel.EquipmentModelMapper;
+import org.opendcs.database.model.mappers.properties.PropertiesMapper;
+import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs.DecodesConfigMapper;
+import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts.DecodesScriptBuilderMapper;
+import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts.FormatStatementMapper;
+import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs.ConfigSensorMapper;
+import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs.DecodesConfigAccumulator;
+import org.opendcs.utils.sql.GenericColumns;
+import org.opendcs.utils.sql.SqlErrorMessages;
+import org.opendcs.utils.sql.SqlQueries;
+import org.openide.util.lookup.ServiceProvider;
+
+import decodes.db.PlatformConfig;
+import decodes.sql.DbKey;
+import decodes.util.DecodesSettings;
+
+import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+
+@ServiceProvider(service = DecodesConfigDao.class)
+public class DecodesConfigDaoImpl implements DecodesConfigDao
+{
+
+    private static final String SELECT_QUERY = """
+            with pc (id, name, description, equipmentId) as (
+                select id, name, description, equipmentId
+                  from PlatformConfig
+                <where>
+                <limit>
+                order by name <collate> ASC
+            )
+            select pc.id pc_id, pc.name pc_name, pc.description pc_description, pc.equipmentId pc_equipmentId,
+                    em.id e_id, em.name e_name, em.company e_company, em.model e_model, em.description e_description,
+                    em.equipmentType e_equipmentType, ep.name ep_name, ep.prop_value ep_prop_value,
+
+                    cs.sensornumber cs_sensornumber, cs.sensorname cs_sensorname, cs.recordingmode cs_recordingmode,
+                    cs.recordinginterval cs_recordinginterval, cs.timeoffirstsample cs_timeoffirstsample, 
+                    cs.equipmentid cs_equipmentid, cs.absolutemin cs_absolutemin, cs.absolutemax cs_absolutemax,
+                    cs.stat_cd cs_stat_cd, csp.sensornumber csp_sensornumber, csp.prop_name csp_prop_name, csp.prop_value csp_prop_value
+
+                    ds.id ds_id, ds.name ds_name, ds.script_type ds_script_type, ds.dataorder ds_dataorder,
+                    fs.sequencenum fs_sequencenum, fs.label fs_label, fs.format fs_format
+
+                    // todo, script sensors
+
+              from pc
+            left outer join equipmentmodel em on em.id = pc.equipmentId
+            left outer join equipmentproperty ep on em.id = ep.equipmentid
+            left outer join configsensor cs on cs.configid = pc.id
+            left outer join configsensorproperty csp on csp.configid = cs.configid and csp.sensornumber = cs.sensornumber
+            left outer join configsensordatatype csdt on cs.configid = csdt.configid and cs.sensornumber = csdt.sensornumber
+            left outer join datatype dt on csdt.datatypeid = dt.id
+            left outer join decodesscript ds on ds.configid = pc.id
+            left outer join formatstatement fs on fs.decodesscriptid = ds.id
+
+
+            order by 
+                pc.name <collate> asc,
+                cs.sensornumber asc,
+                fs.sequencenum asc
+            """;
+
+    @Override
+    public Optional<PlatformConfig> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException
+    {
+        if (DbKey.isNull(id))
+        {
+            return Optional.empty();
+        }
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var dbEngine = ctx.getDatabase();
+        var preferredType = ctx.getSettings(DecodesSettings.class)
+                              .map(ds -> ds.siteNameTypePreference)
+                              .orElseGet(() -> "CWMS");
+        try (var query = handle.createQuery(SELECT_QUERY))
+        {
+            query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
+                 .define(SqlQueries.WHERE_CLAUSE, "where id = :id")
+                 .define(SqlQueries.LIMIT_CLAUSE, "")
+                 .bind("preferredType", preferredType)
+                 .bind(GenericColumns.ID, id);
+
+            return query.registerRowMapper(DecodesConfigMapper.withPrefix("pc"))
+                        .registerRowMapper(EquipmentModelMapper.withPrefix("em"))
+                        .registerRowMapper(PropertiesMapper.PAIR_STRING_STRING, PropertiesMapper.withPrefix("ep"))
+                        .reduceResultSet(new LinkedHashMap<>(),
+                                         new DecodesConfigAccumulator(
+                                            "pc", DecodesConfigMapper.withPrefix("pc"),
+                                            EquipmentModelMapper.withPrefix("em"), PropertiesMapper.withPrefix("ep"),
+                                            ConfigSensorMapper.withPrefix("cs"), PropertiesMapper.withPrefix("csp", true),
+                                            DataTypeMapper.withPrefix("dt"), DecodesScriptBuilderMapper.withPrefix("ds"),
+                                            FormatStatementMapper.withPrefix("fs")
+                                         )
+                                        )
+                        .values()
+                        .stream()
+                        .map(pcb -> pcb.build())
+                        .findFirst();
+        }
+    }
+
+    @Override
+    public Optional<PlatformConfig> getByName(DataTransaction tx, String name) throws OpenDcsDataException
+    {
+        if (name == null || name.isBlank())
+        {
+            return Optional.empty();
+        }
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var dbEngine = ctx.getDatabase();
+        var preferredType = ctx.getSettings(DecodesSettings.class)
+                              .map(ds -> ds.siteNameTypePreference)
+                              .orElseGet(() -> "CWMS");
+        try (var query = handle.createQuery(SELECT_QUERY))
+        {
+            query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
+                 .define(SqlQueries.WHERE_CLAUSE, "where upper(name) = upper(:name)")
+                 .define(SqlQueries.LIMIT_CLAUSE, "")
+                 .bind("preferredType", preferredType)
+                 .bind(GenericColumns.NAME, name);
+
+            return query.registerRowMapper(DecodesConfigMapper.withPrefix("pc"))
+                        .registerRowMapper(EquipmentModelMapper.withPrefix("em"))
+                        .registerRowMapper(PropertiesMapper.PAIR_STRING_STRING, PropertiesMapper.withPrefix("ep"))
+                        .reduceResultSet(new LinkedHashMap<>(),
+                                         new DecodesConfigAccumulator(
+                                            "pc", DecodesConfigMapper.withPrefix("pc"),
+                                            EquipmentModelMapper.withPrefix("em"), PropertiesMapper.withPrefix("ep"),
+                                            ConfigSensorMapper.withPrefix("cs"), PropertiesMapper.withPrefix("csp", true),
+                                            DataTypeMapper.withPrefix("dt"), DecodesScriptBuilderMapper.withPrefix("ds"),
+                                            FormatStatementMapper.withPrefix("fs")
+                                         )
+                                        )
+                        .values()
+                        .stream()
+                        .map(pcb -> pcb.build())
+                        .findFirst();
+        }
+    }
+
+    @Override
+    public PlatformConfig save(DataTransaction arg0, PlatformConfig arg1) throws OpenDcsDataException
+    {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'save'");
+    }
+
+    @Override
+    public void delete(DataTransaction arg0, DbKey arg1) throws OpenDcsDataException
+    {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+    }
+
+    @Override
+    public List<PlatformConfig> getAll(DataTransaction arg0, int arg1, int arg2) throws OpenDcsDataException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getAll'");
+    }
+
+}

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
@@ -111,7 +111,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
                      where configid = :id
                  )
             """;
-    private static final String DELETE_UNITCONVERETER = "delete from unitconverter where id = :id";
+    private static final String DELETE_UNITCONVERTER = "delete from unitconverter where id = :id";
     private static final String DELETE_FORMATSTATEMENTS =
         "delete from formatstatement where decodesscriptid  in (select id from decodesscript where configid = :id)";
     private static final String DELETE_DECODESSCRIPT = "delete from decodesscript where configid = :id";
@@ -223,7 +223,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
              var deleteConfigSensorDataType = handle.createUpdate(DELETE_CONFIGSENSOR_DATATYPE);
              var deleteConfigSensor = handle.createUpdate(DELETE_CONFIGSENSOR);
              var deleteFormatStatements = handle.createUpdate(DELETE_FORMATSTATEMENTS);
-             var deleteScriptSensorUc = handle.prepareBatch(DELETE_UNITCONVERETER);
+             var deleteScriptSensorUc = handle.prepareBatch(DELETE_UNITCONVERTER);
              var getUnitConverterIds = handle.createQuery(GET_SCRIPTSENSOR_UC_ID);
              var deleteScriptSensor = handle.createUpdate(DELETE_SCRIPTSENSOR);
              var deleteScript = handle.createUpdate(DELETE_DECODESSCRIPT)
@@ -412,10 +412,10 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
             var deleteConfigSensorDataType = handle.createUpdate(DELETE_CONFIGSENSOR_DATATYPE);
             var deleteConfigSensor = handle.createUpdate(DELETE_CONFIGSENSOR);
             var deleteFormatStatements = handle.createUpdate(DELETE_FORMATSTATEMENTS);
-            var deleteScriptSensorUc = handle.prepareBatch(DELETE_UNITCONVERETER);
+            var deleteScriptSensorUc = handle.prepareBatch(DELETE_UNITCONVERTER);
             var getUnitConverterIds = handle.createQuery(GET_SCRIPTSENSOR_UC_ID);
             var deleteScriptSensor = handle.createUpdate(DELETE_SCRIPTSENSOR);
-            var deleteScript = handle.createUpdate(DELETE_FORMATSTATEMENTS);
+            var deleteScript = handle.createUpdate(DELETE_DECODESSCRIPT);
             var deleteConfig = handle.createUpdate("delete from platformconfig where id = :id"))
         {
             deleteConfigSensorProps.bind(GenericColumns.ID, id).execute();

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
@@ -28,7 +28,6 @@ import decodes.db.DatabaseException;
 import decodes.db.PlatformConfig;
 import decodes.sql.DbKey;
 import decodes.sql.KeyGenerator;
-import decodes.util.DecodesSettings;
 
 import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
 
@@ -39,6 +38,12 @@ import java.util.Optional;
 @ServiceProvider(service = DecodesConfigDao.class)
 public class DecodesConfigDaoImpl implements DecodesConfigDao
 {
+    private static final String SENSORNUMBER = "sensornumber";
+
+    private static final String DECODESSCRIPTID = "decodesscriptid";
+
+    private static final String CONFIGID = "configid";
+
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
 
     private static final String SELECT_QUERY = """
@@ -221,7 +226,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
              var deleteScriptSensorUc = handle.prepareBatch(DELETE_UNITCONVERETER);
              var getUnitConverterIds = handle.createQuery(GET_SCRIPTSENSOR_UC_ID);
              var deleteScriptSensor = handle.createUpdate(DELETE_SCRIPTSENSOR);
-             var deleteScript = handle.createUpdate(DELETE_DECODESSCRIPT);
+             var deleteScript = handle.createUpdate(DELETE_DECODESSCRIPT)
             )
 
         {
@@ -281,7 +286,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
     }
 
 
-    private void insertConfigSensors(Handle handle, DbKey configId, PlatformConfig pc) throws OpenDcsDataException
+    private void insertConfigSensors(Handle handle, DbKey configId, PlatformConfig pc)
     {
         try (var insertSensor = handle.prepareBatch("""
                     insert into
@@ -307,8 +312,8 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
         {
             for (var sensor: pc.getSensorVec())
             {
-                insertSensor.bind("configid", configId)
-                            .bind("sensornumber", sensor.sensorNumber)
+                insertSensor.bind(CONFIGID, configId)
+                            .bind(SENSORNUMBER, sensor.sensorNumber)
                             .bind("sensorname", sensor.sensorName)
                             .bind("recordingmode", sensor.recordingMode)
                             .bind("recordinginterval", sensor.recordingInterval)
@@ -320,20 +325,19 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
                             .add();
                 for (var dt: sensor.getDataTypeVec())
                 {
-                    insertSensorDataType.bind("configid", configId)
-                                        .bind("sensornumber", sensor.sensorNumber)
+                    insertSensorDataType.bind(CONFIGID, configId)
+                                        .bind(SENSORNUMBER, sensor.sensorNumber)
                                         .bind("datatypeid", dt.getId())
                                         .add();
                 }
 
                 sensor.getProperties().forEach((k,v) ->
-                {
-                    insertSensorProps.bind("configid", configId)
-                                     .bind("sensornumber", sensor.sensorNumber)
+                    insertSensorProps.bind(CONFIGID, configId)
+                                     .bind(SENSORNUMBER, sensor.sensorNumber)
                                      .bind("prop_name", k)
                                      .bind("prop_value", v)
-                                     .add();
-                });
+                                     .add()
+                );
             }
 
             insertSensor.execute();
@@ -365,7 +369,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
             {
                 final var id = script.idIsSet() ? script.getId() : keyGen.getKey("decodesscript", handle.getConnection());
                 insertScript.bind(GenericColumns.ID, id)
-                            .bind("configid", configId)
+                            .bind(CONFIGID, configId)
                             .bind(GenericColumns.NAME, script.scriptName)
                             .bind("script_type", script.scriptType)
                             .bind("dataorder", script.getDataOrder())
@@ -376,15 +380,15 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
 
                     final var uc = ucDao.save(tx, sensor.rawConverter);
 
-                    insertScriptSensor.bind("decodesscriptid", id)
-                                      .bind("sensornumber", sensor.sensorNumber)
+                    insertScriptSensor.bind(DECODESSCRIPTID, id)
+                                      .bind(SENSORNUMBER, sensor.sensorNumber)
                                       .bind("unitconverterid", uc.getId())
                                       .add();
                 }
 
                 for (var fs: script.getFormatStatements())
                 {
-                    insertFormatStatement.bind("decodesscriptid", id)
+                    insertFormatStatement.bind(DECODESSCRIPTID, id)
                                          .bind("sequencenum", fs.sequenceNum)
                                          .bind("label", fs.label)
                                          .bind("format", fs.format)
@@ -448,7 +452,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
                  .define(SqlQueries.WHERE_CLAUSE, "")
-                 .define(SqlQueries.LIMIT_CLAUSE, SqlQueries.addLimitOffset(limit, offset));
+                 .define(SqlQueries.LIMIT_CLAUSE, addLimitOffset(limit, offset));
 
             if (limit >= 0)
             {

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
@@ -41,9 +41,6 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
 {
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
 
-    @InjectDao
-    UnitConverterDao ucDao;
-
     private static final String SELECT_QUERY = """
             with pc (id, name, description, equipmentId) as (
                 select id, name, description, equipmentId
@@ -113,6 +110,9 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
     private static final String DELETE_FORMATSTATEMENTS =
         "delete from formatstatement where decodesscriptid  in (select id from decodesscript where configid = :id)";
     private static final String DELETE_DECODESSCRIPT = "delete from decodesscript where configid = :id";
+
+    @InjectDao
+    UnitConverterDao ucDao;
 
     @Override
     public Optional<PlatformConfig> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException
@@ -242,7 +242,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
             merge.bind(GenericColumns.ID, bindKey)
                  .bind(GenericColumns.NAME, pc.getName())
                  .bind(GenericColumns.DESCRIPTION, pc.description)
-                 .bindByType("equipmentid", em != null ? em.getId() : (DbKey)null, DbKey.class)
+                 .bindByType("equipmentid", em != null ? em.getId() : null, DbKey.class)
                  .execute()
                  ;
 

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
@@ -19,6 +19,7 @@ import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs.DecodesConf
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
+import org.opendcs.utils.sql.SqlKeywords;
 import org.opendcs.utils.sql.SqlQueries;
 import org.openide.util.lookup.ServiceProvider;
 import org.slf4j.Logger;
@@ -48,8 +49,8 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
                 select id, name, description, equipmentId
                   from PlatformConfig
                 <where>
-                <limit>
                 order by name <collate> ASC
+                <limit>
             )
             select pc.id pc_id, pc.name pc_name, pc.description pc_description, pc.equipmentId pc_equipmentId,
                     em.id e_id, em.name e_name, em.company e_company, em.model e_model, em.description e_description,
@@ -124,15 +125,12 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
         var dbEngine = ctx.getDatabase();
-        var preferredType = ctx.getSettings(DecodesSettings.class)
-                              .map(ds -> ds.siteNameTypePreference)
-                              .orElseGet(() -> "CWMS");
+
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
                  .define(SqlQueries.WHERE_CLAUSE, "where id = :id")
                  .define(SqlQueries.LIMIT_CLAUSE, "")
-                 .bind("preferredType", preferredType)
                  .bind(GenericColumns.ID, id);
 
             return query.registerRowMapper(DecodesConfigMapper.withPrefix("pc"))
@@ -315,7 +313,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
                             .bind("recordingmode", sensor.recordingMode)
                             .bind("recordinginterval", sensor.recordingInterval)
                             .bind("timeoffirstsample", sensor.timeOfFirstSample)
-                            .bind("equipmentid", sensor.equipmentModel != null ? sensor.equipmentModel.getId() : null)
+                            .bindByType("equipmentid", sensor.equipmentModel != null ? sensor.equipmentModel.getId() : null, DbKey.class)
                             .bind("absolutemin", sensor.absoluteMin)
                             .bind("absolutemax", sensor.absoluteMax)
                             .bind("stat_cd", sensor.getUsgsStatCode())
@@ -439,9 +437,46 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
     }
 
     @Override
-    public List<PlatformConfig> getAll(DataTransaction arg0, int arg1, int arg2) throws OpenDcsDataException {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getAll'");
+    public List<PlatformConfig> getAll(DataTransaction tx, int limit, int offset) throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var dbEngine = ctx.getDatabase();
+
+        try (var query = handle.createQuery(SELECT_QUERY))
+        {
+            query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
+                 .define(SqlQueries.WHERE_CLAUSE, "")
+                 .define(SqlQueries.LIMIT_CLAUSE, SqlQueries.addLimitOffset(limit, offset));
+
+            if (limit >= 0)
+            {
+                query.bind(SqlKeywords.LIMIT, limit);
+            }
+            if (offset >= 0)
+            {
+                query.bind(SqlKeywords.OFFSET, offset);
+            }
+
+            return query.registerRowMapper(DecodesConfigMapper.withPrefix("pc"))
+                        .registerRowMapper(EquipmentModelMapper.withPrefix("em"))
+                        .registerRowMapper(PropertiesMapper.PAIR_STRING_STRING, PropertiesMapper.withPrefix("ep"))
+                        .registerRowMapper(UnitConverterMapper.withPrefix("uc"))
+                        .reduceResultSet(new LinkedHashMap<>(),
+                                         new DecodesConfigAccumulator(
+                                            "pc", DecodesConfigMapper.withPrefix("pc"),
+                                            EquipmentModelMapper.withPrefix("em"), PropertiesMapper.withPrefix("ep"),
+                                            ConfigSensorMapper.withPrefix("cs"), PropertiesMapper.withPrefix("csp", true),
+                                            DataTypeMapper.withPrefix("dt"), DecodesScriptBuilderMapper.withPrefix("ds"),
+                                            FormatStatementMapper.withPrefix("fs"), UnitConverterMapper.withPrefix("uc")
+                                         )
+                                        )
+                        .values()
+                        .stream()
+                        .map(pcb -> pcb.build())
+                        .toList();
+        }
     }
 
 }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
@@ -1,9 +1,11 @@
 package org.opendcs.database.impl.opendcs.dao;
 
 import org.jdbi.v3.core.Handle;
+import org.opendcs.annotations.api.InjectDao;
 import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.DecodesConfigDao;
+import org.opendcs.database.dai.UnitConverterDao;
 import org.opendcs.database.model.mappers.datatype.DataTypeMapper;
 import org.opendcs.database.model.mappers.equipmentmodel.EquipmentModelMapper;
 import org.opendcs.database.model.mappers.properties.PropertiesMapper;
@@ -13,13 +15,17 @@ import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts.DecodesScri
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts.FormatStatementMapper;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs.ConfigSensorMapper;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs.DecodesConfigAccumulator;
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
 import org.opendcs.utils.sql.SqlQueries;
 import org.openide.util.lookup.ServiceProvider;
+import org.slf4j.Logger;
 
+import decodes.db.DatabaseException;
 import decodes.db.PlatformConfig;
 import decodes.sql.DbKey;
+import decodes.sql.KeyGenerator;
 import decodes.util.DecodesSettings;
 
 import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
@@ -31,6 +37,10 @@ import java.util.Optional;
 @ServiceProvider(service = DecodesConfigDao.class)
 public class DecodesConfigDaoImpl implements DecodesConfigDao
 {
+    private static final Logger log = OpenDcsLoggerFactory.getLogger();
+
+    @InjectDao
+    UnitConverterDao ucDao;
 
     private static final String SELECT_QUERY = """
             with pc (id, name, description, equipmentId) as (
@@ -162,10 +172,58 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
     }
 
     @Override
-    public PlatformConfig save(DataTransaction arg0, PlatformConfig arg1) throws OpenDcsDataException
+    public PlatformConfig save(DataTransaction tx, PlatformConfig pc) throws OpenDcsDataException
     {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'save'");
+
+
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var dbEngine = ctx.getDatabase();
+        var keyGen = ctx.getGenerator(KeyGenerator.class)
+                        .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
+        final var mergeSql = """
+                merge into platformconfig pc
+                using (
+                    select :id id, :name name, :description description, :equipmentid equipmentid                
+                ) input
+                on (pc.id = input.id)
+                when matched then
+                    update set 
+                        name = input.name, description = input.description, equipmentid = input.equipmentid
+                when not matched then
+                    insert (id, name, description, equipmentid)
+                    values(input.id, input.name, input.description, input.equipmentid)
+                """;
+        try (var merge = handle.createUpdate(mergeSql))
+        {
+            DbKey id = pc.getId();
+            var existing = getByName(tx, pc.getName());
+            if (existing.isPresent())
+            {
+                // If there's an existing app with this name, we'll just assume the provided id, if any, was in error
+                id = existing.get().getId();
+                log.trace("""
+                    Using ID from existing Config, id={}, that was found. Provided ID was {}.
+                    """,
+                    id, pc.getId());
+            }
+            final var bindKey = !DbKey.isNull(id) ? id : keyGen.getKey("platformconfig", handle.getConnection());
+
+            final var em = pc.getEquipmentModel();
+            merge.bind(GenericColumns.ID, bindKey)
+                 .bind(GenericColumns.NAME, pc.getName())
+                 .bind(GenericColumns.DESCRIPTION, pc.description)
+                 .bindByType("equipmentid", em != null ? em.getId() : (DbKey)null, DbKey.class)
+                 .execute()
+                 ;
+
+            return getById(tx, bindKey).orElseThrow(() -> new OpenDcsDataException("Unable to retrieve Platform Config we just saved."));
+        }
+        catch (DatabaseException ex)
+        {
+            throw new OpenDcsDataException("Unable to create surrogate key for new platform config.", ex);
+        }
     }
 
     @Override

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
@@ -7,6 +7,7 @@ import org.opendcs.database.dai.DecodesConfigDao;
 import org.opendcs.database.model.mappers.datatype.DataTypeMapper;
 import org.opendcs.database.model.mappers.equipmentmodel.EquipmentModelMapper;
 import org.opendcs.database.model.mappers.properties.PropertiesMapper;
+import org.opendcs.database.model.mappers.unitconverter.UnitConverterMapper;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs.DecodesConfigMapper;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts.DecodesScriptBuilderMapper;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts.FormatStatementMapper;
@@ -46,12 +47,19 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
                     cs.sensornumber cs_sensornumber, cs.sensorname cs_sensorname, cs.recordingmode cs_recordingmode,
                     cs.recordinginterval cs_recordinginterval, cs.timeoffirstsample cs_timeoffirstsample, 
                     cs.equipmentid cs_equipmentid, cs.absolutemin cs_absolutemin, cs.absolutemax cs_absolutemax,
-                    cs.stat_cd cs_stat_cd, csp.sensornumber csp_sensornumber, csp.prop_name csp_prop_name, csp.prop_value csp_prop_value
+                    cs.stat_cd cs_stat_cd, csp.sensornumber csp_sensornumber, csp.prop_name csp_prop_name, csp.prop_value csp_prop_value,
+
+                    dt.id dt_id, dt.standard dt_standard, dt.code dt_code, dt.display_name dt_display_name,
 
                     ds.id ds_id, ds.name ds_name, ds.script_type ds_script_type, ds.dataorder ds_dataorder,
-                    fs.sequencenum fs_sequencenum, fs.label fs_label, fs.format fs_format
+                    fs.sequencenum fs_sequencenum, fs.label fs_label, fs.format fs_format,
 
-                    // todo, script sensors
+
+                    ss.decodesscriptid ss_decodesscriptid, ss.sensornumber ss_sensornumber,
+                    uc.id uc_id, uc.fromunitsabbr uc_fromunitsabbr, uc.tounitsabbr uc_tounitsabbr, uc.algorithm uc_algorithm,
+                    uc.a uc_a, uc.b uc_b, uc.c uc_c, uc.d uc_d, uc.e uc_e, uc.f uc_f,
+                    from_eu.unitabbr from_unitabbr, from_eu.name from_name, from_eu.family from_family, from_eu.measures from_measures,
+                    to_eu.unitabbr to_unitabbr, to_eu.name to_name, to_eu.family to_family, to_eu.measures to_measures
 
               from pc
             left outer join equipmentmodel em on em.id = pc.equipmentId
@@ -62,6 +70,10 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
             left outer join datatype dt on csdt.datatypeid = dt.id
             left outer join decodesscript ds on ds.configid = pc.id
             left outer join formatstatement fs on fs.decodesscriptid = ds.id
+            left outer join scriptsensor ss on ss.decodesscriptid = ds.id
+            left outer join unitconverter uc on ss.unitconverterid = uc.id
+            left join engineeringunit from_eu on from_eu.unitabbr = uc.fromunitsabbr
+            left join engineeringunit to_eu on to_eu.unitabbr = uc.tounitsabbr
 
 
             order by 
@@ -95,13 +107,14 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
             return query.registerRowMapper(DecodesConfigMapper.withPrefix("pc"))
                         .registerRowMapper(EquipmentModelMapper.withPrefix("em"))
                         .registerRowMapper(PropertiesMapper.PAIR_STRING_STRING, PropertiesMapper.withPrefix("ep"))
+                        .registerRowMapper(UnitConverterMapper.withPrefix("uc"))
                         .reduceResultSet(new LinkedHashMap<>(),
                                          new DecodesConfigAccumulator(
                                             "pc", DecodesConfigMapper.withPrefix("pc"),
                                             EquipmentModelMapper.withPrefix("em"), PropertiesMapper.withPrefix("ep"),
                                             ConfigSensorMapper.withPrefix("cs"), PropertiesMapper.withPrefix("csp", true),
                                             DataTypeMapper.withPrefix("dt"), DecodesScriptBuilderMapper.withPrefix("ds"),
-                                            FormatStatementMapper.withPrefix("fs")
+                                            FormatStatementMapper.withPrefix("fs"), UnitConverterMapper.withPrefix("uc")
                                          )
                                         )
                         .values()
@@ -122,15 +135,11 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
         var dbEngine = ctx.getDatabase();
-        var preferredType = ctx.getSettings(DecodesSettings.class)
-                              .map(ds -> ds.siteNameTypePreference)
-                              .orElseGet(() -> "CWMS");
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
                  .define(SqlQueries.WHERE_CLAUSE, "where upper(name) = upper(:name)")
                  .define(SqlQueries.LIMIT_CLAUSE, "")
-                 .bind("preferredType", preferredType)
                  .bind(GenericColumns.NAME, name);
 
             return query.registerRowMapper(DecodesConfigMapper.withPrefix("pc"))
@@ -142,7 +151,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
                                             EquipmentModelMapper.withPrefix("em"), PropertiesMapper.withPrefix("ep"),
                                             ConfigSensorMapper.withPrefix("cs"), PropertiesMapper.withPrefix("csp", true),
                                             DataTypeMapper.withPrefix("dt"), DecodesScriptBuilderMapper.withPrefix("ds"),
-                                            FormatStatementMapper.withPrefix("fs")
+                                            FormatStatementMapper.withPrefix("fs"), UnitConverterMapper.withPrefix("uc")
                                          )
                                         )
                         .values()

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
@@ -13,6 +13,7 @@ import org.opendcs.database.model.mappers.unitconverter.UnitConverterMapper;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs.DecodesConfigMapper;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts.DecodesScriptBuilderMapper;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts.FormatStatementMapper;
+import org.opendcs.database.impl.opendcs.jdbi.column.numeric.NullableDoubleArgumentFactory;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs.ConfigSensorMapper;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs.DecodesConfigAccumulator;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
@@ -55,7 +56,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
                     em.equipmentType e_equipmentType, ep.name ep_name, ep.prop_value ep_prop_value,
 
                     cs.sensornumber cs_sensornumber, cs.sensorname cs_sensorname, cs.recordingmode cs_recordingmode,
-                    cs.recordinginterval cs_recordinginterval, cs.timeoffirstsample cs_timeoffirstsample, 
+                    cs.recordinginterval cs_recordinginterval, cs.timeoffirstsample cs_timeoffirstsample,
                     cs.equipmentid cs_equipmentid, cs.absolutemin cs_absolutemin, cs.absolutemax cs_absolutemax,
                     cs.stat_cd cs_stat_cd, csp.sensornumber csp_sensornumber, csp.prop_name csp_prop_name, csp.prop_value csp_prop_value,
 
@@ -86,11 +87,31 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
             left join engineeringunit to_eu on to_eu.unitabbr = uc.tounitsabbr
 
 
-            order by 
+            order by
                 pc.name <collate> asc,
                 cs.sensornumber asc,
                 fs.sequencenum asc
             """;
+
+    private static final String DELETE_CONFIGSENSOR_PROPERTIES = "delete from configsensorproperty where configid = :id";
+    private static final String DELETE_CONFIGSENSOR_DATATYPE = "delete from configsensordatatype where configid = :id";
+    private static final String DELETE_CONFIGSENSOR = "delete from configsensor where configid = :id";
+    private static final String DELETE_SCRIPTSENSOR = """
+            delete from scriptsensor
+             where decodesscriptid in (select id from decodesscript where configid = :id)
+            """;
+    private static final String GET_SCRIPTSENSOR_UC_ID = """
+                select unitconverterid from scriptsensor
+                 where decodesscriptid in (
+                    select id
+                      from decodesscript
+                     where configid = :id
+                 )
+            """;
+    private static final String DELETE_UNITCONVERETER = "delete from unitconverter where id = :id";
+    private static final String DELETE_FORMATSTATEMENTS =
+        "delete from formatstatement where decodesscriptid  in (select id from decodesscript where configid = :id)";
+    private static final String DELETE_DECODESSCRIPT = "delete from decodesscript where configid = :id";
 
     @Override
     public Optional<PlatformConfig> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException
@@ -179,23 +200,32 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
         var keyGen = ctx.getGenerator(KeyGenerator.class)
                         .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
         final var mergeSql = """
                 merge into platformconfig pc
                 using (
-                    select :id id, :name name, :description description, :equipmentid equipmentid                
+                    select :id id, :name name, :description description, :equipmentid equipmentid
                 ) input
                 on (pc.id = input.id)
                 when matched then
-                    update set 
+                    update set
                         name = input.name, description = input.description, equipmentid = input.equipmentid
                 when not matched then
                     insert (id, name, description, equipmentid)
                     values(input.id, input.name, input.description, input.equipmentid)
                 """;
-        try (var merge = handle.createUpdate(mergeSql))
+        try (var merge = handle.createUpdate(mergeSql);
+             var deleteConfigSensorProps = handle.createUpdate(DELETE_CONFIGSENSOR_PROPERTIES);
+             var deleteConfigSensorDataType = handle.createUpdate(DELETE_CONFIGSENSOR_DATATYPE);
+             var deleteConfigSensor = handle.createUpdate(DELETE_CONFIGSENSOR);
+             var deleteFormatStatements = handle.createUpdate(DELETE_FORMATSTATEMENTS);
+             var deleteScriptSensorUc = handle.prepareBatch(DELETE_UNITCONVERETER);
+             var getUnitConverterIds = handle.createQuery(GET_SCRIPTSENSOR_UC_ID);
+             var deleteScriptSensor = handle.createUpdate(DELETE_SCRIPTSENSOR);
+             var deleteScript = handle.createUpdate(DELETE_DECODESSCRIPT);
+            )
+
         {
             DbKey id = pc.getId();
             var existing = getByName(tx, pc.getName());
@@ -218,6 +248,32 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
                  .execute()
                  ;
 
+            // delete everything
+            deleteConfigSensorProps.bind(GenericColumns.ID, bindKey).execute();
+            deleteConfigSensorDataType.bind(GenericColumns.ID, bindKey).execute();
+
+            var ucIds = getUnitConverterIds.bind(GenericColumns.ID, bindKey)
+                                           .mapTo(DbKey.class)
+                                           .collectIntoList();
+
+            deleteScriptSensor.bind(GenericColumns.ID, bindKey).execute();
+
+            for (var ucId: ucIds)
+            {
+                deleteScriptSensorUc.bind(GenericColumns.ID, ucId).add();
+            }
+            deleteScriptSensorUc.execute();
+
+            deleteConfigSensor.bind(GenericColumns.ID, bindKey).execute();
+            deleteFormatStatements.bind(GenericColumns.ID, bindKey).execute();
+            deleteScript.bind(GenericColumns.ID, bindKey).execute();
+
+
+
+            // put everything back
+            insertConfigSensors(handle, bindKey, pc);
+            insertScripts(tx, handle, bindKey, pc, keyGen);
+
             return getById(tx, bindKey).orElseThrow(() -> new OpenDcsDataException("Unable to retrieve Platform Config we just saved."));
         }
         catch (DatabaseException ex)
@@ -226,11 +282,160 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
         }
     }
 
-    @Override
-    public void delete(DataTransaction arg0, DbKey arg1) throws OpenDcsDataException
+
+    private void insertConfigSensors(Handle handle, DbKey configId, PlatformConfig pc) throws OpenDcsDataException
     {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+        try (var insertSensor = handle.prepareBatch("""
+                    insert into
+                    configsensor(
+                            configid, sensornumber, sensorname, recordingmode,
+                            recordinginterval, timeoffirstsample, equipmentid,
+                            absolutemin, absolutemax, stat_cd
+                        )
+                    values (:configid, :sensornumber, :sensorname, :recordingmode,
+                            :recordinginterval, :timeoffirstsample, :equipmentid,
+                            :absolutemin, :absolutemax, :stat_cd)
+                    """).registerArgument(new NullableDoubleArgumentFactory());
+            var insertSensorProps = handle.prepareBatch("""
+                    insert into
+                     configsensorproperty(configid, sensornumber, prop_name, prop_value)
+                     values (:configid, :sensornumber, :prop_name, :prop_value)
+                    """);
+            var insertSensorDataType = handle.prepareBatch("""
+                    insert into configsensordatatype (configid, sensornumber, datatypeid)
+                    values(:configid, :sensornumber, :datatypeid)
+                    """)
+                )
+        {
+            for (var sensor: pc.getSensorVec())
+            {
+                insertSensor.bind("configid", configId)
+                            .bind("sensornumber", sensor.sensorNumber)
+                            .bind("sensorname", sensor.sensorName)
+                            .bind("recordingmode", sensor.recordingMode)
+                            .bind("recordinginterval", sensor.recordingInterval)
+                            .bind("timeoffirstsample", sensor.timeOfFirstSample)
+                            .bind("equipmentid", sensor.equipmentModel != null ? sensor.equipmentModel.getId() : null)
+                            .bind("absolutemin", sensor.absoluteMin)
+                            .bind("absolutemax", sensor.absoluteMax)
+                            .bind("stat_cd", sensor.getUsgsStatCode())
+                            .add();
+                for (var dt: sensor.getDataTypeVec())
+                {
+                    insertSensorDataType.bind("configid", configId)
+                                        .bind("sensornumber", sensor.sensorNumber)
+                                        .bind("datatypeid", dt.getId())
+                                        .add();
+                }
+
+                sensor.getProperties().forEach((k,v) ->
+                {
+                    insertSensorProps.bind("configid", configId)
+                                     .bind("sensornumber", sensor.sensorNumber)
+                                     .bind("prop_name", k)
+                                     .bind("prop_value", v)
+                                     .add();
+                });
+            }
+
+            insertSensor.execute();
+            insertSensorProps.execute();
+            insertSensorDataType.execute();
+
+        }
+
+    }
+
+    private void insertScripts(DataTransaction tx, Handle handle, DbKey configId, PlatformConfig pc, KeyGenerator keyGen) throws OpenDcsDataException, DatabaseException
+    {
+        try (var insertScript = handle.prepareBatch("""
+                insert into
+                    decodesscript(id, configid, name, script_type, dataorder)
+                           values(:id, :configid, :name, :script_type, :dataorder)
+                """);
+            var insertScriptSensor = handle.prepareBatch("""
+                    insert into scriptsensor (decodesscriptid, sensornumber, unitconverterid)
+                        values (:decodesscriptid, :sensornumber, :unitconverterid)
+                    """);
+            var insertFormatStatement = handle.prepareBatch("""
+                    insert into
+                        formatstatement(decodesscriptid, sequencenum, label, format)
+                        values (:decodesscriptid, :sequencenum, :label, :format)
+                    """))
+        {
+            for (var script: pc.decodesScripts)
+            {
+                final var id = script.idIsSet() ? script.getId() : keyGen.getKey("decodesscript", handle.getConnection());
+                insertScript.bind(GenericColumns.ID, id)
+                            .bind("configid", configId)
+                            .bind(GenericColumns.NAME, script.scriptName)
+                            .bind("script_type", script.scriptType)
+                            .bind("dataorder", script.getDataOrder())
+                            .add();
+
+                for (var sensor: script.scriptSensors)
+                {
+
+                    final var uc = ucDao.save(tx, sensor.rawConverter);
+
+                    insertScriptSensor.bind("decodesscriptid", id)
+                                      .bind("sensornumber", sensor.sensorNumber)
+                                      .bind("unitconverterid", uc.getId())
+                                      .add();
+                }
+
+                for (var fs: script.getFormatStatements())
+                {
+                    insertFormatStatement.bind("decodesscriptid", id)
+                                         .bind("sequencenum", fs.sequenceNum)
+                                         .bind("label", fs.label)
+                                         .bind("format", fs.format)
+                                         .add();
+                }
+            }
+
+            insertScript.execute();
+            insertScriptSensor.execute();
+            insertFormatStatement.execute();
+        }
+    }
+
+
+    @Override
+    public void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        try(var deleteConfigSensorProps = handle.createUpdate(DELETE_CONFIGSENSOR_PROPERTIES);
+            var deleteConfigSensorDataType = handle.createUpdate(DELETE_CONFIGSENSOR_DATATYPE);
+            var deleteConfigSensor = handle.createUpdate(DELETE_CONFIGSENSOR);
+            var deleteFormatStatements = handle.createUpdate(DELETE_FORMATSTATEMENTS);
+            var deleteScriptSensorUc = handle.prepareBatch(DELETE_UNITCONVERETER);
+            var getUnitConverterIds = handle.createQuery(GET_SCRIPTSENSOR_UC_ID);
+            var deleteScriptSensor = handle.createUpdate(DELETE_SCRIPTSENSOR);
+            var deleteScript = handle.createUpdate(DELETE_FORMATSTATEMENTS);
+            var deleteConfig = handle.createUpdate("delete from platformconfig where id = :id"))
+        {
+            deleteConfigSensorProps.bind(GenericColumns.ID, id).execute();
+            deleteConfigSensorDataType.bind(GenericColumns.ID, id).execute();
+            deleteConfigSensor.bind(GenericColumns.ID, id).execute();
+            var ucIds = getUnitConverterIds.bind(GenericColumns.ID, id)
+                                           .mapTo(DbKey.class)
+                                           .collectIntoList();
+
+            deleteScriptSensor.bind(GenericColumns.ID, id).execute();
+
+            for (var ucId: ucIds)
+            {
+                deleteScriptSensorUc.bind(GenericColumns.ID, ucId).add();
+            }
+            deleteScriptSensorUc.execute();
+            deleteFormatStatements.bind(GenericColumns.ID, id).execute();
+            deleteScriptSensor.bind(GenericColumns.ID, id).execute();
+            deleteScript.bind(GenericColumns.ID, id).execute();
+            deleteConfig.bind(GenericColumns.ID, id).execute();
+
+        }
     }
 
     @Override

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/decodesscript/InMemoryDecodesScriptReader.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/decodesscript/InMemoryDecodesScriptReader.java
@@ -21,7 +21,7 @@ public class InMemoryDecodesScriptReader implements DecodesScriptReader
 
     public void addStatement(FormatStatement statement)
     {
-        if (!statements.stream().anyMatch(fs -> fs.sequenceNum == statement.sequenceNum))
+        if (statements.stream().noneMatch(fs -> fs.sequenceNum == statement.sequenceNum))
         {
             statements.add(statement);
         }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/decodesscript/InMemoryDecodesScriptReader.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/decodesscript/InMemoryDecodesScriptReader.java
@@ -1,0 +1,41 @@
+package org.opendcs.database.impl.opendcs.jdbi.decodesscript;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import decodes.db.DecodesScript;
+import decodes.db.DecodesScriptReader;
+import decodes.db.FormatStatement;
+
+public class InMemoryDecodesScriptReader implements DecodesScriptReader
+{
+    private int current = 0;
+
+    private ArrayList<FormatStatement> statements = new ArrayList<>();
+
+
+    public void addStatement(FormatStatement statement)
+    {
+
+    }
+
+    @Override
+    public Optional<FormatStatement> nextStatement(DecodesScript script) throws IOException
+    {
+        if (current >= statements.size())
+        {
+            return Optional.empty();
+        }
+        
+        
+        var ret = new FormatStatement(script, current);
+        var fs = statements.get(current);
+        ret.format = fs.format;
+        ret.label = fs.label;
+
+        current++;
+        return Optional.of(ret);
+    }
+    
+}

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/decodesscript/InMemoryDecodesScriptReader.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/decodesscript/InMemoryDecodesScriptReader.java
@@ -17,7 +17,10 @@ public class InMemoryDecodesScriptReader implements DecodesScriptReader
 
     public void addStatement(FormatStatement statement)
     {
-
+        if (!statements.stream().anyMatch(fs -> fs.sequenceNum == statement.sequenceNum))
+        {
+            statements.add(statement);
+        }
     }
 
     @Override
@@ -28,8 +31,13 @@ public class InMemoryDecodesScriptReader implements DecodesScriptReader
             return Optional.empty();
         }
         
+        if (current == 0)
+        {
+            // make sure the statements are ordered by sequence number, just in case.
+            statements.sort((a,b) -> Integer.compare(a.sequenceNum, b.sequenceNum));
+        }
         
-        var ret = new FormatStatement(script, current);
+        var ret = new FormatStatement(script, current + 1); // statements are 1 based, not 0 based
         var fs = statements.get(current);
         ret.format = fs.format;
         ret.label = fs.label;

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/decodesscript/InMemoryDecodesScriptReader.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/decodesscript/InMemoryDecodesScriptReader.java
@@ -8,6 +8,10 @@ import decodes.db.DecodesScript;
 import decodes.db.DecodesScriptReader;
 import decodes.db.FormatStatement;
 
+/**
+ * used by the {@see DecodesScripterBuilderMapper} to allow manually
+ * adding the format statements to the internal list.
+ */
 public class InMemoryDecodesScriptReader implements DecodesScriptReader
 {
     private int current = 0;
@@ -30,13 +34,13 @@ public class InMemoryDecodesScriptReader implements DecodesScriptReader
         {
             return Optional.empty();
         }
-        
+
         if (current == 0)
         {
             // make sure the statements are ordered by sequence number, just in case.
             statements.sort((a,b) -> Integer.compare(a.sequenceNum, b.sequenceNum));
         }
-        
+
         var ret = new FormatStatement(script, current + 1); // statements are 1 based, not 0 based
         var fs = statements.get(current);
         ret.format = fs.format;
@@ -45,5 +49,5 @@ public class InMemoryDecodesScriptReader implements DecodesScriptReader
         current++;
         return Optional.of(ret);
     }
-    
+
 }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/ConfigSensorMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/ConfigSensorMapper.java
@@ -18,7 +18,7 @@ public class ConfigSensorMapper extends PrefixRowMapper<ConfigSensor>
 
     @Override
     public ConfigSensor map(ResultSet rs, StatementContext ctx) throws SQLException
-    {        
+    {
         final var num = rs.getInt(prefix + "sensornumber");
         if (rs.wasNull())
         {
@@ -31,7 +31,7 @@ public class ConfigSensorMapper extends PrefixRowMapper<ConfigSensor>
 
         cs.recordingInterval = rs.getInt(prefix + "recordinginterval");
         cs.recordingMode = rs.getString(prefix + "recordingMode").charAt(0);
-        
+
         final var absoluteMin = rs.getDouble(prefix + "absolutemin");
         if (!rs.wasNull())
         {
@@ -46,7 +46,7 @@ public class ConfigSensorMapper extends PrefixRowMapper<ConfigSensor>
 
         return cs;
     }
-    
+
 
     public static ConfigSensorMapper withPrefix(String prefix)
     {

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/ConfigSensorMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/ConfigSensorMapper.java
@@ -1,0 +1,55 @@
+package org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.statement.StatementContext;
+import org.opendcs.database.model.mappers.PrefixRowMapper;
+
+import decodes.db.ConfigSensor;
+
+public class ConfigSensorMapper extends PrefixRowMapper<ConfigSensor>
+{
+
+    protected ConfigSensorMapper(String prefix)
+    {
+        super(prefix);
+    }
+
+    @Override
+    public ConfigSensor map(ResultSet rs, StatementContext ctx) throws SQLException
+    {        
+        final var num = rs.getInt(prefix + "sensornumber");
+        if (rs.wasNull())
+        {
+            return null;
+        }
+        final var cs = new ConfigSensor(null, num);
+
+        final var name = rs.getString(prefix + "sensorname");
+        cs.sensorName = name;
+
+        cs.recordingInterval = rs.getInt(prefix + "recordinginterval");
+        cs.recordingMode = rs.getString(prefix + "recordingMode").charAt(0);
+        
+        final var absoluteMin = rs.getDouble(prefix + "absolutemin");
+        if (!rs.wasNull())
+        {
+            cs.absoluteMin = absoluteMin;
+        }
+
+        final var absoluteMax = rs.getDouble(prefix + "absolutemax");
+        if (!rs.wasNull())
+        {
+            cs.absoluteMax = absoluteMax;
+        }
+
+        return cs;
+    }
+    
+
+    public static ConfigSensorMapper withPrefix(String prefix)
+    {
+        return new ConfigSensorMapper(prefix);
+    }
+}

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
@@ -119,7 +119,7 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
 
         var scriptId = columnMapperForKey.map(rs, "ds_" + GenericColumns.ID , ctx);
         var scriptBuilder = pc.getDecodesScriptBuilder(scriptId).orElse(null);
-        if (scriptBuilder == null)
+        if (scriptBuilder == null && !(scriptId == null || DbKey.isNull(scriptId)))
         {
             scriptBuilder = scriptBuilderMapper.map(rs, ctx);
             pc.withDecodesScriptBuilder(scriptBuilder);

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
@@ -40,6 +40,7 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
     private final UnitConverterMapper unitConverterMapper;
 
 
+    @SuppressWarnings("java:S107") // It's just big
     public DecodesConfigAccumulator(String configPrefix, DecodesConfigMapper configMapper,
                                 EquipmentModelMapper equipmentModelMapper, PropertiesMapper equipmentPropertiesMapper,
                                 ConfigSensorMapper sensorMapper, PropertiesMapper sensorPropertiesMapper,

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
@@ -22,6 +22,10 @@ import org.opendcs.utils.sql.SqlErrorMessages;
 import decodes.db.ScriptSensor;
 import decodes.sql.DbKey;
 
+/**
+ * Given the rather complex, and volumous, join of DECODES Configurations (PlatformConfigs)
+ * We process each row manually to assosciate the information with the correct PlatformConfig
+ */
 public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, PlatformConfigBuilder>>
 {
     private final String configPrefix;
@@ -36,7 +40,7 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
     private final UnitConverterMapper unitConverterMapper;
 
 
-    public DecodesConfigAccumulator(String configPrefix, DecodesConfigMapper configMapper, 
+    public DecodesConfigAccumulator(String configPrefix, DecodesConfigMapper configMapper,
                                 EquipmentModelMapper equipmentModelMapper, PropertiesMapper equipmentPropertiesMapper,
                                 ConfigSensorMapper sensorMapper, PropertiesMapper sensorPropertiesMapper,
                                 DataTypeMapper dataTypeMapper, DecodesScriptBuilderMapper scriptBuilderMapper,
@@ -47,14 +51,14 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
         this.equipmentModelMapper = equipmentModelMapper;
         this.equipmentPropertiesMapper = equipmentPropertiesMapper;
         this.sensorMapper = sensorMapper;
-        this.sensorPropertiesMapper = sensorPropertiesMapper;        
+        this.sensorPropertiesMapper = sensorPropertiesMapper;
         this.dataTypeMapper = dataTypeMapper;
         this.scriptBuilderMapper = scriptBuilderMapper;
         this.formatStatementMapper = formatStatementMapper;
         this.unitConverterMapper = unitConverterMapper;
     }
 
-    
+
     @Override
     public Map<Long, PlatformConfigBuilder> apply(Map<Long, PlatformConfigBuilder> previous, ResultSet rs, StatementContext ctx)
             throws SQLException
@@ -66,7 +70,7 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
         {
             pc = previous.computeIfAbsent(rs.getLong(configPrefix+GenericColumns.ID),
                 pcId ->
-                { 
+                {
                     try
                     {
                         return new PlatformConfigBuilder(configMapper.map(rs, ctx));
@@ -93,7 +97,7 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
             pc.withEquipmentModel(equipmentModelMapper.map(rs, ctx));
         }
 
-        
+
         var emProps = equipmentPropertiesMapper.map(rs, ctx);
         if (emProps.first != null)
         {
@@ -124,7 +128,7 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
             scriptBuilder = scriptBuilderMapper.map(rs, ctx);
             pc.withDecodesScriptBuilder(scriptBuilder);
         }
-        
+
         var formatStatement = formatStatementMapper.map(rs, ctx);
         if (formatStatement != null)
         {
@@ -145,5 +149,5 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
 
         return previous;
     }
-    
+
 }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
@@ -14,11 +14,12 @@ import org.opendcs.database.model.mappers.PrefixRowMapper;
 import org.opendcs.database.model.mappers.datatype.DataTypeMapper;
 import org.opendcs.database.model.mappers.equipmentmodel.EquipmentModelMapper;
 import org.opendcs.database.model.mappers.properties.PropertiesMapper;
+import org.opendcs.database.model.mappers.unitconverter.UnitConverterMapper;
 import org.opendcs.models.PlatformConfigBuilder;
 import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
 
-import decodes.db.DecodesScript.DecodesScriptBuilder;
+import decodes.db.ScriptSensor;
 import decodes.sql.DbKey;
 
 public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, PlatformConfigBuilder>>
@@ -32,13 +33,14 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
     private final DataTypeMapper dataTypeMapper;
     private final DecodesScriptBuilderMapper scriptBuilderMapper;
     private final FormatStatementMapper formatStatementMapper;
+    private final UnitConverterMapper unitConverterMapper;
 
 
     public DecodesConfigAccumulator(String configPrefix, DecodesConfigMapper configMapper, 
                                 EquipmentModelMapper equipmentModelMapper, PropertiesMapper equipmentPropertiesMapper,
                                 ConfigSensorMapper sensorMapper, PropertiesMapper sensorPropertiesMapper,
                                 DataTypeMapper dataTypeMapper, DecodesScriptBuilderMapper scriptBuilderMapper,
-                                FormatStatementMapper formatStatementMapper)
+                                FormatStatementMapper formatStatementMapper, UnitConverterMapper unitConverterMapper)
     {
         this.configPrefix = PrefixRowMapper.addUnderscoreIfMissing(configPrefix);
         this.configMapper = configMapper;
@@ -49,6 +51,7 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
         this.dataTypeMapper = dataTypeMapper;
         this.scriptBuilderMapper = scriptBuilderMapper;
         this.formatStatementMapper = formatStatementMapper;
+        this.unitConverterMapper = unitConverterMapper;
     }
 
     
@@ -128,8 +131,17 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
             // we set this so we know it's the In Memory reader
             ((InMemoryDecodesScriptReader)scriptBuilder.getReader()).addStatement(formatStatement);
         }
-        // decodes scripts
-        /// and descript scripts data
+
+        var sensorScriptId = columnMapperForKey.map(rs, "ss_decodesscriptid", ctx);
+        var sensorScriptNum = rs.getInt("ss_sensornumber");
+
+        if (!DbKey.isNull(sensorScriptId))
+        {
+            var scriptSensor = new ScriptSensor(null, sensorScriptNum);
+            var uc = unitConverterMapper.map(rs, ctx);
+            scriptSensor.rawConverter = uc;
+            pc.withScriptSensor(sensorScriptId, scriptSensor);
+        }
 
         return previous;
     }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
@@ -1,0 +1,137 @@
+package org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.result.ResultSetAccumulator;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.opendcs.database.impl.opendcs.jdbi.decodesscript.InMemoryDecodesScriptReader;
+import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts.DecodesScriptBuilderMapper;
+import org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts.FormatStatementMapper;
+import org.opendcs.database.model.mappers.PrefixRowMapper;
+import org.opendcs.database.model.mappers.datatype.DataTypeMapper;
+import org.opendcs.database.model.mappers.equipmentmodel.EquipmentModelMapper;
+import org.opendcs.database.model.mappers.properties.PropertiesMapper;
+import org.opendcs.models.PlatformConfigBuilder;
+import org.opendcs.utils.sql.GenericColumns;
+import org.opendcs.utils.sql.SqlErrorMessages;
+
+import decodes.db.DecodesScript.DecodesScriptBuilder;
+import decodes.sql.DbKey;
+
+public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, PlatformConfigBuilder>>
+{
+    private final String configPrefix;
+    private final DecodesConfigMapper configMapper;
+    private final EquipmentModelMapper equipmentModelMapper;
+    private final PropertiesMapper equipmentPropertiesMapper;
+    private final ConfigSensorMapper sensorMapper;
+    private final PropertiesMapper sensorPropertiesMapper;
+    private final DataTypeMapper dataTypeMapper;
+    private final DecodesScriptBuilderMapper scriptBuilderMapper;
+    private final FormatStatementMapper formatStatementMapper;
+
+
+    public DecodesConfigAccumulator(String configPrefix, DecodesConfigMapper configMapper, 
+                                EquipmentModelMapper equipmentModelMapper, PropertiesMapper equipmentPropertiesMapper,
+                                ConfigSensorMapper sensorMapper, PropertiesMapper sensorPropertiesMapper,
+                                DataTypeMapper dataTypeMapper, DecodesScriptBuilderMapper scriptBuilderMapper,
+                                FormatStatementMapper formatStatementMapper)
+    {
+        this.configPrefix = PrefixRowMapper.addUnderscoreIfMissing(configPrefix);
+        this.configMapper = configMapper;
+        this.equipmentModelMapper = equipmentModelMapper;
+        this.equipmentPropertiesMapper = equipmentPropertiesMapper;
+        this.sensorMapper = sensorMapper;
+        this.sensorPropertiesMapper = sensorPropertiesMapper;        
+        this.dataTypeMapper = dataTypeMapper;
+        this.scriptBuilderMapper = scriptBuilderMapper;
+        this.formatStatementMapper = formatStatementMapper;
+    }
+
+    
+    @Override
+    public Map<Long, PlatformConfigBuilder> apply(Map<Long, PlatformConfigBuilder> previous, ResultSet rs, StatementContext ctx)
+            throws SQLException
+    {
+        ColumnMapper<DbKey> columnMapperForKey = ctx.findColumnMapperFor(DbKey.class)
+                                                    .orElseThrow(() -> new SQLException(SqlErrorMessages.DBKEY_MAPPER_NOT_FOUND));
+        PlatformConfigBuilder pc = null;
+        try
+        {
+            pc = previous.computeIfAbsent(rs.getLong(configPrefix+GenericColumns.ID),
+                pcId ->
+                { 
+                    try
+                    {
+                        return new PlatformConfigBuilder(configMapper.map(rs, ctx));
+                    }
+                catch (SQLException ex)
+                {
+                    // We have to use RuntimeException to escape the computeIfAbsent when there
+                    // is an error.
+                    throw new RuntimeException(ex); // NOSONAR
+                }
+            });
+        }
+        catch (RuntimeException ex)
+        {
+            if (ex.getCause() instanceof SQLException sqlException)
+            {
+                throw sqlException;
+            }
+            throw ex;
+        }
+        var ignored = rs.getLong(configPrefix+"equipmentid");
+        if (!rs.wasNull())
+        {
+            pc.withEquipmentModel(equipmentModelMapper.map(rs, ctx));
+        }
+
+        
+        var emProps = equipmentPropertiesMapper.map(rs, ctx);
+        if (emProps.first != null)
+        {
+            pc.withEquipmentModelProperty(emProps.first, emProps.second);
+        }
+
+        var configSensor = sensorMapper.map(rs, ctx);
+        if (configSensor != null)
+        {
+            pc.withSensor(configSensor);
+        }
+        final var datatype = dataTypeMapper.map(rs, ctx);
+        if (datatype != null)
+        {
+            pc.withSensorDataType(configSensor.sensorNumber, datatype);
+        }
+
+        var sensorProperties = sensorPropertiesMapper.map(rs, ctx);
+        if (sensorProperties.first != null)
+        {
+            pc.withSensorProperty(configSensor.sensorNumber, sensorProperties.first, sensorProperties.second);
+        }
+
+        var scriptId = columnMapperForKey.map(rs, "ds_" + GenericColumns.ID , ctx);
+        var scriptBuilder = pc.getDecodesScriptBuilder(scriptId).orElse(null);
+        if (scriptBuilder == null)
+        {
+            scriptBuilder = scriptBuilderMapper.map(rs, ctx);
+            pc.withDecodesScriptBuilder(scriptBuilder);
+        }
+        
+        var formatStatement = formatStatementMapper.map(rs, ctx);
+        if (formatStatement != null)
+        {
+            // we set this so we know it's the In Memory reader
+            ((InMemoryDecodesScriptReader)scriptBuilder.getReader()).addStatement(formatStatement);
+        }
+        // decodes scripts
+        /// and descript scripts data
+
+        return previous;
+    }
+    
+}

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigAccumulator.java
@@ -91,7 +91,8 @@ public class DecodesConfigAccumulator implements ResultSetAccumulator<Map<Long, 
             }
             throw ex;
         }
-        var ignored = rs.getLong(configPrefix+"equipmentid");
+
+        rs.getLong(configPrefix+"equipmentid");
         if (!rs.wasNull())
         {
             pc.withEquipmentModel(equipmentModelMapper.map(rs, ctx));

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigMapper.java
@@ -15,7 +15,7 @@ import decodes.sql.DbKey;
 public class DecodesConfigMapper extends PrefixRowMapper<PlatformConfig> 
 {
     public static final String DEFAULT_PREFIX = "pc";
-    public static final DecodesConfigMapper DEFAULT_MAPPER = DecodesConfigMapper.withPrefix(DEFAULT_PREFIX);
+    public static final DecodesConfigMapper DEFAULT_MAPPER = new DecodesConfigMapper(DEFAULT_PREFIX);
 
     private DecodesConfigMapper(String prefix)
     {
@@ -44,7 +44,7 @@ public class DecodesConfigMapper extends PrefixRowMapper<PlatformConfig>
         }
         else
         {
-        return new DecodesConfigMapper(prefix);
+            return new DecodesConfigMapper(prefix);
         }
     }
 }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigMapper.java
@@ -1,0 +1,50 @@
+package org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.configs;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.opendcs.database.model.mappers.PrefixRowMapper;
+import org.opendcs.utils.sql.GenericColumns;
+import org.opendcs.utils.sql.SqlErrorMessages;
+
+import decodes.db.PlatformConfig;
+import decodes.sql.DbKey;
+
+public class DecodesConfigMapper extends PrefixRowMapper<PlatformConfig> 
+{
+    public static final String DEFAULT_PREFIX = "pc";
+    public static final DecodesConfigMapper DEFAULT_MAPPER = DecodesConfigMapper.withPrefix(DEFAULT_PREFIX);
+
+    private DecodesConfigMapper(String prefix)
+    {
+        super(prefix);
+    }
+
+    @Override
+    public PlatformConfig map(ResultSet rs, StatementContext ctx) throws SQLException
+    {
+        ColumnMapper<DbKey> columnMapperForKey = ctx.findColumnMapperFor(DbKey.class)
+                                                    .orElseThrow(() -> new SQLException(SqlErrorMessages.DBKEY_MAPPER_NOT_FOUND));
+        final var pc = new PlatformConfig();
+        final var id = columnMapperForKey.map(rs, prefix + GenericColumns.ID, ctx);
+        pc.forceSetId(id);
+        pc.configName = rs.getString(prefix + GenericColumns.NAME);
+        pc.description = rs.getString(prefix + GenericColumns.DESCRIPTION);
+        return pc;
+    }
+ 
+    
+    public static DecodesConfigMapper withPrefix(String prefix)
+    {
+        if (DEFAULT_PREFIX.equalsIgnoreCase(prefix))
+        {
+            return DEFAULT_MAPPER;
+        }
+        else
+        {
+        return new DecodesConfigMapper(prefix);
+        }
+    }
+}

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigMapper.java
@@ -12,7 +12,7 @@ import org.opendcs.utils.sql.SqlErrorMessages;
 import decodes.db.PlatformConfig;
 import decodes.sql.DbKey;
 
-public class DecodesConfigMapper extends PrefixRowMapper<PlatformConfig>
+public final class DecodesConfigMapper extends PrefixRowMapper<PlatformConfig>
 {
     public static final String DEFAULT_PREFIX = "pc";
     public static final DecodesConfigMapper DEFAULT_MAPPER = new DecodesConfigMapper(DEFAULT_PREFIX);

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/configs/DecodesConfigMapper.java
@@ -12,7 +12,7 @@ import org.opendcs.utils.sql.SqlErrorMessages;
 import decodes.db.PlatformConfig;
 import decodes.sql.DbKey;
 
-public class DecodesConfigMapper extends PrefixRowMapper<PlatformConfig> 
+public class DecodesConfigMapper extends PrefixRowMapper<PlatformConfig>
 {
     public static final String DEFAULT_PREFIX = "pc";
     public static final DecodesConfigMapper DEFAULT_MAPPER = new DecodesConfigMapper(DEFAULT_PREFIX);
@@ -34,8 +34,7 @@ public class DecodesConfigMapper extends PrefixRowMapper<PlatformConfig>
         pc.description = rs.getString(prefix + GenericColumns.DESCRIPTION);
         return pc;
     }
- 
-    
+
     public static DecodesConfigMapper withPrefix(String prefix)
     {
         if (DEFAULT_PREFIX.equalsIgnoreCase(prefix))

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/DecodesScriptBuilderMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/DecodesScriptBuilderMapper.java
@@ -28,6 +28,11 @@ public class DecodesScriptBuilderMapper extends PrefixRowMapper<DecodesScriptBui
                                                     .orElseThrow(() -> new SQLException(SqlErrorMessages.DBKEY_MAPPER_NOT_FOUND));
         var builder = new DecodesScriptBuilder(new InMemoryDecodesScriptReader());
         final var id = columnMapperForKey.map(rs, prefix + GenericColumns.ID, ctx);
+
+        if (rs.wasNull() || DbKey.isNull(id))
+        {
+            return null;
+        }
         final var name = rs.getString(prefix + GenericColumns.NAME);
         final var scriptType = rs.getString(prefix + "script_type");
         final var dataOrder = rs.getString(prefix + "dataorder");

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/DecodesScriptBuilderMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/DecodesScriptBuilderMapper.java
@@ -1,0 +1,48 @@
+package org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.opendcs.database.impl.opendcs.jdbi.decodesscript.InMemoryDecodesScriptReader;
+import org.opendcs.database.model.mappers.PrefixRowMapper;
+import org.opendcs.utils.sql.GenericColumns;
+import org.opendcs.utils.sql.SqlErrorMessages;
+
+import decodes.db.DecodesScript.DecodesScriptBuilder;
+import decodes.sql.DbKey;
+
+public class DecodesScriptBuilderMapper extends PrefixRowMapper<DecodesScriptBuilder>
+ {
+
+    protected DecodesScriptBuilderMapper(String prefix)
+    {
+        super(prefix);
+    }
+
+    @Override
+    public DecodesScriptBuilder map(ResultSet rs, StatementContext ctx) throws SQLException
+    {
+        ColumnMapper<DbKey> columnMapperForKey = ctx.findColumnMapperFor(DbKey.class)
+                                                    .orElseThrow(() -> new SQLException(SqlErrorMessages.DBKEY_MAPPER_NOT_FOUND));
+        var builder = new DecodesScriptBuilder(new InMemoryDecodesScriptReader());
+        final var id = columnMapperForKey.map(rs, prefix + GenericColumns.ID, ctx);
+        final var name = rs.getString(prefix + GenericColumns.NAME);
+        final var scriptType = rs.getString(prefix + "script_type");
+        final var dataOrder = rs.getString(prefix + "dataorder");
+
+        builder.withId(id);
+        builder.scriptName(name);
+        builder.scriptType(scriptType);
+        builder.withDataOrder(dataOrder.charAt(0));
+
+        return builder;
+
+    }
+    
+    public static DecodesScriptBuilderMapper withPrefix(String prefix)
+    {
+        return new DecodesScriptBuilderMapper(prefix);
+    }
+}

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/DecodesScriptBuilderMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/DecodesScriptBuilderMapper.java
@@ -45,7 +45,7 @@ public class DecodesScriptBuilderMapper extends PrefixRowMapper<DecodesScriptBui
         return builder;
 
     }
-    
+
     public static DecodesScriptBuilderMapper withPrefix(String prefix)
     {
         return new DecodesScriptBuilderMapper(prefix);

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/FormatStatementMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/FormatStatementMapper.java
@@ -1,0 +1,41 @@
+package org.opendcs.database.impl.opendcs.jdbi.mapper.decodes.scripts;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.statement.StatementContext;
+import org.opendcs.database.model.mappers.PrefixRowMapper;
+
+import decodes.db.FormatStatement;
+
+public class FormatStatementMapper extends PrefixRowMapper<FormatStatement>
+{
+
+    protected FormatStatementMapper(String prefix)
+    {
+        super(prefix);
+    }
+
+    @Override
+    public FormatStatement map(ResultSet rs, StatementContext ctx) throws SQLException
+    {
+        final int num = rs.getInt(prefix + "sequencenum");
+        if (rs.wasNull())
+        {
+            return null;
+        }
+        final String label = rs.getString(prefix + "label");
+        final String format = rs.getString(prefix + "format");
+
+        var fs = new FormatStatement(null, num);
+        fs.label = label;
+        fs.format = format;
+        return fs;
+    }
+    
+
+    public FormatStatementMapper withPrefix(String prefix)
+    {
+        return new FormatStatementMapper(prefix);
+    }
+}

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/FormatStatementMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/FormatStatementMapper.java
@@ -32,7 +32,6 @@ public class FormatStatementMapper extends PrefixRowMapper<FormatStatement>
         fs.format = format;
         return fs;
     }
-    
 
     public static FormatStatementMapper withPrefix(String prefix)
     {

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/FormatStatementMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/decodes/scripts/FormatStatementMapper.java
@@ -34,7 +34,7 @@ public class FormatStatementMapper extends PrefixRowMapper<FormatStatement>
     }
     
 
-    public FormatStatementMapper withPrefix(String prefix)
+    public static FormatStatementMapper withPrefix(String prefix)
     {
         return new FormatStatementMapper(prefix);
     }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/models/PlatformConfigBuilder.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/models/PlatformConfigBuilder.java
@@ -1,0 +1,114 @@
+package org.opendcs.models;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.opendcs.database.api.OpenDcsDataRuntimeException;
+
+import decodes.db.ConfigSensor;
+import decodes.db.DataType;
+import decodes.db.PlatformConfig;
+import decodes.sql.DbKey;
+import decodes.db.DecodesScript.DecodesScriptBuilder;
+import decodes.db.DecodesScriptException;
+import decodes.db.EquipmentModel;
+
+public class PlatformConfigBuilder
+{
+    private PlatformConfig pc;
+    private List<ConfigSensor> sensors = new ArrayList<>();
+    private Map<DbKey, DecodesScriptBuilder> scriptBuilders = new HashMap<>();
+    private EquipmentModel equipmentModel = null;
+
+
+    public PlatformConfigBuilder(PlatformConfig pc)
+    {
+        this.pc = pc.copy();
+    }
+
+    public PlatformConfigBuilder withSensor(ConfigSensor cs)
+    {
+        if (!sensors.contains(cs))
+        {
+            sensors.add(cs);
+        }
+        return this;
+    }
+
+    public PlatformConfigBuilder withSensorProperty(int sensorNumber, String name, String value)
+    {
+        var sensor = sensors.stream()
+                            .filter(cs -> cs.sensorNumber == sensorNumber)
+                            .findFirst();
+        sensor.ifPresent(s -> s.setProperty(name, value));
+        return this;
+    }
+
+    public PlatformConfigBuilder withSensorDataType(int sensorNumber, DataType dataType)
+    {
+        var sensor = sensors.stream()
+                            .filter(cs -> cs.sensorNumber == sensorNumber)
+                            .findFirst();
+        sensor.ifPresent(s -> s.addDataType(dataType));
+        return this;
+    }
+
+    public PlatformConfigBuilder withEquipmentModel(EquipmentModel equipmentModel)
+    {
+        if (this.equipmentModel != null)
+        {
+            this.equipmentModel = equipmentModel;
+        }
+        return this;
+    }
+
+    public PlatformConfigBuilder withEquipmentModelProperty(String name, String value)
+    {
+        if (equipmentModel != null)
+        {
+            this.equipmentModel.properties.put(name, value);
+        }
+        return this;
+    }
+
+    public PlatformConfigBuilder withDecodesScriptBuilder(DecodesScriptBuilder scriptBuilder)
+    {
+        this.scriptBuilders.computeIfAbsent(scriptBuilder.getScriptId(), id -> scriptBuilder);
+        return this;
+    }
+
+
+    public Optional<DecodesScriptBuilder> getDecodesScriptBuilder(DbKey id)
+    {
+        return Optional.ofNullable(scriptBuilders.get(id));
+    }
+
+
+    public PlatformConfig build() throws OpenDcsDataRuntimeException
+    {
+        for (var sensor: sensors)
+        {
+            pc.addSensor(sensor);
+        }
+
+        for (var scriptBuilder: scriptBuilders.values())
+        {
+            try
+            {
+                pc.addScript(scriptBuilder.build(false));
+            }
+            catch (IOException | DecodesScriptException ex)
+            {
+                throw new OpenDcsDataRuntimeException("Unable to build decodes scripts", ex);
+            }
+        }
+
+        pc.equipmentModel = equipmentModel;
+
+        return pc;
+    }
+}

--- a/java/opendcs-implementation/src/main/java/org/opendcs/models/PlatformConfigBuilder.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/models/PlatformConfigBuilder.java
@@ -144,7 +144,7 @@ public class PlatformConfigBuilder
     public PlatformConfigBuilder withScriptSensor(DbKey scriptId, ScriptSensor sensor)
     {
         var scriptSensorsList = scriptSensors.computeIfAbsent(scriptId, num -> new ArrayList<>());
-        if (!scriptSensorsList.stream().anyMatch(ss -> ss.sensorNumber == sensor.sensorNumber))
+        if (scriptSensorsList.stream().noneMatch(ss -> ss.sensorNumber == sensor.sensorNumber))
         {
             scriptSensorsList.add(sensor);
         }
@@ -179,10 +179,13 @@ public class PlatformConfigBuilder
             {
                 var script = scriptBuilder.build(true);
                 var scriptSensorsList = scriptSensors.get(script.getId());
-                for (var sensor: scriptSensorsList)
+                if (scriptSensorsList != null)
                 {
-                    sensor.decodesScript = script;
-                    script.addScriptSensor(sensor);
+                    for (var sensor: scriptSensorsList)
+                    {
+                        sensor.decodesScript = script;
+                        script.addScriptSensor(sensor);
+                    }
                 }
 
                 pc.addScript(script);

--- a/java/opendcs-implementation/src/main/java/org/opendcs/models/PlatformConfigBuilder.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/models/PlatformConfigBuilder.java
@@ -18,6 +18,13 @@ import decodes.db.DecodesScript.DecodesScriptBuilder;
 import decodes.db.DecodesScriptException;
 import decodes.db.EquipmentModel;
 
+/**
+ * PlatformConfigs are rather complex, containg possible sensor information, data about equipment used (including at the sensor level),
+ * as well as the decodes scripts and assosciated format statements and sensor unit converters.
+ *
+ * This class is used by  {@see DecodesConfigAccumulator} to store information retrieved from the returns result rows.
+ *
+ */
 public class PlatformConfigBuilder
 {
     private PlatformConfig pc;
@@ -32,12 +39,26 @@ public class PlatformConfigBuilder
         this.pc = pc.copy();
     }
 
+    /**
+     * Add a sensor if one with the given sensorNumber doesn't already exist.
+     * @param cs
+     * @return
+     */
     public PlatformConfigBuilder withSensor(ConfigSensor cs)
     {
         sensors.computeIfAbsent(cs.sensorNumber, num -> cs);
         return this;
     }
 
+    /**
+     * Add property value to sensor. If sensor doesn't exist this is a no-op.
+     *
+     * This behavior is to account for the possiblity of bad data in existing databases.
+     * @param sensorNumber
+     * @param name
+     * @param value
+     * @return
+     */
     public PlatformConfigBuilder withSensorProperty(int sensorNumber, String name, String value)
     {
         final var cs = sensors.get(sensorNumber);
@@ -48,6 +69,14 @@ public class PlatformConfigBuilder
         return this;
     }
 
+    /**
+     * Add a DataType to the given sensor numer.
+     *
+     * If the sensor doesn't exist, this is a no-op
+     * @param sensorNumber
+     * @param dataType
+     * @return
+     */
     public PlatformConfigBuilder withSensorDataType(int sensorNumber, DataType dataType)
     {
         final var cs = sensors.get(sensorNumber);
@@ -58,6 +87,13 @@ public class PlatformConfigBuilder
         return this;
     }
 
+    /**
+     * Set EquipmentModel if not already set.
+     *
+     * If equipment model was already set, this is a no-op
+     * @param equipmentModel
+     * @return
+     */
     public PlatformConfigBuilder withEquipmentModel(EquipmentModel equipmentModel)
     {
         if (this.equipmentModel != null)
@@ -67,6 +103,18 @@ public class PlatformConfigBuilder
         return this;
     }
 
+    /***
+     * Set a property on the equipment model. If the current equipment model is null,
+     * this is a noop.
+     *
+     * As this class is intended for use by the Decodes Config Mappers and Accumulators
+     * this should be an unlikely occurance. However, some existing databases by have stray
+     * data that remains so we aren't considering this condition an error.
+     *
+     * @param name
+     * @param value
+     * @return
+     */
     public PlatformConfigBuilder withEquipmentModelProperty(String name, String value)
     {
         if (equipmentModel != null)
@@ -76,12 +124,23 @@ public class PlatformConfigBuilder
         return this;
     }
 
+    /**
+     * Add, if it does not already exist, a new decodes script builder to this config builder.
+     * @param scriptBuilder
+     * @return
+     */
     public PlatformConfigBuilder withDecodesScriptBuilder(DecodesScriptBuilder scriptBuilder)
     {
         this.scriptBuilders.computeIfAbsent(scriptBuilder.getScriptId(), id -> scriptBuilder.platformConfig(this.pc));
         return this;
     }
 
+    /**
+     * Add a new Decodes Script Sensor if it does not already exist.
+     * @param scriptId
+     * @param sensor
+     * @return
+     */
     public PlatformConfigBuilder withScriptSensor(DbKey scriptId, ScriptSensor sensor)
     {
         var scriptSensorsList = scriptSensors.computeIfAbsent(scriptId, num -> new ArrayList<>());
@@ -92,11 +151,21 @@ public class PlatformConfigBuilder
         return this;
     }
 
+    /**
+     * Retrieve the script builder for the given DecodesScript ID
+     * @param id Surrogate key for the desired DecodesScript
+     * @return
+     */
     public Optional<DecodesScriptBuilder> getDecodesScriptBuilder(DbKey id)
     {
         return Optional.ofNullable(scriptBuilders.get(id));
     }
 
+    /**
+     * Finalize the PlatformConfig given all of the retrieved data.
+     * @return
+     * @throws OpenDcsDataRuntimeException If there are issues with the decodes script itself.
+     */
     public PlatformConfig build() throws OpenDcsDataRuntimeException
     {
         for (var sensor: sensors.values())

--- a/java/opendcs-implementation/src/main/java/org/opendcs/models/PlatformConfigBuilder.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/models/PlatformConfigBuilder.java
@@ -12,6 +12,7 @@ import org.opendcs.database.api.OpenDcsDataRuntimeException;
 import decodes.db.ConfigSensor;
 import decodes.db.DataType;
 import decodes.db.PlatformConfig;
+import decodes.db.ScriptSensor;
 import decodes.sql.DbKey;
 import decodes.db.DecodesScript.DecodesScriptBuilder;
 import decodes.db.DecodesScriptException;
@@ -20,9 +21,10 @@ import decodes.db.EquipmentModel;
 public class PlatformConfigBuilder
 {
     private PlatformConfig pc;
-    private List<ConfigSensor> sensors = new ArrayList<>();
+    private Map<Integer,ConfigSensor> sensors = new HashMap<>();
     private Map<DbKey, DecodesScriptBuilder> scriptBuilders = new HashMap<>();
     private EquipmentModel equipmentModel = null;
+    private Map<DbKey, List<ScriptSensor>> scriptSensors = new HashMap<>();
 
 
     public PlatformConfigBuilder(PlatformConfig pc)
@@ -32,28 +34,27 @@ public class PlatformConfigBuilder
 
     public PlatformConfigBuilder withSensor(ConfigSensor cs)
     {
-        if (!sensors.contains(cs))
-        {
-            sensors.add(cs);
-        }
+        sensors.computeIfAbsent(cs.sensorNumber, num -> cs);
         return this;
     }
 
     public PlatformConfigBuilder withSensorProperty(int sensorNumber, String name, String value)
     {
-        var sensor = sensors.stream()
-                            .filter(cs -> cs.sensorNumber == sensorNumber)
-                            .findFirst();
-        sensor.ifPresent(s -> s.setProperty(name, value));
+        final var cs = sensors.get(sensorNumber);
+        if (cs != null)
+        {
+            cs.setProperty(name, value);
+        }
         return this;
     }
 
     public PlatformConfigBuilder withSensorDataType(int sensorNumber, DataType dataType)
     {
-        var sensor = sensors.stream()
-                            .filter(cs -> cs.sensorNumber == sensorNumber)
-                            .findFirst();
-        sensor.ifPresent(s -> s.addDataType(dataType));
+        final var cs = sensors.get(sensorNumber);
+        if (cs != null)
+        {
+         cs.addDataType(dataType);
+        }
         return this;
     }
 
@@ -77,20 +78,28 @@ public class PlatformConfigBuilder
 
     public PlatformConfigBuilder withDecodesScriptBuilder(DecodesScriptBuilder scriptBuilder)
     {
-        this.scriptBuilders.computeIfAbsent(scriptBuilder.getScriptId(), id -> scriptBuilder);
+        this.scriptBuilders.computeIfAbsent(scriptBuilder.getScriptId(), id -> scriptBuilder.platformConfig(this.pc));
         return this;
     }
 
+    public PlatformConfigBuilder withScriptSensor(DbKey scriptId, ScriptSensor sensor)
+    {
+        var scriptSensorsList = scriptSensors.computeIfAbsent(scriptId, num -> new ArrayList<>());
+        if (!scriptSensorsList.stream().anyMatch(ss -> ss.sensorNumber == sensor.sensorNumber))
+        {
+            scriptSensorsList.add(sensor);
+        }
+        return this;
+    }
 
     public Optional<DecodesScriptBuilder> getDecodesScriptBuilder(DbKey id)
     {
         return Optional.ofNullable(scriptBuilders.get(id));
     }
 
-
     public PlatformConfig build() throws OpenDcsDataRuntimeException
     {
-        for (var sensor: sensors)
+        for (var sensor: sensors.values())
         {
             pc.addSensor(sensor);
         }
@@ -99,7 +108,15 @@ public class PlatformConfigBuilder
         {
             try
             {
-                pc.addScript(scriptBuilder.build(false));
+                var script = scriptBuilder.build(true);
+                var scriptSensorsList = scriptSensors.get(script.getId());
+                for (var sensor: scriptSensorsList)
+                {
+                    sensor.decodesScript = script;
+                    script.addScriptSensor(sensor);
+                }
+
+                pc.addScript(script);
             }
             catch (IOException | DecodesScriptException ex)
             {

--- a/java/opendcs/src/main/java/decodes/db/DecodesScript.java
+++ b/java/opendcs/src/main/java/decodes/db/DecodesScript.java
@@ -23,6 +23,7 @@ import decodes.decoder.DataOperations;
 import decodes.decoder.EndOfDataException;
 import decodes.decoder.FieldParseException;
 import decodes.decoder.SwitchFormatException;
+import decodes.sql.DbKey;
 import decodes.decoder.EndlessLoopException;
 import decodes.util.DecodesSettings;
 import ilex.var.Variable;
@@ -696,6 +697,8 @@ public class DecodesScript extends IdDatabaseObject
         private Supplier<String> nameSupplier;
         private Supplier<String> scriptType;
         private Supplier<Boolean> addDefaultSensors;
+        private Supplier<Character> dataOrder;
+        private Supplier<DbKey> scriptId;
 
         public DecodesScriptBuilder(DecodesScriptReader reader)
         {
@@ -703,6 +706,8 @@ public class DecodesScript extends IdDatabaseObject
             nameSupplier = () -> "";
             scriptType = () -> Constants.scriptTypeDecodes;
             addDefaultSensors = () -> false;
+            dataOrder = () -> Constants.dataOrderUndefined;
+            scriptId = () -> DbKey.NullKey;
         }
 
         /**
@@ -739,6 +744,8 @@ public class DecodesScript extends IdDatabaseObject
   
             Objects.requireNonNull(scriptType,"Script type cannot be null");
             script.scriptType = scriptType.get();
+            script.dataOrder = dataOrder.get();
+            script.forceSetId(scriptId.get());
             try
             {
                 Optional<FormatStatement> fs = null;
@@ -815,6 +822,38 @@ public class DecodesScript extends IdDatabaseObject
             return this;
         }
 
+        /**
+         * Assign a data order
+         * @param dataOrder 
+         * @return
+         */
+        public DecodesScriptBuilder withDataOrder(char dataOrder)
+        {
+            return withDataOrder(() -> dataOrder);
+        }        
+
+        /**
+         * Assign a data order supplier
+         * @param dataOrder
+         * @return
+         */
+        public DecodesScriptBuilder withDataOrder(Supplier<Character> dataOrder)
+        {
+            this.dataOrder = dataOrder;
+            return this;
+        }
+
+        public DecodesScriptBuilder withId(DbKey id)
+        {
+            return withId(() -> id);
+        }
+
+        public DecodesScriptBuilder withId(Supplier<DbKey> scriptIdSupplier)
+        {
+            this.scriptId = scriptIdSupplier;
+            return this;
+        }
+
         public DecodesScriptBuilder scriptType(String scriptType)
         {
             Objects.requireNonNull(scriptType,"Script type cannot be null");
@@ -838,8 +877,19 @@ public class DecodesScript extends IdDatabaseObject
                 ss.rawConverter.algorithm = Constants.eucvt_none;
                 ds.addScriptSensor(ss);
             }
-            
+        }
 
+        /**
+         * Retrieve the current reader.
+         */
+        public DecodesScriptReader getReader()
+        {
+            return this.scriptReader;
+        }
+
+        public DbKey getScriptId()
+        {
+            return this.scriptId.get();
         }
     }
 

--- a/java/opendcs/src/main/java/decodes/db/DecodesScript.java
+++ b/java/opendcs/src/main/java/decodes/db/DecodesScript.java
@@ -1,16 +1,16 @@
 /*
 * Where Applicable, Copyright 2025 OpenDCS Consortium and/or its contributors
-* 
+*
 * Licensed under the Apache License, Version 2.0 (the "License"); you may not
 * use this file except in compliance with the License. You may obtain a copy
 * of the License at
-* 
+*
 *   http://www.apache.org/licenses/LICENSE-2.0
-* 
-* Unless required by applicable law or agreed to in writing, software 
+*
+* Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations 
+* License for the specific language governing permissions and limitations
 * under the License.
 */
 package decodes.db;
@@ -324,7 +324,7 @@ public class DecodesScript extends IdDatabaseObject
      * Clear the replacement and missing symbol lists.
      */
     private void clearReplacements(){
-        
+
         missingSymbols.clear();
         replaceSymbols.clear();;
 
@@ -584,7 +584,7 @@ public class DecodesScript extends IdDatabaseObject
     {
         return replaceSymbols.getOrDefault(value, value);
     }
-    
+
     public void setIncludePMs(ArrayList<String> includePMs)
     {
         this.includePMs = includePMs;
@@ -667,7 +667,7 @@ public class DecodesScript extends IdDatabaseObject
     }
 
     /**
-     * Used for starting a new blank decodes script. 
+     * Used for starting a new blank decodes script.
      * @return a Builder object for further operations
      */
     public static DecodesScriptBuilder empty()
@@ -686,7 +686,7 @@ public class DecodesScript extends IdDatabaseObject
     }
 
     /**
-     * Utility class to help with creating DecodesScript objects 
+     * Utility class to help with creating DecodesScript objects
      * and making sure they're in a valid state.
      * @since 2022-11-05
      */
@@ -711,7 +711,7 @@ public class DecodesScript extends IdDatabaseObject
         }
 
         /**
-         * Finalize the creation of a decodes script. After this 
+         * Finalize the creation of a decodes script. After this
          * the script should be ready for decoding operations.
          *
          * Defaults to <b>NOT</b> throwing an exception on a script processing error.
@@ -737,11 +737,11 @@ public class DecodesScript extends IdDatabaseObject
         {
             Objects.requireNonNull(nameSupplier, "nameSupplier cannot be null. Set before calling build.");
             DecodesScript script = new DecodesScript(nameSupplier.get());
-            
+
             Objects.requireNonNull(platformSupplier, "platformSupplier cannot be null. Set before calling build.");
             script.platformConfig = platformSupplier.get();
             Objects.requireNonNull(script.platformConfig, "A valid platform configuration was not available.");
-  
+
             Objects.requireNonNull(scriptType,"Script type cannot be null");
             script.scriptType = scriptType.get();
             script.dataOrder = dataOrder.get();
@@ -775,7 +775,7 @@ public class DecodesScript extends IdDatabaseObject
         }
 
         /**
-         * Assign a platform configuration 
+         * Assign a platform configuration
          * @param pc initialized PlatformConfig
          * @return the builder for further operations
          */
@@ -824,13 +824,13 @@ public class DecodesScript extends IdDatabaseObject
 
         /**
          * Assign a data order
-         * @param dataOrder 
+         * @param dataOrder
          * @return
          */
         public DecodesScriptBuilder withDataOrder(char dataOrder)
         {
             return withDataOrder(() -> dataOrder);
-        }        
+        }
 
         /**
          * Assign a data order supplier

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/DataTypeDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/DataTypeDao.java
@@ -49,6 +49,16 @@ public interface DataTypeDao extends OpenDcsDao
      */
 	Optional<DataType> lookup(DataTransaction tx, String dataTypeCode) throws OpenDcsDataException;
 
+     /**
+      * Given a Standard and DataType Code attempt to find a matching data type. {@see DataType for more information}
+      * @param tx
+      * @param standard
+      * @param dataTypeCode
+      * @return
+      * @throws OpenDcsDataException
+      */
+     Optional<DataType> lookup(DataTransaction tx, String standard, String dataTypeCode) throws OpenDcsDataException;
+
 	/**
      * Retreive all DataTypes constrained to a limit and office if desired.
      * @param tx active transaction

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/DecodesConfigDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/DecodesConfigDao.java
@@ -10,13 +10,53 @@ import org.opendcs.database.api.OpenDcsDataException;
 import decodes.db.PlatformConfig;
 import decodes.sql.DbKey;
 
+/**
+ * Access to Decodes Configuration (Also know as PlatformConfig)
+ */
 public interface DecodesConfigDao extends OpenDcsDao
 {
+    /**
+     * Retrieve a given PlatformConfig by Id
+     * @param tx
+     * @param id
+     * @return
+     * @throws OpenDcsDataException
+     */
     Optional<PlatformConfig> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException;
+
+    /**
+     * Retrieve a given PlatformConfig by Name
+     * @param tx
+     * @param id
+     * @return
+     * @throws OpenDcsDataException
+     */
     Optional<PlatformConfig> getByName(DataTransaction tx, String id) throws OpenDcsDataException;
 
+    /**
+     * Save or update a platform config
+     * @param tx
+     * @param config PlatformConfiguration that will be saved as-is to the database.
+     * @return a NEW instance of PlatformConfig containing all of the elements, and the generated identifier. Never null
+     * @throws OpenDcsDataException
+     */
     PlatformConfig save(DataTransaction tx, PlatformConfig config) throws OpenDcsDataException;
+
+    /**
+     * Delete a PlatformConfig from the database, including all sensors and scripts.
+     * @param tx
+     * @param id
+     * @throws OpenDcsDataException
+     */
     void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException;
 
+    /**
+     * Retrieve all, or desired limit and offset, Decodes Configurations from the database.
+     * @param tx
+     * @param limit
+     * @param offset
+     * @return
+     * @throws OpenDcsDataException
+     */
     List<PlatformConfig> getAll(DataTransaction tx, int limit, int offset) throws OpenDcsDataException;
 }

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/DecodesConfigDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/DecodesConfigDao.java
@@ -1,0 +1,22 @@
+package org.opendcs.database.dai;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.opendcs.database.api.DataTransaction;
+import org.opendcs.database.api.OpenDcsDao;
+import org.opendcs.database.api.OpenDcsDataException;
+
+import decodes.db.PlatformConfig;
+import decodes.sql.DbKey;
+
+public interface DecodesConfigDao extends OpenDcsDao
+{
+    Optional<PlatformConfig> getById(DataTransaction tx, DbKey id) throws OpenDcsDataException;
+    Optional<PlatformConfig> getByName(DataTransaction tx, String id) throws OpenDcsDataException;
+
+    PlatformConfig save(DataTransaction tx, PlatformConfig config) throws OpenDcsDataException;
+    void delete(DataTransaction tx, DbKey id) throws OpenDcsDataException;
+
+    List<PlatformConfig> getAll(DataTransaction tx, int limit, int offset) throws OpenDcsDataException;
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/model/mappers/datatype/DataTypeMapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/model/mappers/datatype/DataTypeMapper.java
@@ -31,6 +31,10 @@ public final class DataTypeMapper extends PrefixRowMapper<DataType>
         ColumnMapper<DbKey> dbKeyMapper = ctx.findColumnMapperFor(DbKey.class)
                                              .orElseThrow(() -> new SQLException("No mapper registered for DbKey class."));
         final DbKey id = dbKeyMapper.map(rs, prefix + GenericColumns.ID, ctx);
+        if (rs.wasNull() || DbKey.isNull(id))
+        {
+            return null;
+        }
         String standard = rs.getString(prefix + "standard");
         String code = rs.getString(prefix + "code");
         String displayname = rs.getString(prefix + "display_name");


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #1225. 

## Solution

Create DAO in the new stateless style

Opening as draft is this is a bit... nuts. But the alternative is a bunch of totally separate DAOs and we'd have to do the join in memory.

Given the overall complexity, I think for this one I'll make some extra methods for the REST API "ref" retrievals. Don't really need to do the full join for those. (previously haven't worried about it because they were small but there's like 2-3 more join tables to do on this one.)

NOTE: This is, currently, intentionally duplicating a rather large about of column names in the SQL. I don't think that's unnecessary duplication, but I'm considering better ways to handle mapping out the columns, most likely from the DAOs, but an additional method on the PrefixRowMapper may be better, basically a "retrieve list of required columns with prefix." The mappers are generally what would change with newer versions anyways.... but suggestions welcome. This is already large enough I won't do it in this PR, but I think before the next one of these.

## how you tested the change

- Manually testing query

Otherwise todo.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
