### PR TITLE
Make computationExecutor autocloseable

### DIFF
--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
@@ -353,19 +353,21 @@ public final class ComputationResources extends OpenDcsResource
 					{
 						MDC.setContextMap(contextMap);
 					}
-					ComputationExecution execution = new ComputationExecution(createDb());
-					SseProgressListener listener = new SseProgressListener(eventSink, sse, compStatus, taskID);
-					ComputationExecution.CompResults results = execution.execute(List.of(comp), new DataCollection(), startDate, endDate, listener);
+					try (ComputationExecution execution = new ComputationExecution(createDb()))
+					{
+						SseProgressListener listener = new SseProgressListener(eventSink, sse, compStatus, taskID);
+						ComputationExecution.CompResults results = execution.execute(List.of(comp), new DataCollection(), startDate, endDate, listener);
 
-					event = sse.newEventBuilder()
-							.name(compStatus)
-							.id(taskID)
-							.mediaType(MediaType.TEXT_PLAIN_TYPE)
-							.data(String.format("Computation executed with %d errors", results.numErrors()))
-							.build();
-					eventSink.send(event);
+						event = sse.newEventBuilder()
+								.name(compStatus)
+								.id(taskID)
+								.mediaType(MediaType.TEXT_PLAIN_TYPE)
+								.data(String.format("Computation executed with %d errors", results.numErrors()))
+								.build();
+						eventSink.send(event);
 
-					processOutput(outputList, taskID, sse, eventSink, startTime, endTime);
+						processOutput(outputList, taskID, sse, eventSink, startTime, endTime);
+					}
 				}
 				finally
 				{

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
@@ -370,34 +370,35 @@ public class ComputationApp extends TsdbAppTemplate
 						DbComputation[] comps = resolver.resolve(dataCollection);
 
 						action = "Applying computations";
-						ComputationExecution execution = new ComputationExecution(db);
-
-						ComputationExecution.CompResults results = execution.execute(List.of(comps), dataCollection,
-						dc ->
+						try (ComputationExecution execution = new ComputationExecution(db))
 						{
-							List<CTimeSeries> tsList = dc.getAllTimeSeries();
-							log.trace("Saving results for {} time series in data.", tsList.size());
-							try (var allTsTimer = MDCTimer.startTimer("saving results"))
+							ComputationExecution.CompResults results = execution.execute(List.of(comps), dataCollection,
+							dc ->
 							{
-								for(CTimeSeries ts : tsList)
+								List<CTimeSeries> tsList = dc.getAllTimeSeries();
+								log.trace("Saving results for {} time series in data.", tsList.size());
+								try (var allTsTimer = MDCTimer.startTimer("saving results"))
 								{
-									try
+									for(CTimeSeries ts : tsList)
 									{
-										log.info("Saving {} values for {}", ts.size(), ts.getNameString());
-										timeSeriesDAO.saveTimeSeries(ts);
-									}
-									catch (DbIoException | BadTimeSeriesException ex)
-									{
-										log.atWarn()
-										.setCause(ex)
-										.log("Cannot save time series '{}'", ts.getNameString());
+										try
+										{
+											log.info("Saving {} values for {}", ts.size(), ts.getNameString());
+											timeSeriesDAO.saveTimeSeries(ts);
+										}
+										catch (DbIoException | BadTimeSeriesException ex)
+										{
+											log.atWarn()
+											.setCause(ex)
+											.log("Cannot save time series '{}'", ts.getNameString());
+										}
 									}
 								}
-							}
-							return dc;
-						});
-						compsTried += results.computesTried();
-						compErrors += results.numErrors();
+								return dc;
+							});
+							compsTried += results.computesTried();
+							compErrors += results.numErrors();
+						}
 
 
 
@@ -826,19 +827,19 @@ public class ComputationApp extends TsdbAppTemplate
 			until = timedCompCal.getTime();
 		}
 
-		ComputationExecution execution = new ComputationExecution(db);
-
-		log.debug("Executing comp '{}' over time period {} to {}", tc.getName(), since, until);
-		if (!DbKey.isNull(tc.getGroupId()))
+		try (ComputationExecution execution = new ComputationExecution(db))
 		{
-			ArrayList<DbComputation> executeList = expandForGroup(tc, timeSeriesDAO, tsGroupDAO);
-			execution.execute(executeList, dataCollection, since, until);
+			log.debug("Executing comp '{}' over time period {} to {}", tc.getName(), since, until);
+			if (!DbKey.isNull(tc.getGroupId()))
+			{
+				ArrayList<DbComputation> executeList = expandForGroup(tc, timeSeriesDAO, tsGroupDAO);
+				execution.execute(executeList, dataCollection, since, until);
+			}
+			else // Not a group computation, just execute.
+			{
+				execution.executeSingleComp(tc, since, until, dataCollection);
+			}
 		}
-		else // Not a group computation, just execute.
-		{
-			execution.executeSingleComp(tc, since, until, dataCollection);
-		}
-
 	}
 
 	private ArrayList<DbComputation> expandForGroup(DbComputation tc, TimeSeriesDAI timeSeriesDAO, TsGroupDAI tsGroupDAO)

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationExecution.java
@@ -37,7 +37,7 @@ import org.slf4j.event.Level;
 
 import static org.opendcs.utils.logging.ThreadUtils.propagate;
 
-public final class ComputationExecution
+public final class ComputationExecution implements AutoCloseable
 {
 	private static final Logger log = OpenDcsLoggerFactory.getLogger();
 	private static final String COMPUTATION_KEY = "computation";
@@ -45,6 +45,7 @@ public final class ComputationExecution
 	private AtomicInteger numErrors = new AtomicInteger(0);
 	private AtomicInteger computesTried = new AtomicInteger(0);
 	private final ExecutorService executor;
+	private final boolean ownsExecutor;
 
 	/**
 	 * Create instance of ComputationExecution using a new SingleThreadExeuctor
@@ -52,7 +53,9 @@ public final class ComputationExecution
 	 */
 	public ComputationExecution(OpenDcsDatabase db)
 	{
-		this(db, Executors.newSingleThreadExecutor());
+		this.db = db;
+		this.executor = Executors.newSingleThreadExecutor();
+		this.ownsExecutor = true;
 	}
 
 
@@ -63,6 +66,8 @@ public final class ComputationExecution
 	 * This is being initially setup to provided chaining operations and too allow for that
 	 * follow on work. Experiment with a > 1 Thread pool at your own risk.
 	 *
+	 * The caller retains ownership of the provided executor and is responsible for its shutdown.
+	 *
 	 * @param db
 	 * @param executor
 	 */
@@ -70,6 +75,16 @@ public final class ComputationExecution
 	{
 		this.db = db;
 		this.executor = executor;
+		this.ownsExecutor = false;
+	}
+
+	@Override
+	public void close()
+	{
+		if (ownsExecutor)
+		{
+			executor.shutdown();
+		}
 	}
 
 	/**

--- a/java/opendcs/src/main/java/decodes/tsdb/comprungui/CompExec.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/comprungui/CompExec.java
@@ -286,9 +286,10 @@ public class CompExec extends TsdbAppTemplate
 				System.exit(0);
 		}
 
-		ComputationExecution execution = new ComputationExecution(db);
-
-		execution.execute(toRun, theData);
+		try (ComputationExecution execution = new ComputationExecution(db))
+		{
+			execution.execute(toRun, theData);
+		}
 
 		// if an output format is specified, format the data and send to stdout
 		if (outputFormatter != null)


### PR DESCRIPTION
## Problem Description

I think this is causing the flaky test failure we have been seeing. When you change the comp processor to be multi threaded we needed to make sure the comp executor was closing the thread correctly.

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
