### PR TITLE
Loading apps page

### DIFF
--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
@@ -37,7 +37,8 @@ import decodes.db.UnitConverterDb;
 class DecodesConfigDaoTestIT extends AppTestBase
 {
 
-    private static final String[] SENSORS = new String[]{"Stage", "Elev", "Flow"};
+    private static final String DATATYPE_STANDARD = "SHEF-PE";
+    private static final String[] SENSORS = new String[]{"HG", "PC", "VB"};
     private static final String[] UNITS = new String[]{"in", "ft", "cfs"};
 
     @ConfiguredField
@@ -97,7 +98,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
             sensor1.recordingInterval = 0;
             sensor1.recordingMode = Constants.recordingModeFixed;
             sensor1.setProperty("cwmsInterval", "15Minutes");
-            sensor1.addDataType(dataTypeDao.lookup(tx, "CWMS", "Stage").orElseThrow());
+            sensor1.addDataType(dataTypeDao.lookup(tx, "SHEF-PE", "HG").orElseThrow());
             pcIn.addSensor(sensor1);
             final var script = DecodesScript.empty()
                                             .platformConfig(pcIn)
@@ -135,7 +136,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
             var all = decodesConfigDao.getAll(tx, -1, -1);
             assertFalse(all.isEmpty());
 
-            var onlyOne = decodesConfigDao.getAll(tx, 1, 1);
+            var onlyOne = decodesConfigDao.getAll(tx, 1, 0);
             assertEquals(1, onlyOne.size());
             assertEquals("OKVI4", onlyOne.getFirst().getName());
             assertEquals("ST", onlyOne.getFirst().decodesScripts.getFirst().scriptName);
@@ -183,7 +184,7 @@ class DecodesConfigDaoTestIT extends AppTestBase
             sensor.recordingInterval = 900;
             sensor.recordingMode = 'F';
             sensor.timeOfFirstSample = 0;
-            sensor.addDataType(dataTypeDao.lookup(tx, "CWMS", sensor.sensorName)
+            sensor.addDataType(dataTypeDao.lookup(tx, DATATYPE_STANDARD, sensor.sensorName)
                                           .orElseGet(() -> fail("DataType for " + sensor.sensorName + " doesn't exist.")));
             if (sensorProperties)
             {

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/DecodesConfigDaoTestIT.java
@@ -138,8 +138,6 @@ class DecodesConfigDaoTestIT extends AppTestBase
 
             var onlyOne = decodesConfigDao.getAll(tx, 1, 0);
             assertEquals(1, onlyOne.size());
-            assertEquals("OKVI4", onlyOne.getFirst().getName());
-            assertEquals("ST", onlyOne.getFirst().decodesScripts.getFirst().scriptName);
 
             final var numConfigs = 30;
 

--- a/javascript/opendcs-web-ui-react/.storybook/mock/WithI18Next.tsx
+++ b/javascript/opendcs-web-ui-react/.storybook/mock/WithI18Next.tsx
@@ -41,6 +41,7 @@ i18n.on("languageChanged", (locale) => {
     "platforms",
     "properties",
     "decodes",
+    "loadingapps",
   ]);
 });
 

--- a/javascript/opendcs-web-ui-react/public/locales/en-US/loadingapps.json
+++ b/javascript/opendcs-web-ui-react/public/locales/en-US/loadingapps.json
@@ -1,0 +1,14 @@
+{
+  "title": "Loading Apps",
+  "add_app": "Add new Loading App",
+  "app_id": "App ID",
+  "app_name": "App Name",
+  "app_type": "App Type",
+  "comment": "Comment",
+  "last_modified": "Last Modified",
+  "manual_editing": "Manual Editing App",
+  "edit_app": "Edit loading app with id {{id}}",
+  "save_app": "Save loading app with id {{id}}",
+  "cancel_for": "Cancel editing loading app with id {{id}}",
+  "delete_for": "Delete loading app with id {{id}}"
+}

--- a/javascript/opendcs-web-ui-react/src/App.tsx
+++ b/javascript/opendcs-web-ui-react/src/App.tsx
@@ -9,6 +9,7 @@ import { Platforms } from "./pages/platforms";
 import { Algorithms } from "./pages/computations/algorithms";
 import { Computations } from "./pages/computations/computations";
 import { SitesPage } from "./pages/sites";
+import { LoadingAppsPage } from "./pages/loading-apps";
 import OidcCallback from "./pages/auth/login/OidcCallback";
 
 function App() {
@@ -38,6 +39,7 @@ function App() {
               <Route path="/sites" element={<SitesPage />} />
               <Route path="/computations" element={<Computations />} />
               <Route path="/algorithms" element={<Algorithms />} />
+              <Route path="/loading-apps" element={<LoadingAppsPage />} />
             </Route>
           </Route>
         </Routes>

--- a/javascript/opendcs-web-ui-react/src/components/layout/SideBar.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/layout/SideBar.tsx
@@ -8,7 +8,13 @@ export interface SideBarProps {
 }
 
 export const SideBar = ({ open, onClose }: SideBarProps) => {
-  const [t] = useTranslation(["platforms", "sites", "algorithms", "computations"]);
+  const [t] = useTranslation([
+    "platforms",
+    "sites",
+    "algorithms",
+    "computations",
+    "loadingapps",
+  ]);
   const location = useLocation();
 
   return (
@@ -56,6 +62,14 @@ export const SideBar = ({ open, onClose }: SideBarProps) => {
             onClick={onClose}
           >
             {t("algorithms:algorithmsTitle")}
+          </Nav.Link>
+          <Nav.Link
+            as={Link}
+            to="/loading-apps"
+            active={location.pathname === "/loading-apps"}
+            onClick={onClose}
+          >
+            {t("loadingapps:title")}
           </Nav.Link>
         </Nav>
       </nav>

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingApp.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingApp.tsx
@@ -1,0 +1,240 @@
+import { Button, Card, Col, Form, FormGroup, Placeholder, Row } from "react-bootstrap";
+import { PropertiesTable, type Property } from "../../components/properties";
+import { use, useCallback, useMemo, useReducer } from "react";
+import type { ApiLoadingApp } from "opendcs-api";
+import { useTranslation } from "react-i18next";
+import type { CancelAction, CollectionActions, SaveAction } from "../../util/Actions";
+import { Save, X } from "react-bootstrap-icons";
+import { LoadingAppReducer } from "./LoadingAppReducer";
+import { DetailFade } from "../../components/data-table";
+
+const INPUT_H = { height: "2.25rem" };
+const LABEL_H = { height: "1rem" };
+
+const APP_FIELDS = ["appName", "appType", "comment"] as const;
+
+export const LoadingAppSkeleton: React.FC<{ edit?: boolean; className?: string }> = ({
+  edit = false,
+  className,
+}) => (
+  <Card className={["loading-app-card", className].filter(Boolean).join(" ")}>
+    <Card.Body>
+      <Row>
+        <Col>
+          {APP_FIELDS.map((f) => (
+            <Row key={f} className="mb-3 align-items-center">
+              <Placeholder as={Col} sm={3} animation="glow">
+                <Placeholder xs={8} className="rounded" style={LABEL_H} />
+              </Placeholder>
+              <Placeholder as={Col} sm={9} animation="glow">
+                <Placeholder xs={12} className="rounded" style={INPUT_H} />
+              </Placeholder>
+            </Row>
+          ))}
+          <Row className="mb-3 align-items-center">
+            <Placeholder as={Col} sm={3} animation="glow">
+              <Placeholder xs={8} className="rounded" style={LABEL_H} />
+            </Placeholder>
+            <Col sm={9}>
+              <Placeholder animation="glow">
+                <Placeholder xs={2} className="rounded" style={INPUT_H} />
+              </Placeholder>
+            </Col>
+          </Row>
+        </Col>
+        <Col>
+          <Placeholder animation="glow">
+            <Placeholder xs={12} className="rounded" style={{ height: "10rem" }} />
+          </Placeholder>
+        </Col>
+      </Row>
+      {edit && (
+        <Row className="mt-3">
+          <Col className="d-flex justify-content-end gap-2">
+            <Placeholder animation="glow">
+              <Placeholder
+                className="rounded"
+                style={{ ...INPUT_H, width: "5.5rem" }}
+              />
+            </Placeholder>
+            <Placeholder animation="glow">
+              <Placeholder
+                className="rounded"
+                style={{ ...INPUT_H, width: "4.5rem" }}
+              />
+            </Placeholder>
+          </Col>
+        </Row>
+      )}
+    </Card.Body>
+  </Card>
+);
+
+export type UiLoadingApp = Partial<ApiLoadingApp>;
+
+export interface LoadingAppProperties {
+  app: Promise<UiLoadingApp> | UiLoadingApp;
+  actions?: SaveAction<ApiLoadingApp> & CancelAction<number>;
+  edit?: boolean;
+}
+
+export const LoadingApp: React.FC<LoadingAppProperties> = ({
+  app,
+  actions = {},
+  edit = false,
+}) => {
+  const { t } = useTranslation(["loadingapps", "translation"]);
+  const providedApp = app instanceof Promise ? use(app) : app;
+  const [localApp, dispatch] = useReducer(LoadingAppReducer, providedApp);
+
+  const props = useMemo<Property[]>(() => {
+    return Object.entries(localApp.properties ?? {}).map(([name, value]) => ({
+      name,
+      value,
+    }));
+  }, [localApp.properties]);
+
+  const propertyActions: CollectionActions<Property, string> = edit
+    ? {
+        remove: (propName) => {
+          dispatch({ type: "delete_prop", payload: { name: propName } });
+        },
+        save: (prop) => {
+          dispatch({
+            type: "save_prop",
+            payload: { name: prop.name, value: prop.value },
+          });
+        },
+      }
+    : {};
+
+  const saveApp = useCallback(() => {
+    actions.save?.(localApp as ApiLoadingApp);
+  }, [actions, localApp]);
+
+  const inputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { name, value } = event.target;
+      dispatch({ type: "save", payload: { [name]: value } });
+    },
+    [],
+  );
+
+  const checkChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch({ type: "save", payload: { manualEditingApp: event.target.checked } });
+  }, []);
+
+  return (
+    <DetailFade skeleton={<LoadingAppSkeleton edit={edit} />}>
+      <Card className="loading-app-card">
+        <Card.Body>
+          <Row>
+            <Col>
+              <FormGroup as={Row} className="mb-3">
+                <Form.Label column sm={3} htmlFor="appName">
+                  {t("loadingapps:app_name")}
+                </Form.Label>
+                <Col sm={9}>
+                  <Form.Control
+                    type="text"
+                    id="appName"
+                    name="appName"
+                    readOnly={!edit}
+                    maxLength={24}
+                    defaultValue={localApp.appName}
+                    onChange={inputChange}
+                  />
+                </Col>
+              </FormGroup>
+              <FormGroup as={Row} className="mb-3">
+                <Form.Label column sm={3} htmlFor="appType">
+                  {t("loadingapps:app_type")}
+                </Form.Label>
+                <Col sm={9}>
+                  <Form.Control
+                    type="text"
+                    id="appType"
+                    name="appType"
+                    readOnly={!edit}
+                    list="appTypeOptions"
+                    defaultValue={localApp.appType}
+                    onChange={inputChange}
+                  />
+                  <datalist id="appTypeOptions">
+                    <option value="computationprocess" />
+                    <option value="routingscheduler" />
+                    <option value="compdepends" />
+                    <option value="utility" />
+                    <option value="gui" />
+                  </datalist>
+                </Col>
+              </FormGroup>
+              <FormGroup as={Row} className="mb-3">
+                <Form.Label column sm={3} htmlFor="comment">
+                  {t("loadingapps:comment")}
+                </Form.Label>
+                <Col sm={9}>
+                  <Form.Control
+                    as="textarea"
+                    rows={3}
+                    id="comment"
+                    name="comment"
+                    readOnly={!edit}
+                    defaultValue={localApp.comment}
+                    onChange={inputChange}
+                  />
+                </Col>
+              </FormGroup>
+              <FormGroup as={Row} className="mb-3 align-items-center">
+                <Form.Label column sm={3} htmlFor="manualEditingApp">
+                  {t("loadingapps:manual_editing")}
+                </Form.Label>
+                <Col sm={9}>
+                  <Form.Check
+                    id="manualEditingApp"
+                    name="manualEditingApp"
+                    disabled={!edit}
+                    defaultChecked={localApp.manualEditingApp ?? false}
+                    onChange={checkChange}
+                  />
+                </Col>
+              </FormGroup>
+            </Col>
+            <Col>
+              <PropertiesTable
+                theProps={props}
+                actions={propertyActions}
+                edit={edit}
+                canAdd={true}
+                width="100%"
+                height="auto"
+              />
+            </Col>
+          </Row>
+          {edit && (
+            <Row className="mt-3">
+              <Col className="d-flex justify-content-end gap-2">
+                <Button
+                  onClick={() => actions.cancel?.(providedApp.appId!)}
+                  variant="secondary"
+                  aria-label={t("loadingapps:cancel_for", { id: providedApp.appId })}
+                >
+                  <X /> {t("translation:cancel")}
+                </Button>
+                <Button
+                  onClick={saveApp}
+                  variant="primary"
+                  aria-label={t("loadingapps:save_app", { id: localApp.appId })}
+                >
+                  <Save /> {t("translation:save")}
+                </Button>
+              </Col>
+            </Row>
+          )}
+        </Card.Body>
+      </Card>
+    </DetailFade>
+  );
+};
+
+export default LoadingApp;

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppReducer.ts
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppReducer.ts
@@ -1,0 +1,31 @@
+import type { UiLoadingApp } from "./LoadingApp";
+
+export type LoadingAppAction =
+  | { type: "save_prop"; payload: { name: string; value: string } }
+  | { type: "delete_prop"; payload: { name: string } }
+  | { type: "save"; payload: UiLoadingApp };
+
+export function LoadingAppReducer(
+  current: UiLoadingApp,
+  action: LoadingAppAction,
+): UiLoadingApp {
+  switch (action.type) {
+    case "save_prop": {
+      return {
+        ...current,
+        properties: {
+          ...current.properties,
+          [action.payload.name]: action.payload.value,
+        },
+      };
+    }
+    case "delete_prop": {
+      const props = { ...(current.properties ?? {}) };
+      delete props[action.payload.name];
+      return { ...current, properties: props };
+    }
+    case "save": {
+      return { ...current, ...action.payload };
+    }
+  }
+}

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsPage.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsPage.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LoadingAppsPage } from "./LoadingAppsPage";
+import { http, HttpResponse } from "msw";
+import type { ApiAppRef, ApiLoadingApp } from "opendcs-api";
+import { act } from "react";
+import { expect } from "storybook/test";
+
+const meta = {
+  component: LoadingAppsPage,
+} satisfies Meta<typeof LoadingAppsPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const mockRefs: ApiAppRef[] = [
+  {
+    appId: 1,
+    appName: "compproc",
+    appType: "computationprocess",
+    comment: "Computation process",
+  },
+  {
+    appId: 2,
+    appName: "dbimport",
+    appType: "utility",
+    comment: "Database import utility",
+  },
+];
+
+const mockApps: ApiLoadingApp[] = [
+  {
+    appId: 1,
+    appName: "compproc",
+    appType: "computationprocess",
+    comment: "Computation process",
+    manualEditingApp: false,
+    properties: { OfficeID: "CWMS", logFile: "compproc.log" },
+  },
+  {
+    appId: 2,
+    appName: "dbimport",
+    appType: "utility",
+    comment: "Database import utility",
+    manualEditingApp: true,
+    properties: {},
+  },
+];
+
+export const Default: Story = {
+  args: {},
+  parameters: {
+    msw: {
+      handlers: {
+        apprefs: http.get("/odcsapi/apprefs", () =>
+          HttpResponse.json<ApiAppRef[]>(mockRefs),
+        ),
+        app: http.get("/odcsapi/app", ({ request }) => {
+          const url = new URL(request.url);
+          const id = parseInt(url.searchParams.get("appid") ?? "-1");
+          return HttpResponse.json<ApiLoadingApp>(
+            mockApps.find((a) => a.appId === id) ?? mockApps[0],
+          );
+        }),
+      },
+    },
+  },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    const compProcRow = await canvas.findByText("compproc");
+    await act(async () => userEvent.click(compProcRow));
+
+    const appNameInput = await canvas.findByLabelText(i18n.t("loadingapps:app_name"));
+    expect((appNameInput as HTMLInputElement).value).toEqual("compproc");
+  },
+};
+
+export const EditSave: Story = {
+  args: {},
+  parameters: {
+    msw: {
+      handlers: {
+        apprefs: http.get("/odcsapi/apprefs", () =>
+          HttpResponse.json<ApiAppRef[]>(mockRefs),
+        ),
+        app: http.get("/odcsapi/app", ({ request }) => {
+          const url = new URL(request.url);
+          const id = parseInt(url.searchParams.get("appid") ?? "-1");
+          return HttpResponse.json<ApiLoadingApp>(
+            mockApps.find((a) => a.appId === id) ?? mockApps[0],
+          );
+        }),
+        save: http.post("/odcsapi/app", async ({ request }) => {
+          const body = (await request.json()) as ApiLoadingApp;
+          return HttpResponse.json<ApiLoadingApp>({ ...body, appId: body.appId ?? 99 });
+        }),
+      },
+    },
+  },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    const editBtn = await canvas.findByLabelText(
+      i18n.t("loadingapps:edit_app", { id: 1 }),
+    );
+    await act(async () => userEvent.click(editBtn));
+
+    const saveBtn = await canvas.findByLabelText(
+      i18n.t("loadingapps:save_app", { id: 1 }),
+    );
+    expect(saveBtn).toBeTruthy();
+  },
+};

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsPage.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsPage.tsx
@@ -1,0 +1,57 @@
+import {
+  ApiLoadingApp,
+  RESTLoadingApplicationRecordsApi,
+  type ApiAppRef,
+} from "opendcs-api";
+import { LoadingAppsTable } from "./LoadingAppsTable";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useApi } from "../../contexts/app/ApiContext";
+
+export const LoadingAppsPage: React.FC = () => {
+  const [apps, setApps] = useState<ApiAppRef[]>([]);
+  const [stale, setStale] = useState(true);
+  const api = useApi();
+  const appsApi = useMemo(
+    () => new RESTLoadingApplicationRecordsApi(api.conf),
+    [api.conf],
+  );
+
+  useEffect(() => {
+    const fetchApps = async () => {
+      const refs = await appsApi.getAppRefs(api.org);
+      setApps(refs);
+      setStale(false);
+    };
+    if (stale === true) {
+      fetchApps();
+    }
+  }, [stale, api.org, appsApi]);
+
+  const getApp = useCallback(
+    (appId: number) => appsApi.getApp(api.org, appId),
+    [api.org, appsApi],
+  );
+
+  const saveApp = useCallback(
+    (app: ApiLoadingApp) => {
+      appsApi.postApp(api.org, app).then(() => setStale(true));
+    },
+    [api.org, appsApi],
+  );
+
+  const deleteApp = useCallback(
+    (appId: number) => {
+      appsApi.deleteApp(api.org, appId).then(() => setStale(true));
+    },
+    [api.org, appsApi],
+  );
+
+  return (
+    <LoadingAppsTable
+      apps={apps}
+      loading={stale}
+      getApp={getApp}
+      actions={{ save: saveApp, remove: deleteApp }}
+    />
+  );
+};

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsTable.tsx
@@ -1,0 +1,114 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type { ApiAppRef, ApiLoadingApp } from "opendcs-api";
+import LoadingApp, { LoadingAppSkeleton, type UiLoadingApp } from "./LoadingApp";
+import type { RemoveAction, SaveAction } from "../../util/Actions";
+import {
+  AppDataTable,
+  type ColumnDef,
+  type RowAction,
+} from "../../components/data-table";
+
+export type TableAppRef = Partial<ApiAppRef>;
+
+export interface LoadingAppsTableProperties {
+  apps: TableAppRef[];
+  getApp?: (appId: number) => Promise<ApiLoadingApp>;
+  actions?: SaveAction<ApiLoadingApp> & RemoveAction<number>;
+  loading?: boolean;
+}
+
+export const LoadingAppsTable: React.FC<LoadingAppsTableProperties> = ({
+  apps,
+  getApp,
+  actions = {},
+  loading = false,
+}) => {
+  const [t] = useTranslation(["loadingapps", "translation"]);
+
+  const columns = useMemo<ColumnDef<TableAppRef>[]>(
+    () => [
+      {
+        data: "appId",
+        header: t("loadingapps:app_id"),
+        defaultContent: "new",
+        type: "num",
+      },
+      { data: "appName", header: t("loadingapps:app_name"), type: "string" },
+      { data: "appType", header: t("loadingapps:app_type"), type: "string" },
+      { data: "comment", header: t("loadingapps:comment"), type: "string" },
+      {
+        data: "lastModified",
+        header: t("loadingapps:last_modified"),
+        type: "date",
+        render: (data: unknown, type: string) => {
+          if (type !== "display") return data;
+          if (!data) return "";
+          const d = data instanceof Date ? data : new Date(data as string);
+          return isNaN(d.getTime()) ? "" : d.toLocaleString();
+        },
+      },
+    ],
+    [t],
+  );
+
+  const rowActions = useMemo<RowAction<TableAppRef>[]>(
+    () => [
+      {
+        key: "edit",
+        icon: "bi-pencil",
+        variant: "warning",
+        aria: (row) => t("loadingapps:edit_app", { id: row.appId }),
+        onClick: ({ row, api }) => api.setMode(row, "edit"),
+      },
+      {
+        key: "delete",
+        icon: "bi-trash",
+        variant: "danger",
+        show: (row) => (row.appId ?? 0) > 0,
+        aria: (row) => t("loadingapps:delete_for", { id: row.appId }),
+        onClick: ({ row }) => {
+          if (row.appId !== undefined) actions.remove?.(row.appId);
+        },
+      },
+    ],
+    [t, actions],
+  );
+
+  return (
+    <AppDataTable<TableAppRef, number, ApiLoadingApp>
+      data={apps}
+      loading={loading}
+      getId={(a) => a.appId!}
+      columns={columns}
+      actionsLabel={t("translation:actions")}
+      rowActions={rowActions}
+      renderDetail={({ row, mode, actions: detailActions }) => {
+        const appPromise: Promise<UiLoadingApp> =
+          row.appId && row.appId > 0 && getApp
+            ? getApp(row.appId)
+            : Promise.resolve({ appId: row.appId } as UiLoadingApp);
+        return (
+          <LoadingApp
+            app={appPromise}
+            actions={{
+              save: (app) => detailActions.save(app),
+              cancel: () => detailActions.cancel(),
+            }}
+            edit={mode !== "show"}
+          />
+        );
+      }}
+      renderSkeleton={({ mode }) => (
+        <LoadingAppSkeleton edit={mode !== "show"} className="child-row-opening" />
+      )}
+      addNew={{
+        template: (id) => ({ appId: id }),
+        ariaLabel: t("loadingapps:add_app"),
+      }}
+      onSave={actions.save}
+      caption={t("loadingapps:title")}
+      tableId="loadingAppsTable"
+    />
+  );
+};

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/index.ts
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/index.ts
@@ -1,0 +1,4 @@
+export { LoadingAppsPage } from "./LoadingAppsPage";
+export { LoadingAppsTable } from "./LoadingAppsTable";
+export { LoadingApp } from "./LoadingApp";
+export { LoadingAppReducer } from "./LoadingAppReducer";


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->

<!-- if you are referencing a specific issue a problem description is not required -->

Adds a Loading Apps management page to the OpenDCS web client. Loading Apps are the named process registrations that the OpenDCS computation engine uses to track and lock running processes (e.g., compproc, routingscheduler).

## Solution

Describe your solution.

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

All 102 React unit and Storybook tests pass (npm run test -- --run)
Prettier formatting check passes (npm run format:check)
No new ESLint errors introduced in changed files
Java unit tests pass
XML integration tests pass (135 tests)
OpenDCS-Postgres integration tests pass (141 tests)
OpenDCS-Oracle integration tests pass
CWMS-Oracle integration tests pass (141 tests)

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
