### PR TITLE
Lrl debounce app property

### DIFF
--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/regression_tests/CompProcTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/regression_tests/CompProcTestIT.java
@@ -186,7 +186,7 @@ public class CompProcTestIT extends AppTestBase
             dao.doModify("insert into cp_comp_tasklist(record_num, loading_application_id, ts_id, num_value, date_time_loaded, sample_time, flags) "
                        + "values (?,?,?,?,?,?,?)",keyGen.getKey("cp_comp_tasklist", c), appKey, inputKey, 1.0,new Date(), new Date(),0);
 
-            DataCollection data = tsDAI.getNewData(appKey, 20000); // arbitrary number, previously the default.
+            DataCollection data = tsDAI.getNewData(appKey, 20000, 0); // arbitrary number, previously the default.
             assertTrue(data.isEmpty());
             assertEquals(0,
                          dao.getSingleResultOr("select count(ts_id) from cp_comp_tasklist where ts_id=?",

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/regression_tests/TasklistDebounceTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/regression_tests/TasklistDebounceTestIT.java
@@ -41,11 +41,11 @@ final class TasklistDebounceTestIT extends AppTestBase
     private static final String APP_NAME = "compproc_regtest";
     private static final long FRESH_AGE_MS = 100L;
     private static final long AGED_AGE_MS = 10_000L;
+    private static final int DEBOUNCE_SECONDS = 2;
 
     @Test
     void debounce_excludes_fresh_row_keeps_aged_row_processed() throws Exception
     {
-        db.setTasklistDebounceSeconds(2);
         try (TimeSeriesDAI tsDAI = db.makeTimeSeriesDAO();
              LoadingAppDAI laDAI = db.makeLoadingAppDAO();
              DaoBase dao = new DaoBase(db, "test"))
@@ -58,7 +58,7 @@ final class TasklistDebounceTestIT extends AppTestBase
             DbKey freshRec = insertTasklistRow(dao, appKey, tsKey, sourceKey, now - FRESH_AGE_MS);
             DbKey agedRec = insertTasklistRow(dao, appKey, tsKey, sourceKey, now - AGED_AGE_MS);
 
-            consumeNewData(tsDAI, appKey);
+            consumeNewData(tsDAI, appKey, DEBOUNCE_SECONDS);
 
             assertTrue(rowExists(dao, freshRec),
                 "Fresh row should remain in cp_comp_tasklist (debounce held it back).");
@@ -70,7 +70,6 @@ final class TasklistDebounceTestIT extends AppTestBase
     @Test
     void debounce_zero_processes_both_rows() throws Exception
     {
-        db.setTasklistDebounceSeconds(0);
         try (TimeSeriesDAI tsDAI = db.makeTimeSeriesDAO();
              LoadingAppDAI laDAI = db.makeLoadingAppDAO();
              DaoBase dao = new DaoBase(db, "test"))
@@ -83,7 +82,7 @@ final class TasklistDebounceTestIT extends AppTestBase
             DbKey freshRec = insertTasklistRow(dao, appKey, tsKey, sourceKey, now - FRESH_AGE_MS);
             DbKey agedRec = insertTasklistRow(dao, appKey, tsKey, sourceKey, now - AGED_AGE_MS);
 
-            consumeNewData(tsDAI, appKey);
+            consumeNewData(tsDAI, appKey, 0);
 
             assertFalse(rowExists(dao, freshRec),
                 "With debounce=0, fresh row should have been processed and removed.");
@@ -99,9 +98,9 @@ final class TasklistDebounceTestIT extends AppTestBase
      * whether a row was visible to getNewData at all, not on which deletion path
      * it took.
      */
-    private void consumeNewData(TimeSeriesDAI tsDAI, DbKey appKey) throws Exception
+    private void consumeNewData(TimeSeriesDAI tsDAI, DbKey appKey, int debounceSeconds) throws Exception
     {
-        DataCollection dc = tsDAI.getNewData(appKey, 20000);
+        DataCollection dc = tsDAI.getNewData(appKey, 20000, debounceSeconds);
         db.releaseNewData(dc, tsDAI, 250);
     }
 

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/regression_tests/TasklistDebounceTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/regression_tests/TasklistDebounceTestIT.java
@@ -16,7 +16,6 @@ import decodes.sql.DbKey;
 import decodes.tsdb.DataCollection;
 import decodes.tsdb.TimeSeriesDb;
 import decodes.tsdb.TimeSeriesIdentifier;
-import decodes.util.DecodesSettings;
 import opendcs.dai.LoadingAppDAI;
 import opendcs.dai.TimeSeriesDAI;
 import opendcs.dao.DaoBase;
@@ -46,7 +45,7 @@ final class TasklistDebounceTestIT extends AppTestBase
     @Test
     void debounce_excludes_fresh_row_keeps_aged_row_processed() throws Exception
     {
-        DecodesSettings.instance().tasklistDebounceSeconds = 2;
+        db.setTasklistDebounceSeconds(2);
         try (TimeSeriesDAI tsDAI = db.makeTimeSeriesDAO();
              LoadingAppDAI laDAI = db.makeLoadingAppDAO();
              DaoBase dao = new DaoBase(db, "test"))
@@ -71,7 +70,7 @@ final class TasklistDebounceTestIT extends AppTestBase
     @Test
     void debounce_zero_processes_both_rows() throws Exception
     {
-        DecodesSettings.instance().tasklistDebounceSeconds = 0;
+        db.setTasklistDebounceSeconds(0);
         try (TimeSeriesDAI tsDAI = db.makeTimeSeriesDAO();
              LoadingAppDAI laDAI = db.makeLoadingAppDAO();
              DaoBase dao = new DaoBase(db, "test"))

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
@@ -1326,7 +1326,7 @@ public class CwmsTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
                     : "";
 
         String debounceClause = "";
-        int debounceSec = DecodesSettings.instance().tasklistDebounceSeconds;
+        int debounceSec = ((TimeSeriesDb) db).getTasklistDebounceSeconds();
         if (debounceSec > 0)
             debounceClause = " and a.DATE_TIME_LOADED <= SYSDATE - ?/86400";
 

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsTimeSeriesDAO.java
@@ -1315,7 +1315,7 @@ public class CwmsTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
     }
 
     @Override
-    public DataCollection getNewData(DbKey applicationId, int maxTake)
+    public DataCollection getNewData(DbKey applicationId, int maxTake, int tasklistDebounceSeconds)
         throws DbIoException
     {
         DataCollection dataCollection = new DataCollection();
@@ -1326,8 +1326,7 @@ public class CwmsTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
                     : "";
 
         String debounceClause = "";
-        int debounceSec = ((TimeSeriesDb) db).getTasklistDebounceSeconds();
-        if (debounceSec > 0)
+        if (tasklistDebounceSeconds > 0)
             debounceClause = " and a.DATE_TIME_LOADED <= SYSDATE - ?/86400";
 
         getTaskListStmtQuery =
@@ -1345,8 +1344,8 @@ public class CwmsTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
             )
         {
             getTaskListStmt.setLong(1,applicationId.getValue());
-            if (debounceSec > 0)
-                getTaskListStmt.setInt(2, debounceSec);
+            if (tasklistDebounceSeconds > 0)
+                getTaskListStmt.setInt(2, tasklistDebounceSeconds);
 
             ArrayList<TasklistRec> tasklistRecs = new ArrayList<TasklistRec>();
             ArrayList<Integer> badRecs = new ArrayList<Integer>();

--- a/java/opendcs/src/main/java/decodes/hdb/HdbTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/decodes/hdb/HdbTimeSeriesDAO.java
@@ -1208,7 +1208,7 @@ public class HdbTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 					+ "to_char(FAIL_TIME,'dd-mon-yyyy hh24:mi:ss'),"
 					+ "'dd-mon-yyyy hh24:mi:ss') >= 1/24)";
 
-		int debounceSec = DecodesSettings.instance().tasklistDebounceSeconds;
+		int debounceSec = ((TimeSeriesDb)db).getTasklistDebounceSeconds();
 		if (debounceSec > 0)
 			q = q + " and DATE_TIME_LOADED <= SYSDATE - " + debounceSec + "/86400";
 

--- a/java/opendcs/src/main/java/decodes/hdb/HdbTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/decodes/hdb/HdbTimeSeriesDAO.java
@@ -1186,7 +1186,7 @@ public class HdbTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 
 
 	@Override
-	public DataCollection getNewData(DbKey applicationId, int maxTake)
+	public DataCollection getNewData(DbKey applicationId, int maxTake, int tasklistDebounceSeconds)
 		throws DbIoException
 	{
 		// Since DAO is recreated every compApp loop, removed cache load
@@ -1208,9 +1208,8 @@ public class HdbTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 					+ "to_char(FAIL_TIME,'dd-mon-yyyy hh24:mi:ss'),"
 					+ "'dd-mon-yyyy hh24:mi:ss') >= 1/24)";
 
-		int debounceSec = ((TimeSeriesDb)db).getTasklistDebounceSeconds();
-		if (debounceSec > 0)
-			q = q + " and DATE_TIME_LOADED <= SYSDATE - " + debounceSec + "/86400";
+		if (tasklistDebounceSeconds > 0)
+			q = q + " and DATE_TIME_LOADED <= SYSDATE - " + tasklistDebounceSeconds + "/86400";
 
 //		now add the order by record_num to insure last change wins
 		q = q + " order by record_num";

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
@@ -110,6 +110,7 @@ public class ComputationApp extends TsdbAppTemplate
 
 	private ArrayList<DbComputation> timedComps = new ArrayList<DbComputation>();
 	private int checkTimedCompsSec = 600;
+	private int tasklistDebounceSeconds = 0;
 	private SimpleDateFormat debugSdf = new SimpleDateFormat("yyyy/MM/dd-HH:mm:ss");
 
 	private static ComputationApp _instance = null;
@@ -355,7 +356,7 @@ public class ComputationApp extends TsdbAppTemplate
 					action = "Getting new data";
 					try (var newDataTime = MDCTimer.startTimer(action))
 					{
-						dataCollection = timeSeriesDAO.getNewData(getAppId(), COMP_RUN_MAX_TAKE);
+						dataCollection = timeSeriesDAO.getNewData(getAppId(), COMP_RUN_MAX_TAKE, tasklistDebounceSeconds);
 					}
 					// In Regression Test Mode, exit after 5 sec of idle
 					if (!dataCollection.isEmpty())
@@ -547,18 +548,18 @@ public class ComputationApp extends TsdbAppTemplate
 			s = appInfo.getProperty("tasklistDebounceSeconds");
 			if (s != null)
 			{
-				try { theDb.setTasklistDebounceSeconds(Integer.parseInt(s.trim())); }
+				try { tasklistDebounceSeconds = Integer.parseInt(s.trim()); }
 				catch(NumberFormatException ex)
 				{
 					log.atWarn()
 					   .setCause(ex)
 					   .log("Bad app property 'tasklistDebounceSeconds' -- should be integer -- ignored.");
-					theDb.setTasklistDebounceSeconds(0);
+					tasklistDebounceSeconds = 0;
 				}
 			}
 			else
-				theDb.setTasklistDebounceSeconds(0);
-			log.info("tasklistDebounceSeconds={}", theDb.getTasklistDebounceSeconds());
+				tasklistDebounceSeconds = 0;
+			log.info("tasklistDebounceSeconds={}", tasklistDebounceSeconds);
 
 			if (!theDb.isCwms())
 			{

--- a/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/ComputationApp.java
@@ -128,6 +128,11 @@ public class ComputationApp extends TsdbAppTemplate
 		new PropertySpec("checkTimedCompsSec", PropertySpec.INT,
 			"(default=600, or 10 minutes) check for changes to timed computations "
 			+ "every this number of seconds."),
+		new PropertySpec("tasklistDebounceSeconds", PropertySpec.INT,
+			"(default=0) Seconds a CP_COMP_TASKLIST entry must age before "
+			+ "getNewData() returns it. Prevents downstream comps from running on "
+			+ "partial inputs when multiple upstream timeseries are saved in the "
+			+ "same poll cycle."),
 
 		new PropertySpec("mail.smtp.auth", PropertySpec.BOOLEAN, "(default=false) "
 			+ "If true then authenticate when connecting to mail server."),
@@ -472,8 +477,6 @@ public class ComputationApp extends TsdbAppTemplate
 	private void runAppInit()
 	{
 		debugSdf.setTimeZone(TimeZone.getTimeZone(theDb.databaseTimezone));
-		log.info("tasklistDebounceSeconds={}",
-				DecodesSettings.instance().tasklistDebounceSeconds);
 		LoadingAppDAI loadingAppDao = theDb.makeLoadingAppDAO();
 		TimeSeriesDAI tsDAO = theDb.makeTimeSeriesDAO();
 		TsGroupDAI groupDAO = theDb.makeTsGroupDAO();
@@ -540,6 +543,22 @@ public class ComputationApp extends TsdbAppTemplate
 					checkTimedCompsSec = 600;
 				}
 			}
+
+			s = appInfo.getProperty("tasklistDebounceSeconds");
+			if (s != null)
+			{
+				try { theDb.setTasklistDebounceSeconds(Integer.parseInt(s.trim())); }
+				catch(NumberFormatException ex)
+				{
+					log.atWarn()
+					   .setCause(ex)
+					   .log("Bad app property 'tasklistDebounceSeconds' -- should be integer -- ignored.");
+					theDb.setTasklistDebounceSeconds(0);
+				}
+			}
+			else
+				theDb.setTasklistDebounceSeconds(0);
+			log.info("tasklistDebounceSeconds={}", theDb.getTasklistDebounceSeconds());
 
 			if (!theDb.isCwms())
 			{

--- a/java/opendcs/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -167,25 +167,6 @@ public abstract class TimeSeriesDb implements HasProperties, DatabaseConnectionO
     // If reclaimTasklistSec > 0, this is the time the reclaim was last done.
     protected long lastReclaimMsec = 0L;
 
-    /**
-     * Set by the tasklistDebounceSeconds Computation App Property.
-     * Number of seconds a CP_COMP_TASKLIST entry must age before
-     * getNewData() returns it. Prevents a downstream comp from running
-     * on a partial input set when multiple upstream timeseries are saved
-     * within the same poll cycle. Default 0 = no debounce.
-     */
-    protected int tasklistDebounceSeconds = 0;
-
-    public int getTasklistDebounceSeconds()
-    {
-        return tasklistDebounceSeconds;
-    }
-
-    public void setTasklistDebounceSeconds(int seconds)
-    {
-        this.tasklistDebounceSeconds = seconds;
-    }
-
     private boolean connected = false;
 
     protected final DecodesSettings settings;

--- a/java/opendcs/src/main/java/decodes/tsdb/TimeSeriesDb.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/TimeSeriesDb.java
@@ -167,6 +167,25 @@ public abstract class TimeSeriesDb implements HasProperties, DatabaseConnectionO
     // If reclaimTasklistSec > 0, this is the time the reclaim was last done.
     protected long lastReclaimMsec = 0L;
 
+    /**
+     * Set by the tasklistDebounceSeconds Computation App Property.
+     * Number of seconds a CP_COMP_TASKLIST entry must age before
+     * getNewData() returns it. Prevents a downstream comp from running
+     * on a partial input set when multiple upstream timeseries are saved
+     * within the same poll cycle. Default 0 = no debounce.
+     */
+    protected int tasklistDebounceSeconds = 0;
+
+    public int getTasklistDebounceSeconds()
+    {
+        return tasklistDebounceSeconds;
+    }
+
+    public void setTasklistDebounceSeconds(int seconds)
+    {
+        this.tasklistDebounceSeconds = seconds;
+    }
+
     private boolean connected = false;
 
     protected final DecodesSettings settings;

--- a/java/opendcs/src/main/java/decodes/util/DecodesSettings.java
+++ b/java/opendcs/src/main/java/decodes/util/DecodesSettings.java
@@ -284,14 +284,6 @@ public class DecodesSettings implements PropertiesOwner, OpenDcsSettings
     public boolean retryFailedComputations = false;
 
     /**
-     * Number of seconds a CP_COMP_TASKLIST entry must age before
-     * getNewData() returns it. Prevents a downstream comp from running
-     * on a partial input set when multiple upstream timeseries are saved
-     * within the same poll cycle. Default 0 = no debounce.
-     */
-    public int tasklistDebounceSeconds = 0;
-
-    /**
      * Process the minute offset fields when decoding ASCII self-describing messages.
      */
     public boolean asciiSelfDescProcessMOFF = true;
@@ -511,11 +503,6 @@ public class DecodesSettings implements PropertiesOwner, OpenDcsSettings
             "If (false) then don't attempt to retry failed computations. If (true)" +
             " then do attempt to retry by using FAIL_TIME in the tasklist records " +
             "to retry up to maxComputationRetries set above"),
-        new PropertySpec("tasklistDebounceSeconds", PropertySpec.INT,
-            "(default=0) Seconds a CP_COMP_TASKLIST entry must age before " +
-            "getNewData() returns it. Prevents downstream comps from running on " +
-            "partial inputs when multiple upstream timeseries are saved in the " +
-            "same poll cycle"),
         new PropertySpec("defaultMaxDecimals", PropertySpec.INT,
             "(default=4) Default max decimals if no presentation element is found"),
         new PropertySpec("platformListDesignatorCol", PropertySpec.BOOLEAN,

--- a/java/opendcs/src/main/java/opendcs/dai/TimeSeriesDAI.java
+++ b/java/opendcs/src/main/java/opendcs/dai/TimeSeriesDAI.java
@@ -256,10 +256,12 @@ public interface TimeSeriesDAI extends DaiBase, OpenDcsDao
 	 * marked with the DB_DELETED flag.
 	 * @param applicationId used to lookup &amp; save the since time.
 	 * @param maxTake maximum number of records to acquire at one time.
+	 * @param tasklistDebounceSeconds seconds a tasklist row must age before being returned.
+	 *        Pass 0 to disable.
 	 * @return DataCollection with newly added or deleted values.
 	 * @throws DbIoException on Database IO error.
 	 */
-	public DataCollection getNewData( DbKey applicationId, int maxTake )
+	public DataCollection getNewData( DbKey applicationId, int maxTake, int tasklistDebounceSeconds )
 		throws DbIoException;
 
 }

--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
@@ -1721,7 +1721,7 @@ public class OpenTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 			failTimeClause = " and (a.FAIL_TIME is null OR "
 				+ System.currentTimeMillis() + " -  a.FAIL_TIME >= 3600000)";
 		String debounceClause = "";
-		int debounceSec = DecodesSettings.instance().tasklistDebounceSeconds;
+		int debounceSec = ((TimeSeriesDb)db).getTasklistDebounceSeconds();
 		if (debounceSec > 0)
 		{
 			// DATE_TIME_LOADED is BIGINT epoch millis (see V6.8__opendcs.sql),

--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
@@ -1696,7 +1696,7 @@ public class OpenTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 
 
 	@Override
-	public DataCollection getNewData(DbKey applicationId, int maxTake)
+	public DataCollection getNewData(DbKey applicationId, int maxTake, int tasklistDebounceSeconds)
 		throws DbIoException
 	{
 		// Reload the TSID cache every hour.
@@ -1721,12 +1721,11 @@ public class OpenTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 			failTimeClause = " and (a.FAIL_TIME is null OR "
 				+ System.currentTimeMillis() + " -  a.FAIL_TIME >= 3600000)";
 		String debounceClause = "";
-		int debounceSec = ((TimeSeriesDb)db).getTasklistDebounceSeconds();
-		if (debounceSec > 0)
+		if (tasklistDebounceSeconds > 0)
 		{
 			// DATE_TIME_LOADED is BIGINT epoch millis (see V6.8__opendcs.sql),
 			// so compare against an epoch-ms cutoff rather than SYSDATE/CURRENT_TIMESTAMP.
-			long cutoffMs = System.currentTimeMillis() - (debounceSec * 1000L);
+			long cutoffMs = System.currentTimeMillis() - (tasklistDebounceSeconds * 1000L);
 			debounceClause = " and a.DATE_TIME_LOADED <= " + cutoffMs;
 		}
 		String getMinStmtQuery = "select min(a.record_num) from cp_comp_tasklist a "


### PR DESCRIPTION
## Problem Description        
                                                                                          
  Follow-up to #1919.                                                                                                                                                                  
                                                                                                                                                                                       
  `tasklistDebounceSeconds` was added in #1919 as a global VM-wide setting on `DecodesSettings`. That scope is wrong: the value tunes one specific app — the CompProc tasklist polling 
  loop — and operators have to set it in `decodes.properties` where it applies uniformly to every CompProc instance running on the JVM.                                                
                                                                                                                                                                                     
  Other CompProc tunables (`reclaimTasklistSec`, `checkTimedCompsSec`, `compRunWaitTime`) already live as per-app `CompAppInfo` properties on the `REF_LOADING_APPLICATION_PROP` row   
  for the loading application. `tasklistDebounceSeconds` should follow the same pattern so each CompProc instance can be tuned independently from its own DB row.
                                                                                                                                                                                       
  ## Solution                                                                                                                                                                        

  Move `tasklistDebounceSeconds` from `DecodesSettings` to a per-app `CompAppInfo` property, mirroring the existing `reclaimTasklistSec` wiring:

  - Removed the field and `PropertySpec` entry from `DecodesSettings`.                                                                                                                 
  - Added a `protected int tasklistDebounceSeconds` field plus public `getTasklistDebounceSeconds()` / `setTasklistDebounceSeconds(int)` to `TimeSeriesDb` (next to
  `reclaimTasklistSec`).                                                                                                                                                               
  - Added a `PropertySpec` entry to `ComputationApp.myProps[]` so the property is visible in the app-properties editor.                                                              
  - In `ComputationApp.runAppInit()`, read `appInfo.getProperty("tasklistDebounceSeconds")` with the same parse-with-default pattern as `reclaimTasklistSec`, then assign via
  `theDb.setTasklistDebounceSeconds(...)`. Moved the startup log line so it shows the resolved per-app value instead of the global default.                                            
  - Updated the three DAOs (`CwmsTimeSeriesDAO`, `HdbTimeSeriesDAO`, `OpenTimeSeriesDAO`) to read `((TimeSeriesDb) db).getTasklistDebounceSeconds()` instead of
  `DecodesSettings.instance().tasklistDebounceSeconds`.                                                                                                                                
                                                                                                                                                                                     
  **Operator migration:** any deployment with `tasklistDebounceSeconds=N` in `decodes.properties` will silently revert to `0`. The value must be moved to the CompProc app's           
  `REF_LOADING_APPLICATION_PROP` row before deploying this build (GUI: launcher → Processes → edit compproc app → Properties tab; or direct SQL).                                    

  ## how you tested the change

  - `./gradlew :opendcs:compileJava` — clean.
  - `./gradlew :testing:opendcs-tests:compileTestJava` — clean.
  - Updated `TasklistDebounceTestIT` to set the value via `db.setTasklistDebounceSeconds(N)` instead of mutating `DecodesSettings`. Existing assertions unchanged; the test still
  exercises the same fresh-row-excluded / aged-row-admitted behavior end-to-end through `getNewData` + `releaseNewData`.
  - `CwmsTasklistDebounceTestIT` is unchanged — it asserts the SQL predicate by hand-rolling the WHERE clause, so it was unaffected by where the value comes from.
  - Grep sweep confirms zero references to the removed `DecodesSettings.tasklistDebounceSeconds` field.
                                                                                                                                                                                       
  ## Where the following done:
                                                                                                                                                                                       
  - [x] Tests. Check all that apply:                                                                                                                                                 
     - [ ] Unit tests created or modified that run during ant test.
     - [x] Integration tests created or modified that run during integration testing
           (Formerly called regression tests.)
     - [ ] Test procedure descriptions for manual testing
  - [x] Was relevant documentation updated? (PropertySpec description on the `tasklistDebounceSeconds` entry in `ComputationApp.myProps[]` carries the same operator-facing description
   that was previously on the `DecodesSettings` PropertySpec — surfaces in the app-properties editor.)
  - [ ] Were relevant config element (e.g. XML data) updated as appropriate

developed with Claude opus 4.7
