### PR TITLE
Modify ts store handler to account for possible difference in time pr…

### DIFF
--- a/schema/opendcs-schemas-cwms-oracle/src/main/resources/db/CWMS-Oracle/packages/R__cwms_ccp.sql
+++ b/schema/opendcs-schemas-cwms-oracle/src/main/resources/db/CWMS-Oracle/packages/R__cwms_ccp.sql
@@ -308,36 +308,29 @@ create or replace package body cwms_ccp as
     for r2 in
       (select distinct cc.loading_application_id
          from cp_comp_depends cd, cp_computation cc
-         where cd.ts_id = p_ts_code
+         where cd.ts_id = p_ts_code and cc.enabled = 'Y'
            and cc.loading_application_id is not null and cd.computation_id = cc.computation_id
       )
     loop
-      insert into cp_comp_tasklist
-      (  record_num,
-         loading_application_id,
-         site_datatype_id,
-         date_time_loaded,
-         start_date_time,
-         value,
-         unit_id,
-         delete_flag,
-         quality_code,
-         flags)
-      select
-         cp_comp_tasklistidseq.nextval,
-         r2.loading_application_id,
-         p_ts_code,
-         sysdate,
-         r1.date_time,
-         nvl(r1.value,0),
-         l_unit_id,
-         decode (r1.quality_code,5,'Y','N') delete_flag,
-         r1.quality_code,
-         r1.quality_code
-      from cwms_v_tsv r1
-      where r1.ts_code = p_ts_code
-        and r1.date_time >= l_start_time and r1.date_time <= l_end_time
-        and r1.data_entry_date <= p_enqueue_time;
+      for r1 in
+        (select date_time,value,quality_code from cwms_v_tsv
+           where ts_code = p_ts_code and date_time between l_start_time and l_end_time
+            -- and p_enqueue_time >= data_entry_date
+             and (cwms_util.to_millis(p_store_time) = cwms_util.to_millis(data_entry_date) OR p_store_time is NULL)
+        )
+      loop
+        l_delete_flag := 'N';
+        if (r1.quality_code = 5) then
+          l_delete_flag := 'Y';
+        end if;
+
+        insert into cp_comp_tasklist(record_num,loading_application_id,
+          site_datatype_id,date_time_loaded,start_date_time,value,
+          unit_id,delete_flag,quality_code,flags)
+        values(cp_comp_tasklistidseq.nextval,r2.loading_application_id,
+          p_ts_code,sysdate,r1.date_time,nvl(r1.value,0),l_unit_id,
+          l_delete_flag,r1.quality_code,r1.quality_code);
+      end loop; /* end of for r1 loop */
     end loop;   /* end of for r2 loop */
 
     commit;

--- a/schema/opendcs-schemas-cwms-oracle/src/main/resources/db/CWMS-Oracle/packages/R__cwms_ccp.sql
+++ b/schema/opendcs-schemas-cwms-oracle/src/main/resources/db/CWMS-Oracle/packages/R__cwms_ccp.sql
@@ -20,6 +20,8 @@
 -- create the callback procedure within the cwms_ccp package
 ---------------------------------------------------------------------------
 create or replace package cwms_ccp authid current_user as
+  MISSING_VALUE_QUALITY CONSTANT NUMBER := 5;
+
   procedure unregister_callback_proc (
     p_subscriber_name in varchar2,
     p_queue_name      in varchar2)
@@ -320,7 +322,7 @@ create or replace package body cwms_ccp as
         )
       loop
         l_delete_flag := 'N';
-        if (r1.quality_code = 5) then
+        if (r1.quality_code = MISSING_VALUE_QUALITY) then
           l_delete_flag := 'Y';
         end if;
 


### PR DESCRIPTION
…ecision.

## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #743. 

## Solution

Modifies how it is determined that values go into to the cp_comp_tasklist.

Primary change is the addition of the time series value data_entry_date to the message l_store_time, which would match the data_entry_date for any data changed.

Additionally remove the enqueue time check.

The use of the data_entry_date comparison allow data managers to edit bulk windows of data, but only reprocess data that was actually changed. 

NOTE: this does have the side affect where if data in between *should* be recomputed, it may not be. I believe the performance gain achieved by this warrants that issue; which needs to have it's own workaround anyways as a computation triggered by both regular and irregular data has the same problem.

It was also discovered that the data_entry_date values *may* include sub millisecond data. While this is not supposed to happen, the column is defined as `timestamp (6)` (microseconds) and data as been see in live databases that contain values to the microsecond.

## how you tested the change

- existing integration tests that make use of the queue
- MVP has been testing this for more than a year now
  - EXCEPT: remove of enqueue check, change of comparison to explicitly be millis.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
