### PR TITLE
Add live process status to Loading Apps

### DIFF
--- a/javascript/opendcs-web-ui-react/public/locales/de-DE/loadingapps.json
+++ b/javascript/opendcs-web-ui-react/public/locales/de-DE/loadingapps.json
@@ -10,5 +10,8 @@
   "edit_app": "Ladeanwendung {{id}} bearbeiten",
   "save_app": "Ladeanwendung {{id}} speichern",
   "cancel_for": "Bearbeitung von Ladeanwendung {{id}} abbrechen",
-  "delete_for": "Ladeanwendung {{id}} löschen"
+  "delete_for": "Ladeanwendung {{id}} löschen",
+  "status": "Status",
+  "status_running": "Läuft",
+  "status_inactive": "Inaktiv"
 }

--- a/javascript/opendcs-web-ui-react/public/locales/en-US/loadingapps.json
+++ b/javascript/opendcs-web-ui-react/public/locales/en-US/loadingapps.json
@@ -10,5 +10,8 @@
   "edit_app": "Edit loading app with id {{id}}",
   "save_app": "Save loading app with id {{id}}",
   "cancel_for": "Cancel editing loading app with id {{id}}",
-  "delete_for": "Delete loading app with id {{id}}"
+  "delete_for": "Delete loading app with id {{id}}",
+  "status": "Status",
+  "status_running": "Running",
+  "status_inactive": "Inactive"
 }

--- a/javascript/opendcs-web-ui-react/public/locales/es-ES/loadingapps.json
+++ b/javascript/opendcs-web-ui-react/public/locales/es-ES/loadingapps.json
@@ -10,5 +10,8 @@
   "edit_app": "Editar aplicación de carga con id {{id}}",
   "save_app": "Guardar aplicación de carga con id {{id}}",
   "cancel_for": "Cancelar edición de aplicación de carga con id {{id}}",
-  "delete_for": "Eliminar aplicación de carga con id {{id}}"
+  "delete_for": "Eliminar aplicación de carga con id {{id}}",
+  "status": "Estado",
+  "status_running": "Ejecutando",
+  "status_inactive": "Inactivo"
 }

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsPage.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsPage.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse } from "msw";
+import type { ApiAppRef, ApiAppStatus } from "opendcs-api";
+import { expect, waitFor } from "storybook/test";
+import { LoadingAppsPage } from "./LoadingAppsPage";
+
+// Mock data
+
+const mockAppRefs: ApiAppRef[] = [
+  {
+    appId: 1,
+    appName: "compproc",
+    appType: "computationprocess",
+    comment: "Main computation process",
+  },
+  {
+    appId: 2,
+    appName: "routing",
+    appType: "routingscheduler",
+    comment: "Routing scheduler",
+  },
+];
+
+// appId 1 is running; appId 2 is inactive (pid absent).
+const mockAppStats: ApiAppStatus[] = [
+  { appId: 1, pid: 12345, status: "Cmps: 0/0" },
+  { appId: 2 },
+];
+
+const handlers = {
+  appRefs: http.get("/odcsapi/apprefs", () =>
+    HttpResponse.json<ApiAppRef[]>(mockAppRefs),
+  ),
+  appStat: http.get("/odcsapi/appstat", () =>
+    HttpResponse.json<ApiAppStatus[]>(mockAppStats),
+  ),
+};
+
+const meta = {
+  component: LoadingAppsPage,
+  parameters: { msw: { handlers } },
+} satisfies Meta<typeof LoadingAppsPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Stories
+
+// Verifies that the page loads app refs and merges running status from the
+// monitor endpoint. Covers useAppStatQuery (success path), the appsWithStatus
+// memo in LoadingAppsPage, and both branches of the status column renderer.
+export const WithRunningAndInactiveApps: Story = {
+  play: async ({ mount, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    await waitFor(() => canvas.getByText(i18n.t("loadingapps:status_running")), {
+      timeout: 5000,
+    });
+    expect(canvas.getByText(i18n.t("loadingapps:status_inactive"))).toBeInTheDocument();
+  },
+};
+
+// Verifies that when the monitor endpoint is unavailable, the page still
+// renders with all apps shown as inactive.
+export const WithUnavailableMonitor: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        ...handlers,
+        appStat: http.get("/odcsapi/appstat", () => HttpResponse.error()),
+      },
+    },
+  },
+  play: async ({ mount, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    await waitFor(() => canvas.getAllByText(i18n.t("loadingapps:status_inactive")), {
+      timeout: 5000,
+    });
+    expect(
+      canvas.queryByText(i18n.t("loadingapps:status_running")),
+    ).not.toBeInTheDocument();
+  },
+};

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsPage.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsPage.tsx
@@ -1,6 +1,7 @@
 import { LoadingAppsTable } from "./LoadingAppsTable";
 import {
   useAppRefsQuery,
+  useAppStatQuery,
   useDeleteAppMutation,
   useFetchApp,
   useSaveAppMutation,
@@ -8,6 +9,7 @@ import {
 
 export const LoadingAppsPage: React.FC = () => {
   const { data: apps = [], isLoading } = useAppRefsQuery();
+  const { data: appStats = [] } = useAppStatQuery();
   const fetchApp = useFetchApp();
   const saveApp = useSaveAppMutation();
   const deleteApp = useDeleteAppMutation();
@@ -16,6 +18,7 @@ export const LoadingAppsPage: React.FC = () => {
     <div className="content">
       <LoadingAppsTable
         apps={apps}
+        appStats={appStats}
         loading={isLoading}
         getApp={fetchApp}
         actions={{

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsPage.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { LoadingAppsTable } from "./LoadingAppsTable";
 import {
   useAppRefsQuery,
@@ -14,11 +15,19 @@ export const LoadingAppsPage: React.FC = () => {
   const saveApp = useSaveAppMutation();
   const deleteApp = useDeleteAppMutation();
 
+  const appsWithStatus = useMemo(
+    () =>
+      apps.map((app) => ({
+        ...app,
+        _pid: appStats.find((s) => s.appId === app.appId)?.pid ?? null,
+      })),
+    [apps, appStats],
+  );
+
   return (
     <div className="content">
       <LoadingAppsTable
-        apps={apps}
-        appStats={appStats}
+        apps={appsWithStatus}
         loading={isLoading}
         getApp={fetchApp}
         actions={{

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsTable.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsTable.stories.tsx
@@ -122,6 +122,30 @@ export const Default: Story = {
   },
 };
 
+export const WithRunningStatus: Story = {
+  args: {
+    apps: [
+      {
+        appId: 1,
+        appName: "compproc",
+        appType: "computationprocess",
+        comment: "Main computation process",
+        _pid: 12345,
+      },
+      {
+        appId: 2,
+        appName: "routing",
+        appType: "routingscheduler",
+        comment: "Routing scheduler",
+        _pid: null,
+      },
+    ],
+  },
+  play: async ({ mount }) => {
+    await mount();
+  },
+};
+
 export const WithApps: Story = {
   args: { apps: toAppRefs(sharedApps) },
   render: StoryRender,

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsTable.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import type { ApiAppRef, ApiAppStatus, ApiLoadingApp } from "opendcs-api";
+import type { ApiAppRef, ApiLoadingApp } from "opendcs-api";
 import LoadingApp, { LoadingAppSkeleton, type UiLoadingApp } from "./LoadingApp";
 import type { RemoveAction, SaveAction } from "../../util/Actions";
 import {
@@ -9,11 +9,11 @@ import {
   type RowAction,
 } from "../../components/data-table";
 
-export type TableAppRef = Partial<ApiAppRef>;
+// DataTables sees a row-data change when status loads, triggering a redraw.
+export type TableAppRef = Partial<ApiAppRef> & { _pid?: number | null };
 
 export interface LoadingAppsTableProperties {
   apps: TableAppRef[];
-  appStats?: ApiAppStatus[];
   getApp?: (appId: number) => Promise<ApiLoadingApp>;
   actions?: SaveAction<ApiLoadingApp> & RemoveAction<number>;
   loading?: boolean;
@@ -21,7 +21,6 @@ export interface LoadingAppsTableProperties {
 
 export const LoadingAppsTable: React.FC<LoadingAppsTableProperties> = ({
   apps,
-  appStats = [],
   getApp,
   actions = {},
   loading = false,
@@ -51,14 +50,13 @@ export const LoadingAppsTable: React.FC<LoadingAppsTableProperties> = ({
         },
       },
       {
-        data: null,
+        data: "_pid",
         header: t("loadingapps:status"),
         orderable: false,
         searchable: false,
-        render: (_: unknown, type: string, row: TableAppRef) => {
-          if (type !== "display") return "";
-          const stat = appStats.find((s) => s.appId === row.appId);
-          const running = stat?.pid != null;
+        render: (data: unknown, type: string) => {
+          if (type !== "display") return data ?? "";
+          const running = data != null;
           const label = running
             ? t("loadingapps:status_running")
             : t("loadingapps:status_inactive");
@@ -67,7 +65,7 @@ export const LoadingAppsTable: React.FC<LoadingAppsTableProperties> = ({
         },
       },
     ],
-    [t, appStats],
+    [t],
   );
 
   const rowActions = useMemo<RowAction<TableAppRef>[]>(

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingAppsTable.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import type { ApiAppRef, ApiLoadingApp } from "opendcs-api";
+import type { ApiAppRef, ApiAppStatus, ApiLoadingApp } from "opendcs-api";
 import LoadingApp, { LoadingAppSkeleton, type UiLoadingApp } from "./LoadingApp";
 import type { RemoveAction, SaveAction } from "../../util/Actions";
 import {
@@ -13,6 +13,7 @@ export type TableAppRef = Partial<ApiAppRef>;
 
 export interface LoadingAppsTableProperties {
   apps: TableAppRef[];
+  appStats?: ApiAppStatus[];
   getApp?: (appId: number) => Promise<ApiLoadingApp>;
   actions?: SaveAction<ApiLoadingApp> & RemoveAction<number>;
   loading?: boolean;
@@ -20,6 +21,7 @@ export interface LoadingAppsTableProperties {
 
 export const LoadingAppsTable: React.FC<LoadingAppsTableProperties> = ({
   apps,
+  appStats = [],
   getApp,
   actions = {},
   loading = false,
@@ -48,8 +50,24 @@ export const LoadingAppsTable: React.FC<LoadingAppsTableProperties> = ({
           return Number.isNaN(d.getTime()) ? "" : d.toLocaleString();
         },
       },
+      {
+        data: null,
+        header: t("loadingapps:status"),
+        orderable: false,
+        searchable: false,
+        render: (_: unknown, type: string, row: TableAppRef) => {
+          if (type !== "display") return "";
+          const stat = appStats.find((s) => s.appId === row.appId);
+          const running = stat?.pid != null;
+          const label = running
+            ? t("loadingapps:status_running")
+            : t("loadingapps:status_inactive");
+          const cls = running ? "bg-success" : "bg-secondary";
+          return `<span class="badge ${cls}">${label}</span>`;
+        },
+      },
     ],
-    [t],
+    [t, appStats],
   );
 
   const rowActions = useMemo<RowAction<TableAppRef>[]>(

--- a/javascript/opendcs-web-ui-react/src/queries/apps.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/apps.ts
@@ -6,8 +6,10 @@ import {
   type UseMutationOptions,
 } from "@tanstack/react-query";
 import {
+  OpenDCSProcessMonitorAndControlAPPApi,
   RESTLoadingApplicationRecordsApi,
   type ApiAppRef,
+  type ApiAppStatus,
   type ApiLoadingApp,
 } from "opendcs-api";
 import { useApi } from "../contexts/app/ApiContext";
@@ -20,6 +22,15 @@ const useAppsApi = () => {
     [api.conf],
   );
   return { appApi, org: api.org };
+};
+
+const useAppMonitorApi = () => {
+  const api = useApi();
+  const monitorApi = useMemo(
+    () => new OpenDCSProcessMonitorAndControlAPPApi(api.conf),
+    [api.conf],
+  );
+  return { monitorApi, org: api.org };
 };
 
 // App refs power the "process" dropdown on the Computations editor and the
@@ -74,5 +85,20 @@ export const useDeleteAppMutation = (
       queryClient.invalidateQueries({ queryKey: appKeys.all(org) });
       options?.onSuccess?.(...args);
     },
+  });
+};
+
+export const useAppStatQuery = () => {
+  const { monitorApi, org } = useAppMonitorApi();
+  return useQuery<ApiAppStatus[]>({
+    queryKey: appKeys.stat(org),
+    queryFn: async () => {
+      try {
+        return await monitorApi.getAppStat(org);
+      } catch {
+        return [];
+      }
+    },
+    refetchInterval: 30_000,
   });
 };

--- a/javascript/opendcs-web-ui-react/src/queries/keys.test.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/keys.test.ts
@@ -146,7 +146,15 @@ describe("appKeys", () => {
     expect(list).toEqual(["apps", "acme", "list"]);
   });
 
+  test("stat() extends all() so invalidating all() also invalidates stat()", () => {
+    const all = appKeys.all("acme");
+    const stat = appKeys.stat("acme");
+    expect(stat.slice(0, all.length)).toEqual([...all]);
+    expect(stat).toEqual(["apps", "acme", "stat"]);
+  });
+
   test("keys for different orgs never collide", () => {
     expect(appKeys.list("acme")).not.toEqual(appKeys.list("globex"));
+    expect(appKeys.stat("acme")).not.toEqual(appKeys.stat("globex"));
   });
 });

--- a/javascript/opendcs-web-ui-react/src/queries/keys.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/keys.ts
@@ -37,6 +37,7 @@ export const computationKeys = {
 export const appKeys = {
   all: (org: string) => ["apps", org] as const,
   list: (org: string) => [...appKeys.all(org), "list"] as const,
+  stat: (org: string) => [...appKeys.all(org), "stat"] as const,
 };
 
 export const tsGroupKeys = {


### PR DESCRIPTION
## Problem Description

The Loading Apps table had no way to tell whether an app process was actually
running or not. 

## Solution

Added a live Status column to the Loading Apps table. It polls the
/appstat endpoint and renders a green when the app has an active PID, or gray otherwise.

## how you tested the change

- Status column appears in the Loading Apps table
- Badge updates automatically after 30ish seconds when a process starts or stops
- Confirmed the page still loads normally when `/appstat` is unavailable
- All existing unit and storybook tests pass 

- Inserted a fake running record into cp_comp_proc_lock for compproc (appId 4) directly in Postgres to simulate a live process. Confirmed compproc showed a green Running badge in the table while all other apps showed gray Inactive. 

<img width="1904" height="929" alt="Screenshot 2026-05-26 at 4 49 13 PM" src="https://github.com/user-attachments/assets/8a57c3ac-f81e-4336-9b76-d0d6c19e82b5" />


## Where the following done:

- [x] Tests. Check all that apply:
   - [x] Unit tests created or modified that run during ant test.
   - [x] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [x] Test procedure descriptions for manual testing
- [x] Was relevant documentation updated?
- [x] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
