### PR TITLE
Ensure token is for the same client before accepting and auto-register

### DIFF
--- a/compose_files/keycloak/realm.json
+++ b/compose_files/keycloak/realm.json
@@ -816,6 +816,57 @@
       ]
     },
     {
+      "id": "a1b2c3d4-0000-4000-8000-00000000c111",
+      "clientId": "test-other-client",
+      "name": "test-other-client",
+      "description": "A separate client in the same realm, used by tests to verify tokens minted for a different client are rejected.",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "not-used",
+      "redirectUris": [
+        "http://localhost:*",
+        "http://localhost*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oauth2.device.authorization.grant.enabled": "false",
+        "use.refresh.tokens": "true",
+        "oidc.ciba.grant.enabled": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email",
+        "subjectDN"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
       "id": "f09103f0-5563-4dc0-bc70-2ff0309edae7",
       "clientId": "realm-management",
       "name": "${client_realm-management}",

--- a/compose_files/keycloak/realm.json
+++ b/compose_files/keycloak/realm.json
@@ -2415,6 +2415,22 @@
       "realmRoles": [
           "opendcs_user"
       ]
+    },
+    {
+      "id": "45ee99c4-3dc8-444d-81d8-2c669a148b03",
+      "username": "wrong_client_user",
+      "enabled": true,
+      "email": "wrong_client_user@localhost.localdomain",
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test_password"
+        }
+      ],
+      "realmRoles": [
+          "opendcs_user"
+      ]
     }
   ]
 }

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/sec/openid/OpenIdTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/sec/openid/OpenIdTestIT.java
@@ -59,6 +59,7 @@ import decodes.sql.DbKey;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -437,6 +438,52 @@ final class OpenIdTestIT extends BaseApiIT
 			.statusCode(is(Response.Status.OK.getStatusCode()))
 		;
 
+	}
+
+	@Test
+	void test_login_jwt_rejects_token_from_other_client() throws Exception
+	{
+		// A token minted for a DIFFERENT client in the same realm (admin-cli) shares the issuer
+		// but is not intended for OpenDCS. It must be rejected and must not auto-register a user.
+		final String wrongClientToken = given()
+			.log().ifValidationFails(LogDetail.ALL, true)
+			.contentType(ContentType.URLENC)
+				.formParam("client_id", "admin-cli")
+				.formParam("grant_type", "password")
+				.formParam("scope", "openid profile email")
+				.formParam("username", "wrong_client_user")
+				.formParam("password", "test_password")
+		.when()
+			.post(URI.create(KeyCloakTestExtension.getTokenUrl()))
+		.then()
+			.log().ifValidationFails(LogDetail.ALL, true)
+			.assertThat()
+			.statusCode(is(Response.Status.OK.getStatusCode()))
+			.extract()
+			.jsonPath()
+			.getString("access_token")
+		;
+
+		given()
+			.log().ifValidationFails(LogDetail.ALL, true)
+			.accept(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer " + wrongClientToken)
+		.when()
+			.post("/login_jwt")
+		.then()
+			.log().ifValidationFails(LogDetail.ALL, true)
+		.assertThat()
+			.statusCode(is(Response.Status.UNAUTHORIZED.getStatusCode()))
+		;
+
+		// The wrong-client token must not have caused a user to be registered.
+		final var umDao = db.getDao(UserManagementDao.class).orElseThrow();
+		try (var tx = db.newTransaction())
+		{
+			var registered = umDao.getUsers(tx, -1, -1).stream()
+					.anyMatch(u -> "wrong_client_user@localhost.localdomain".equals(u.email));
+			assertFalse(registered, "A user was registered from a token issued for a different client.");
+		}
 	}
 
 	private Cookie doAuthCodeLogin(Cookie initialSession) throws IOException

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/sec/openid/OpenIdTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/sec/openid/OpenIdTestIT.java
@@ -443,12 +443,12 @@ final class OpenIdTestIT extends BaseApiIT
 	@Test
 	void test_login_jwt_rejects_token_from_other_client() throws Exception
 	{
-		// A token minted for a DIFFERENT client in the same realm (admin-cli) shares the issuer
-		// but is not intended for OpenDCS. It must be rejected and must not auto-register a user.
+		// A token minted for a DIFFERENT client in the same realm (test-other-client) shares the
+		// issuer but is not intended for OpenDCS. It must be rejected and must not auto-register a user.
 		final String wrongClientToken = given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.contentType(ContentType.URLENC)
-				.formParam("client_id", "admin-cli")
+				.formParam("client_id", "test-other-client")
 				.formParam("grant_type", "password")
 				.formParam("scope", "openid profile email")
 				.formParam("username", "wrong_client_user")

--- a/java/opendcs/src/main/java/org/opendcs/authentication/identityprovider/impl/oidc/JwtVerifier.java
+++ b/java/opendcs/src/main/java/org/opendcs/authentication/identityprovider/impl/oidc/JwtVerifier.java
@@ -30,6 +30,7 @@ import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimNames;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
@@ -49,7 +50,7 @@ final class JwtVerifier
 		return instance;
 	}
 
-	JWTClaimsSet getClaimsSet(JWKSource<SecurityContext> keySource, String accessToken, String issuer)
+	JWTClaimsSet getClaimsSet(JWKSource<SecurityContext> keySource, String accessToken, String issuer, String clientId)
 			throws BadJOSEException, ParseException, JOSEException
 	{
 		// Nimbus API documentation taken from:
@@ -62,13 +63,27 @@ final class JwtVerifier
 		JWSAlgorithm expectedJWSAlg = JWSAlgorithm.RS256;
 		JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, keySource);
 		jwtProcessor.setJWSKeySelector(keySelector);
-		jwtProcessor.setJWTClaimsSetVerifier(new DefaultJWTClaimsVerifier<>(
+		// Beyond issuer/expiry, require the token to have been minted for this client. ID tokens carry
+		// the client in "aud"; Keycloak access tokens may omit "aud" and only set "azp", so accept either.
+		jwtProcessor.setJWTClaimsSetVerifier(new DefaultJWTClaimsVerifier<SecurityContext>(
 				new JWTClaimsSet.Builder().issuer(issuer).build(),
 				new HashSet<>(Arrays.asList(
 						JWTClaimNames.SUBJECT,
 						JWTClaimNames.ISSUED_AT,
 						JWTClaimNames.EXPIRATION_TIME,
-						JWTClaimNames.JWT_ID))));
+						JWTClaimNames.JWT_ID)))
+		{
+			@Override
+			public void verify(JWTClaimsSet claimsSet, SecurityContext context) throws BadJWTException
+			{
+				super.verify(claimsSet, context);
+				boolean inAudience = claimsSet.getAudience() != null && claimsSet.getAudience().contains(clientId);
+				if (!inAudience && !clientId.equals(claimsSet.getClaim("azp")))
+				{
+					throw new BadJWTException("JWT was not issued for this client.");
+				}
+			}
+		});
 		return jwtProcessor.process(accessToken, null);
 	}
 }

--- a/java/opendcs/src/main/java/org/opendcs/authentication/identityprovider/impl/oidc/OidcIdentityProvider.java
+++ b/java/opendcs/src/main/java/org/opendcs/authentication/identityprovider/impl/oidc/OidcIdentityProvider.java
@@ -223,7 +223,7 @@ public final class OidcIdentityProvider implements IdentityProvider
     private JWTClaimsSet verifyTokenAndGetClaims(OpenIdConfiguration config, String token) throws MalformedURLException, BadJOSEException, ParseException, JOSEException
     {
         var keySource = JWKSourceBuilder.create(config.getJwksUri().toURL()).retrying(true).build();
-        return JwtVerifier.getInstance().getClaimsSet(keySource, token, oidcConfig.getIssuer());
+        return JwtVerifier.getInstance().getClaimsSet(keySource, token, oidcConfig.getIssuer(), this.clientId);
     }
 
     @Override


### PR DESCRIPTION
note: PR into another PR.

The new test below failed , before adding the clientID check against 'azp'  (Authorized Party).