### PR TITLE
add the schedule entries page to the react app

### DIFF
--- a/javascript/opendcs-web-ui-react/public/locales/de-DE/schedule.json
+++ b/javascript/opendcs-web-ui-react/public/locales/de-DE/schedule.json
@@ -1,0 +1,33 @@
+{
+  "title": "Zeitplan",
+  "header": {
+    "Id": "ID",
+    "Name": "Name",
+    "LoadingApp": "Ladeanwendung",
+    "RoutingSpec": "Routing-Spezifikation",
+    "Enabled": "Aktiviert",
+    "LastModified": "Zuletzt geändert"
+  },
+  "name": "Name",
+  "loading_app": "Ladeanwendung",
+  "routing_spec": "Routing-Spezifikation",
+  "enabled": "Aktiviert",
+  "start_time": "Startzeit",
+  "timezone": "Zeitzone",
+  "execution_schedule": "Ausführungsplan",
+  "run_continuously": "Fortlaufend ausführen",
+  "run_once": "Einmal ausführen",
+  "run_every": "Alle",
+  "run_amount": "Intervallwert",
+  "run_unit": "Intervalleinheit",
+  "unit_minute": "Minuten",
+  "unit_hour": "Stunden",
+  "unit_day": "Tage",
+  "select_routing": "Routing-Spezifikation auswählen",
+  "select_routing_none": "Keine Routing-Spezifikationen verfügbar.",
+  "add_schedule": "Zeitplaneintrag hinzufügen",
+  "edit_schedule": "Zeitplaneintrag {{id}} bearbeiten",
+  "delete_for": "Zeitplaneintrag {{id}} löschen",
+  "save_schedule": "Zeitplaneintrag {{id}} speichern",
+  "cancel_for": "Bearbeitung von Zeitplaneintrag {{id}} abbrechen"
+}

--- a/javascript/opendcs-web-ui-react/public/locales/en-US/schedule.json
+++ b/javascript/opendcs-web-ui-react/public/locales/en-US/schedule.json
@@ -1,0 +1,33 @@
+{
+  "title": "Schedule",
+  "header": {
+    "Id": "Id",
+    "Name": "Name",
+    "LoadingApp": "Loading App",
+    "RoutingSpec": "Routing Spec",
+    "Enabled": "Enabled",
+    "LastModified": "Last Modified"
+  },
+  "name": "Name",
+  "loading_app": "Loading App",
+  "routing_spec": "Routing Spec",
+  "enabled": "Enabled",
+  "start_time": "Start Time",
+  "timezone": "Timezone",
+  "execution_schedule": "Execution Schedule",
+  "run_continuously": "Run Continuously",
+  "run_once": "Run Once",
+  "run_every": "Run Every",
+  "run_amount": "Run interval amount",
+  "run_unit": "Run interval unit",
+  "unit_minute": "Minutes",
+  "unit_hour": "Hours",
+  "unit_day": "Days",
+  "select_routing": "Select routing spec",
+  "select_routing_none": "No routing specs available.",
+  "add_schedule": "Add schedule entry",
+  "edit_schedule": "Edit schedule entry {{id}}",
+  "delete_for": "Delete schedule entry {{id}}",
+  "save_schedule": "Save schedule entry {{id}}",
+  "cancel_for": "Cancel editing schedule entry {{id}}"
+}

--- a/javascript/opendcs-web-ui-react/public/locales/es-ES/schedule.json
+++ b/javascript/opendcs-web-ui-react/public/locales/es-ES/schedule.json
@@ -1,0 +1,33 @@
+{
+  "title": "Programación",
+  "header": {
+    "Id": "ID",
+    "Name": "Nombre",
+    "LoadingApp": "Aplicación de carga",
+    "RoutingSpec": "Especificación de ruteo",
+    "Enabled": "Habilitado",
+    "LastModified": "Última modificación"
+  },
+  "name": "Nombre",
+  "loading_app": "Aplicación de carga",
+  "routing_spec": "Especificación de ruteo",
+  "enabled": "Habilitado",
+  "start_time": "Hora de inicio",
+  "timezone": "Zona horaria",
+  "execution_schedule": "Programa de ejecución",
+  "run_continuously": "Ejecutar continuamente",
+  "run_once": "Ejecutar una vez",
+  "run_every": "Ejecutar cada",
+  "run_amount": "Valor del intervalo",
+  "run_unit": "Unidad del intervalo",
+  "unit_minute": "Minutos",
+  "unit_hour": "Horas",
+  "unit_day": "Días",
+  "select_routing": "Seleccionar especificación de ruteo",
+  "select_routing_none": "No hay especificaciones de ruteo disponibles.",
+  "add_schedule": "Agregar entrada de programación",
+  "edit_schedule": "Editar entrada de programación {{id}}",
+  "delete_for": "Eliminar entrada de programación {{id}}",
+  "save_schedule": "Guardar entrada de programación {{id}}",
+  "cancel_for": "Cancelar la edición de la entrada de programación {{id}}"
+}

--- a/javascript/opendcs-web-ui-react/src/App.tsx
+++ b/javascript/opendcs-web-ui-react/src/App.tsx
@@ -9,6 +9,7 @@ import { Platforms } from "./pages/platforms";
 import { Configs } from "./pages/decodes/configs";
 import { Routing } from "./pages/decodes/routing";
 import { DataSources } from "./pages/decodes/data-sources";
+import { Schedules } from "./pages/schedule";
 import { Algorithms } from "./pages/computations/algorithms";
 import { Computations } from "./pages/computations/computations";
 import { SitesPage } from "./pages/sites";
@@ -43,6 +44,7 @@ function App() {
               <Route path="/configs" element={<Configs />} />
               <Route path="/routing" element={<Routing />} />
               <Route path="/data-sources" element={<DataSources />} />
+              <Route path="/schedule" element={<Schedules />} />
               <Route path="/sites" element={<SitesPage />} />
               <Route path="/computations" element={<Computations />} />
               <Route path="/algorithms" element={<Algorithms />} />

--- a/javascript/opendcs-web-ui-react/src/components/forms/EditFormActions.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/forms/EditFormActions.tsx
@@ -1,0 +1,52 @@
+import type { PropsWithChildren } from "react";
+import { Button, type ButtonProps, Col, Row } from "react-bootstrap";
+import { Save, X } from "react-bootstrap-icons";
+import { useTranslation } from "react-i18next";
+
+// Layout shell for the bottom-right action row on an edit card. Compose any
+// buttons you want as children — typically <CancelButton/> + <SaveButton/>,
+// optionally with a <DeleteButton/> or extra controls in between.
+export const EditFormActions: React.FC<PropsWithChildren> = ({ children }) => (
+  <Row className="mt-3">
+    <Col className="d-flex justify-content-end gap-2">{children}</Col>
+  </Row>
+);
+
+// Standard Cancel button: secondary variant, X icon, localized "Cancel" label.
+// Override `children` for a different label/icon; spread the rest of ButtonProps
+// for onClick, aria-label, disabled, type, etc.
+export const CancelButton: React.FC<ButtonProps> = ({
+  children,
+  variant = "secondary",
+  ...rest
+}) => {
+  const [t] = useTranslation("translation");
+  return (
+    <Button variant={variant} {...rest}>
+      {children ?? (
+        <>
+          <X /> {t("cancel")}
+        </>
+      )}
+    </Button>
+  );
+};
+
+// Standard Save button: primary variant, Save icon, localized "Save" label.
+// Same composition rules as CancelButton.
+export const SaveButton: React.FC<ButtonProps> = ({
+  children,
+  variant = "primary",
+  ...rest
+}) => {
+  const [t] = useTranslation("translation");
+  return (
+    <Button variant={variant} {...rest}>
+      {children ?? (
+        <>
+          <Save /> {t("save")}
+        </>
+      )}
+    </Button>
+  );
+};

--- a/javascript/opendcs-web-ui-react/src/components/forms/index.ts
+++ b/javascript/opendcs-web-ui-react/src/components/forms/index.ts
@@ -1,0 +1,2 @@
+export { CancelButton, EditFormActions, SaveButton } from "./EditFormActions";
+export { INPUT_H, LABEL_H } from "./sizes";

--- a/javascript/opendcs-web-ui-react/src/components/forms/sizes.ts
+++ b/javascript/opendcs-web-ui-react/src/components/forms/sizes.ts
@@ -1,0 +1,5 @@
+// Default heights for form-field skeletons (Placeholder rows). Callers can
+// spread-and-override (e.g. `{ ...INPUT_H, width: "5.5rem" }`) when the
+// default isn't a fit; redefine locally when a card needs a different baseline.
+export const INPUT_H = { height: "2.25rem" };
+export const LABEL_H = { height: "1rem" };

--- a/javascript/opendcs-web-ui-react/src/components/layout/SideBar.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/layout/SideBar.tsx
@@ -17,6 +17,7 @@ export const SideBar = ({ open, onClose }: SideBarProps) => {
     "loadingapps",
     "routing",
     "datasources",
+    "schedule",
   ]);
   const location = useLocation();
 
@@ -69,6 +70,14 @@ export const SideBar = ({ open, onClose }: SideBarProps) => {
             onClick={onClose}
           >
             {t("datasources:title")}
+          </Nav.Link>
+          <Nav.Link
+            as={Link}
+            to="/schedule"
+            active={location.pathname === "/schedule"}
+            onClick={onClose}
+          >
+            {t("schedule:title")}
           </Nav.Link>
         </Nav>
 

--- a/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingApp.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/loading-apps/LoadingApp.tsx
@@ -1,15 +1,18 @@
-import { Button, Card, Col, Form, FormGroup, Placeholder, Row } from "react-bootstrap";
+import { Card, Col, Form, FormGroup, Placeholder, Row } from "react-bootstrap";
 import { PropertiesTable, type Property } from "../../components/properties";
 import { use, useCallback, useMemo, useReducer } from "react";
 import type { ApiLoadingApp } from "opendcs-api";
 import { useTranslation } from "react-i18next";
 import type { CancelAction, CollectionActions, SaveAction } from "../../util/Actions";
-import { Save, X } from "react-bootstrap-icons";
 import { LoadingAppReducer } from "./LoadingAppReducer";
 import { DetailFade } from "../../components/data-table";
-
-const INPUT_H = { height: "2.25rem" };
-const LABEL_H = { height: "1rem" };
+import {
+  CancelButton,
+  EditFormActions,
+  INPUT_H,
+  LABEL_H,
+  SaveButton,
+} from "../../components/forms";
 
 const APP_FIELDS = ["appName", "appType", "comment"] as const;
 
@@ -224,27 +227,18 @@ export const LoadingApp: React.FC<LoadingAppProperties> = ({
           </Row>
 
           {edit && (
-            <Row className="mt-3">
-              <Col className="d-flex justify-content-end gap-2">
-                <Button
-                  onClick={() =>
-                    providedApp.appId !== undefined &&
-                    actions.cancel?.(providedApp.appId)
-                  }
-                  variant="secondary"
-                  aria-label={t("loadingapps:cancel_for", { id: providedApp.appId })}
-                >
-                  <X /> {t("translation:cancel")}
-                </Button>
-                <Button
-                  onClick={saveApp}
-                  variant="primary"
-                  aria-label={t("loadingapps:save_app", { id: localApp.appId })}
-                >
-                  <Save /> {t("translation:save")}
-                </Button>
-              </Col>
-            </Row>
+            <EditFormActions>
+              <CancelButton
+                onClick={() =>
+                  providedApp.appId !== undefined && actions.cancel?.(providedApp.appId)
+                }
+                aria-label={t("loadingapps:cancel_for", { id: providedApp.appId })}
+              />
+              <SaveButton
+                onClick={saveApp}
+                aria-label={t("loadingapps:save_app", { id: localApp.appId })}
+              />
+            </EditFormActions>
           )}
         </Card.Body>
       </Card>

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/ExecutionSchedule.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/ExecutionSchedule.stories.tsx
@@ -1,0 +1,300 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { expect, fn, waitFor } from "storybook/test";
+import { ExecutionSchedule, type ExecutionScheduleChange } from "./ExecutionSchedule";
+
+// Controlled wrapper so the component sees state updates without us having to
+// reach into React internals. Mirrors how `Schedule.tsx` drives it.
+type WrapperProps = {
+  startTime?: Date;
+  runInterval?: string;
+  timeZone?: string;
+  edit?: boolean;
+  onChange: (change: ExecutionScheduleChange) => void;
+  onTimeZoneChange: (value: string) => void;
+};
+
+const ExecutionScheduleDemo: React.FC<WrapperProps> = ({
+  startTime: initStart,
+  runInterval: initInterval,
+  timeZone: initTz,
+  edit = true,
+  onChange,
+  onTimeZoneChange,
+}) => {
+  const [startTime, setStartTime] = useState<Date | undefined>(initStart);
+  const [runInterval, setRunInterval] = useState<string | undefined>(initInterval);
+  const [timeZone, setTimeZone] = useState<string | undefined>(initTz);
+
+  return (
+    <ExecutionSchedule
+      startTime={startTime}
+      runInterval={runInterval}
+      timeZone={timeZone}
+      edit={edit}
+      onChange={(change) => {
+        setStartTime(change.startTime);
+        setRunInterval(change.runInterval);
+        onChange(change);
+      }}
+      onTimeZoneChange={(value) => {
+        setTimeZone(value);
+        onTimeZoneChange(value);
+      }}
+    />
+  );
+};
+
+const meta = {
+  component: ExecutionScheduleDemo,
+  args: {
+    edit: true,
+    onChange: fn(),
+    onTimeZoneChange: fn(),
+  },
+} satisfies Meta<typeof ExecutionScheduleDemo>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// No startTime + no runInterval → "Run Continuously" mode. Start time and
+// timezone are disabled because they have no effect, and the periodic amount
+// input is disabled too.
+export const RunContinuously: Story = {
+  play: async ({ canvas, mount, parameters }) => {
+    await mount();
+    const { i18n } = parameters;
+    const cont = (await canvas.findByRole("radio", {
+      name: i18n.t("schedule:run_continuously"),
+    })) as HTMLInputElement;
+    expect(cont.checked).toBe(true);
+    const start = canvas.getByLabelText(
+      i18n.t("schedule:start_time"),
+    ) as HTMLInputElement;
+    expect(start.disabled).toBe(true);
+    const tz = canvas.getByLabelText(i18n.t("schedule:timezone")) as HTMLSelectElement;
+    expect(tz.disabled).toBe(true);
+    const amount = canvas.getByLabelText(
+      i18n.t("schedule:run_amount"),
+    ) as HTMLInputElement;
+    expect(amount.disabled).toBe(true);
+  },
+};
+
+// startTime set, no runInterval → "Run Once" mode. Start time is enabled, the
+// periodic amount/unit stay disabled.
+export const RunOnce: Story = {
+  args: {
+    startTime: new Date("2024-06-15T10:30:00"),
+    timeZone: "UTC",
+  },
+  play: async ({ canvas, mount, parameters }) => {
+    await mount();
+    const { i18n } = parameters;
+    const once = (await canvas.findByRole("radio", {
+      name: i18n.t("schedule:run_once"),
+    })) as HTMLInputElement;
+    expect(once.checked).toBe(true);
+    const start = canvas.getByLabelText(
+      i18n.t("schedule:start_time"),
+    ) as HTMLInputElement;
+    expect(start.disabled).toBe(false);
+    expect(start.value).not.toEqual("");
+    const amount = canvas.getByLabelText(
+      i18n.t("schedule:run_amount"),
+    ) as HTMLInputElement;
+    expect(amount.disabled).toBe(true);
+  },
+};
+
+// startTime + parseable runInterval → "Run Every" mode. Amount and unit are
+// populated and editable; start-time + tz are enabled.
+export const RunEvery: Story = {
+  args: {
+    startTime: new Date("2024-06-15T10:30:00"),
+    runInterval: "30 minutes",
+    timeZone: "America/New_York",
+  },
+  play: async ({ canvas, mount, parameters }) => {
+    await mount();
+    const { i18n } = parameters;
+    const every = (await canvas.findByRole("radio", {
+      name: i18n.t("schedule:run_every"),
+    })) as HTMLInputElement;
+    expect(every.checked).toBe(true);
+    const amount = canvas.getByLabelText(
+      i18n.t("schedule:run_amount"),
+    ) as HTMLInputElement;
+    expect(amount.value).toEqual("30");
+    expect(amount.disabled).toBe(false);
+    const unit = canvas.getByLabelText(
+      i18n.t("schedule:run_unit"),
+    ) as HTMLSelectElement;
+    expect(unit.value).toEqual("minute");
+  },
+};
+
+// Switching from Continuously to Once enables the start-time picker and
+// populates it with a default value so the user has something to refine.
+export const SwitchToOnceEnablesStartTime: Story = {
+  play: async ({ canvas, mount, parameters, userEvent }) => {
+    await mount();
+    const { i18n } = parameters;
+    const once = await canvas.findByRole("radio", {
+      name: i18n.t("schedule:run_once"),
+    });
+    await userEvent.click(once);
+    await waitFor(() => {
+      const start = canvas.getByLabelText(
+        i18n.t("schedule:start_time"),
+      ) as HTMLInputElement;
+      expect(start.disabled).toBe(false);
+      expect(start.value).not.toEqual("");
+    });
+  },
+};
+
+// Switching to Run Every populates an interval too and onChange fires with
+// the encoded `<n> <unit>` string the API expects.
+export const SwitchToRunEveryEmitsInterval: Story = {
+  play: async ({ args, canvas, mount, parameters, userEvent }) => {
+    await mount();
+    const { i18n } = parameters;
+    const every = await canvas.findByRole("radio", {
+      name: i18n.t("schedule:run_every"),
+    });
+    await userEvent.click(every);
+    await waitFor(() => {
+      expect(args.onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runInterval: expect.stringMatching(/^\d+\s+(minute|hour|day)$/),
+        }),
+      );
+    });
+  },
+};
+
+// Typing into the amount input updates the runInterval on every keystroke,
+// preserving the unit. We don't care about exact intermediate calls, just
+// that the latest emitted interval starts with the new amount.
+export const EditAmountUpdatesInterval: Story = {
+  args: {
+    startTime: new Date("2024-06-15T10:30:00"),
+    runInterval: "2 hour",
+    timeZone: "UTC",
+  },
+  play: async ({ args, canvas, mount, parameters, userEvent }) => {
+    await mount();
+    const { i18n } = parameters;
+    const amount = (await canvas.findByLabelText(
+      i18n.t("schedule:run_amount"),
+    )) as HTMLInputElement;
+    await userEvent.clear(amount);
+    await userEvent.type(amount, "12");
+    await waitFor(() => {
+      expect(args.onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ runInterval: "12 hour" }),
+      );
+    });
+  },
+};
+
+// Changing the unit select preserves the count.
+export const EditUnitUpdatesInterval: Story = {
+  args: {
+    startTime: new Date("2024-06-15T10:30:00"),
+    runInterval: "5 minute",
+    timeZone: "UTC",
+  },
+  play: async ({ args, canvas, mount, parameters, userEvent }) => {
+    await mount();
+    const { i18n } = parameters;
+    const unit = (await canvas.findByLabelText(
+      i18n.t("schedule:run_unit"),
+    )) as HTMLSelectElement;
+    await userEvent.selectOptions(unit, "day");
+    await waitFor(() => {
+      expect(args.onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ runInterval: "5 day" }),
+      );
+    });
+  },
+};
+
+// Selecting Run Continuously nulls both startTime and runInterval atomically
+// — the API contract for the "always running" mode.
+export const SwitchToContinuouslyClearsBothFields: Story = {
+  args: {
+    startTime: new Date("2024-06-15T10:30:00"),
+    runInterval: "1 hour",
+    timeZone: "UTC",
+  },
+  play: async ({ args, canvas, mount, parameters, userEvent }) => {
+    await mount();
+    const { i18n } = parameters;
+    const cont = await canvas.findByRole("radio", {
+      name: i18n.t("schedule:run_continuously"),
+    });
+    await userEvent.click(cont);
+    await waitFor(() => {
+      expect(args.onChange).toHaveBeenCalledWith({
+        startTime: undefined,
+        runInterval: undefined,
+      });
+    });
+  },
+};
+
+// edit=false freezes the whole control: every radio, the start-time picker,
+// the timezone select, and the periodic amount/unit are all disabled.
+export const ReadOnly: Story = {
+  args: {
+    edit: false,
+    startTime: new Date("2024-06-15T10:30:00"),
+    runInterval: "1 hour",
+    timeZone: "UTC",
+  },
+  play: async ({ canvas, mount, parameters }) => {
+    await mount();
+    const { i18n } = parameters;
+    const cont = (await canvas.findByRole("radio", {
+      name: i18n.t("schedule:run_continuously"),
+    })) as HTMLInputElement;
+    expect(cont.disabled).toBe(true);
+    const start = canvas.getByLabelText(
+      i18n.t("schedule:start_time"),
+    ) as HTMLInputElement;
+    expect(start.disabled).toBe(true);
+    const tz = canvas.getByLabelText(i18n.t("schedule:timezone")) as HTMLSelectElement;
+    expect(tz.disabled).toBe(true);
+    const amount = canvas.getByLabelText(
+      i18n.t("schedule:run_amount"),
+    ) as HTMLInputElement;
+    expect(amount.disabled).toBe(true);
+  },
+};
+
+// Changing the timezone fires onTimeZoneChange independently of the
+// startTime/runInterval pair.
+export const EditTimezoneFiresCallback: Story = {
+  args: {
+    startTime: new Date("2024-06-15T10:30:00"),
+    runInterval: "1 hour",
+    timeZone: "UTC",
+  },
+  play: async ({ args, canvas, mount, parameters, userEvent }) => {
+    await mount();
+    const { i18n } = parameters;
+    const tz = (await canvas.findByLabelText(
+      i18n.t("schedule:timezone"),
+    )) as HTMLSelectElement;
+    // Pick whatever non-UTC option the runtime offers — Intl exposes plenty.
+    const nonUtc = Array.from(tz.options).find((o) => o.value && o.value !== "UTC");
+    if (!nonUtc) throw new Error("expected at least one non-UTC timezone option");
+    await userEvent.selectOptions(tz, nonUtc.value);
+    await waitFor(() => {
+      expect(args.onTimeZoneChange).toHaveBeenCalledWith(nonUtc.value);
+    });
+  },
+};

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/ExecutionSchedule.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/ExecutionSchedule.tsx
@@ -1,0 +1,227 @@
+import { useMemo } from "react";
+import { Col, Form, FormGroup, InputGroup, Row } from "react-bootstrap";
+import { useTranslation } from "react-i18next";
+import { TimezoneSelect } from "../decodes/routing/RoutingSelects";
+import { formatRunInterval, parseRunInterval, type RunUnit } from "./runInterval";
+
+export type RunMode = "continuously" | "once" | "every";
+
+export type StartTimeInput = Date | string | undefined;
+
+export interface ExecutionScheduleChange {
+  startTime: Date | undefined;
+  runInterval: string | undefined;
+}
+
+export interface ExecutionScheduleProps {
+  startTime: StartTimeInput;
+  runInterval: string | undefined;
+  timeZone: string | undefined;
+  edit?: boolean;
+  /**
+   * Fires with the next (startTime, runInterval) pair. Both arrive in the same
+   * change so the parent reducer can update the API record atomically — the
+   * three radio modes are encoded by the *combination* of these fields, so
+   * splitting the callback would let the parent observe an inconsistent
+   * intermediate state.
+   */
+  onChange: (next: ExecutionScheduleChange) => void;
+  onTimeZoneChange: (value: string) => void;
+}
+
+// HTML <input type="datetime-local"> requires YYYY-MM-DDTHH:mm with no tz suffix.
+const toLocalInput = (value: StartTimeInput): string => {
+  if (!value) return "";
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  );
+};
+
+const fromLocalInput = (value: string): Date | undefined => {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+};
+
+// Mirrors the legacy Swing editor: no startTime means "run continuously"; a
+// startTime with no interval means "run once"; both set means "run every".
+const deriveMode = (
+  startTime: StartTimeInput,
+  runInterval: string | undefined,
+): RunMode => {
+  if (!startTime) return "continuously";
+  return parseRunInterval(runInterval) ? "every" : "once";
+};
+
+const toDate = (value: StartTimeInput): Date | undefined => {
+  if (value === undefined) return undefined;
+  if (value instanceof Date) return value;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+};
+
+const UNITS: RunUnit[] = ["minute", "hour", "day"];
+
+export const ExecutionSchedule: React.FC<ExecutionScheduleProps> = ({
+  startTime,
+  runInterval,
+  timeZone,
+  edit = false,
+  onChange,
+  onTimeZoneChange,
+}) => {
+  const [t] = useTranslation(["schedule"]);
+
+  const mode = deriveMode(startTime, runInterval);
+  const parsed = useMemo(() => parseRunInterval(runInterval), [runInterval]);
+  // Carry the prior amount/unit forward when the user toggles modes, so
+  // re-selecting "Periodically" doesn't blank the values they had typed.
+  const count = parsed?.count ?? 1;
+  const unit: RunUnit = parsed?.unit ?? "hour";
+
+  const setMode = (next: RunMode) => {
+    if (next === "continuously") {
+      onChange({ startTime: undefined, runInterval: undefined });
+      return;
+    }
+    // Switching to "once" or "periodically" requires a start time — default to
+    // whatever the user had, falling back to "now" so the datetime-local input
+    // has something to display.
+    const baseStart = toDate(startTime) ?? new Date();
+    onChange({
+      startTime: baseStart,
+      runInterval: next === "every" ? formatRunInterval({ count, unit }) : undefined,
+    });
+  };
+
+  const setStart = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({ startTime: fromLocalInput(event.target.value), runInterval });
+  };
+
+  const setCount = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const n = Number(event.target.value);
+    const safe = Number.isFinite(n) && n >= 0 ? n : 0;
+    onChange({
+      startTime: toDate(startTime) ?? new Date(),
+      runInterval: formatRunInterval({ count: safe, unit }),
+    });
+  };
+
+  const setUnit = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextUnit = (
+      UNITS.includes(event.target.value as RunUnit) ? event.target.value : "hour"
+    ) as RunUnit;
+    onChange({
+      startTime: toDate(startTime) ?? new Date(),
+      runInterval: formatRunInterval({ count, unit: nextUnit }),
+    });
+  };
+
+  const radioName = "schedule-run-mode";
+  const startDisabled = !edit || mode === "continuously";
+  const periodicDisabled = !edit || mode !== "every";
+
+  return (
+    <fieldset className="border rounded p-3">
+      <legend className="float-none w-auto px-2 fs-6 text-muted">
+        {t("schedule:execution_schedule")}
+      </legend>
+
+      <FormGroup className="mb-2">
+        <Form.Check
+          type="radio"
+          id="run-mode-continuously"
+          name={radioName}
+          disabled={!edit}
+          checked={mode === "continuously"}
+          onChange={() => setMode("continuously")}
+          label={t("schedule:run_continuously")}
+        />
+      </FormGroup>
+      <FormGroup className="mb-2">
+        <Form.Check
+          type="radio"
+          id="run-mode-once"
+          name={radioName}
+          disabled={!edit}
+          checked={mode === "once"}
+          onChange={() => setMode("once")}
+          label={t("schedule:run_once")}
+        />
+      </FormGroup>
+      <FormGroup className="mb-3">
+        <Form.Check
+          type="radio"
+          id="run-mode-every"
+          name={radioName}
+          disabled={!edit}
+          checked={mode === "every"}
+          onChange={() => setMode("every")}
+          label={t("schedule:run_every")}
+        />
+        <div className="ps-4 pt-2" style={{ maxWidth: "20rem" }}>
+          <InputGroup size="sm">
+            <Form.Control
+              type="number"
+              min={0}
+              aria-label={t("schedule:run_amount")}
+              disabled={periodicDisabled}
+              value={parsed ? String(parsed.count) : ""}
+              onChange={setCount}
+            />
+            <Form.Select
+              aria-label={t("schedule:run_unit")}
+              disabled={periodicDisabled}
+              value={parsed ? parsed.unit : unit}
+              onChange={setUnit}
+            >
+              {UNITS.map((u) => (
+                <option key={u} value={u}>
+                  {t(`schedule:unit_${u}`)}
+                </option>
+              ))}
+            </Form.Select>
+          </InputGroup>
+        </div>
+      </FormGroup>
+
+      <FormGroup as={Row} className="mb-3">
+        <Form.Label column sm={4} htmlFor="startTime">
+          {t("schedule:start_time")}
+        </Form.Label>
+        <Col sm={8}>
+          <Form.Control
+            type="datetime-local"
+            id="startTime"
+            name="startTime"
+            readOnly={startDisabled}
+            disabled={startDisabled}
+            value={toLocalInput(startTime)}
+            onChange={setStart}
+          />
+        </Col>
+      </FormGroup>
+
+      <FormGroup as={Row} className="mb-0">
+        <Form.Label column sm={4} htmlFor="timeZone">
+          {t("schedule:timezone")}
+        </Form.Label>
+        <Col sm={8}>
+          <TimezoneSelect
+            id="timeZone"
+            value={timeZone}
+            edit={edit && mode !== "continuously"}
+            ariaLabel={t("schedule:timezone")}
+            onChange={onTimeZoneChange}
+          />
+        </Col>
+      </FormGroup>
+    </fieldset>
+  );
+};
+
+export default ExecutionSchedule;

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/RoutingSpecSelectModal.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/RoutingSpecSelectModal.stories.tsx
@@ -1,0 +1,144 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+import type { ApiRoutingRef } from "opendcs-api";
+import { expect, fn, screen, waitFor } from "storybook/test";
+import { RoutingSpecSelectModal } from "./RoutingSpecSelectModal";
+
+const ROUTING_REFS: ApiRoutingRef[] = [
+  {
+    routingId: 101,
+    name: "goes1",
+    dataSourceName: "lrgs-main",
+    destination: "directory",
+  },
+  {
+    routingId: 102,
+    name: "goes2",
+    dataSourceName: "lrgs-main",
+    destination: "directory",
+  },
+  {
+    routingId: 103,
+    name: "polltest",
+    dataSourceName: "polled-modem",
+    destination: "directory",
+  },
+];
+
+// Wrapper that mirrors how `Schedule.tsx` drives the modal: holds `show`
+// state, hides on cancel/select, and forwards the picked record to a spy.
+type WrapperProps = {
+  routings: ApiRoutingRef[];
+  loading?: boolean;
+  onSelect: (r: ApiRoutingRef) => void;
+};
+
+const RoutingSpecSelectModalDemo: React.FC<WrapperProps> = ({
+  routings,
+  loading = false,
+  onSelect,
+}) => {
+  const [show, setShow] = useState(true);
+  const handleSelect = useCallback(
+    (r: ApiRoutingRef) => {
+      onSelect(r);
+      setShow(false);
+    },
+    [onSelect],
+  );
+  return (
+    <RoutingSpecSelectModal
+      show={show}
+      onHide={() => setShow(false)}
+      onSelect={handleSelect}
+      routings={routings}
+      loading={loading}
+    />
+  );
+};
+
+const meta = {
+  component: RoutingSpecSelectModalDemo,
+  args: {
+    routings: ROUTING_REFS,
+    onSelect: fn(),
+  },
+} satisfies Meta<typeof RoutingSpecSelectModalDemo>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Default render: the modal opens with the routing list and its title shows.
+export const Default: Story = {
+  play: async ({ mount, parameters }) => {
+    await mount();
+    const { i18n } = parameters;
+    await screen.findByText(i18n.t("schedule:select_routing"));
+    expect(await screen.findByText("goes1")).toBeInTheDocument();
+    expect(await screen.findByText("goes2")).toBeInTheDocument();
+    expect(await screen.findByText("polltest")).toBeInTheDocument();
+  },
+};
+
+// Empty state: noneMessage renders instead of the chooser table.
+export const Empty: Story = {
+  args: { routings: [] },
+  play: async ({ mount, parameters }) => {
+    await mount();
+    const { i18n } = parameters;
+    expect(
+      await screen.findByText(i18n.t("schedule:select_routing_none")),
+    ).toBeInTheDocument();
+  },
+};
+
+// Loading state: showed with no data => the spinner appears.
+export const Loading: Story = {
+  args: { routings: [], loading: true },
+  play: async ({ mount }) => {
+    await mount();
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+  },
+};
+
+// Pick a routing spec — onSelect fires with the picked record, modal closes.
+export const SelectAndConfirm: Story = {
+  play: async ({ mount, args, parameters, userEvent }) => {
+    await mount();
+    const { i18n } = parameters;
+    await screen.findByText(i18n.t("schedule:select_routing"));
+    await userEvent.click(await screen.findByText("polltest"));
+    await userEvent.click(
+      screen.getByRole("button", { name: i18n.t("translation:select") }),
+    );
+    await waitFor(() =>
+      expect(args.onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ routingId: 103, name: "polltest" }),
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText(i18n.t("schedule:select_routing")),
+      ).not.toBeInTheDocument(),
+    );
+  },
+};
+
+// Cancel button closes the modal without firing onSelect.
+export const CancelClosesModal: Story = {
+  play: async ({ mount, args, parameters, userEvent }) => {
+    await mount();
+    const { i18n } = parameters;
+    await screen.findByText(i18n.t("schedule:select_routing"));
+    await userEvent.click(
+      screen.getByRole("button", { name: i18n.t("translation:cancel") }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText(i18n.t("schedule:select_routing")),
+      ).not.toBeInTheDocument(),
+    );
+    expect(args.onSelect).not.toHaveBeenCalled();
+  },
+};

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/RoutingSpecSelectModal.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/RoutingSpecSelectModal.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type { ApiRoutingRef } from "opendcs-api";
+import { SelectorModal, type ChooserColumnDef } from "../../components/data-table";
+
+interface Props {
+  show: boolean;
+  onHide: () => void;
+  onSelect: (routing: ApiRoutingRef) => void;
+  routings: ApiRoutingRef[];
+  loading?: boolean;
+}
+
+export const RoutingSpecSelectModal: React.FC<Props> = ({
+  show,
+  onHide,
+  onSelect,
+  routings,
+  loading = false,
+}) => {
+  const [t] = useTranslation(["schedule", "routing", "translation"]);
+
+  const columns: ChooserColumnDef<ApiRoutingRef>[] = useMemo(
+    () => [
+      { data: "routingId", header: t("routing:header.Id"), type: "num" },
+      { data: "name", header: t("routing:header.Name") },
+      {
+        data: "dataSourceName",
+        header: t("routing:header.DataSource"),
+        defaultContent: "",
+      },
+      {
+        data: "destination",
+        header: t("routing:header.Consumer"),
+        defaultContent: "",
+      },
+    ],
+    [t],
+  );
+
+  return (
+    <SelectorModal<ApiRoutingRef, number>
+      show={show}
+      onHide={onHide}
+      onSelect={onSelect}
+      title={t("schedule:select_routing")}
+      noneMessage={t("schedule:select_routing_none")}
+      data={routings}
+      loading={loading}
+      getId={(r) => r.routingId ?? -1}
+      columns={columns}
+    />
+  );
+};
+
+export default RoutingSpecSelectModal;

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/Schedule.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/Schedule.tsx
@@ -9,17 +9,20 @@ import {
   Placeholder,
   Row,
 } from "react-bootstrap";
-import { Save, X } from "react-bootstrap-icons";
 import { useTranslation } from "react-i18next";
 import type { ApiAppRef, ApiRoutingRef, ApiScheduleEntry } from "opendcs-api";
 import { DetailFade } from "../../components/data-table";
+import {
+  CancelButton,
+  EditFormActions,
+  INPUT_H,
+  LABEL_H,
+  SaveButton,
+} from "../../components/forms";
 import type { CancelAction, SaveAction } from "../../util/Actions";
 import { ExecutionSchedule } from "./ExecutionSchedule";
 import { RoutingSpecSelectModal } from "./RoutingSpecSelectModal";
 import { ScheduleReducer, type UiSchedule } from "./ScheduleReducer";
-
-const INPUT_H = { height: "2.25rem" };
-const LABEL_H = { height: "1rem" };
 
 const SKELETON_FIELDS = ["name", "appName", "routingSpecName", "enabled"] as const;
 
@@ -281,28 +284,20 @@ export const Schedule: React.FC<ScheduleProperties> = ({
           </Row>
 
           {edit && (
-            <Row className="mt-3">
-              <Col className="d-flex justify-content-end gap-2">
-                <Button
-                  onClick={cancel}
-                  variant="secondary"
-                  aria-label={t("schedule:cancel_for", {
-                    id: provided.schedEntryId,
-                  })}
-                >
-                  <X /> {t("translation:cancel")}
-                </Button>
-                <Button
-                  onClick={saveSchedule}
-                  variant="primary"
-                  aria-label={t("schedule:save_schedule", {
-                    id: provided.schedEntryId,
-                  })}
-                >
-                  <Save /> {t("translation:save")}
-                </Button>
-              </Col>
-            </Row>
+            <EditFormActions>
+              <CancelButton
+                onClick={cancel}
+                aria-label={t("schedule:cancel_for", {
+                  id: provided.schedEntryId,
+                })}
+              />
+              <SaveButton
+                onClick={saveSchedule}
+                aria-label={t("schedule:save_schedule", {
+                  id: provided.schedEntryId,
+                })}
+              />
+            </EditFormActions>
           )}
         </Card.Body>
       </Card>

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/Schedule.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/Schedule.tsx
@@ -1,0 +1,323 @@
+import { use, useCallback, useMemo, useReducer, useState } from "react";
+import {
+  Button,
+  Card,
+  Col,
+  Form,
+  FormGroup,
+  InputGroup,
+  Placeholder,
+  Row,
+} from "react-bootstrap";
+import { Save, X } from "react-bootstrap-icons";
+import { useTranslation } from "react-i18next";
+import type { ApiAppRef, ApiRoutingRef, ApiScheduleEntry } from "opendcs-api";
+import { DetailFade } from "../../components/data-table";
+import type { CancelAction, SaveAction } from "../../util/Actions";
+import { ExecutionSchedule } from "./ExecutionSchedule";
+import { RoutingSpecSelectModal } from "./RoutingSpecSelectModal";
+import { ScheduleReducer, type UiSchedule } from "./ScheduleReducer";
+
+const INPUT_H = { height: "2.25rem" };
+const LABEL_H = { height: "1rem" };
+
+const SKELETON_FIELDS = ["name", "appName", "routingSpecName", "enabled"] as const;
+
+export interface ScheduleSkeletonProps {
+  edit?: boolean;
+  className?: string;
+}
+
+export const ScheduleSkeleton: React.FC<ScheduleSkeletonProps> = ({
+  edit = false,
+  className,
+}) => (
+  <Card
+    className={["schedule-card", edit ? "schedule-card--edit" : null, className]
+      .filter(Boolean)
+      .join(" ")}
+  >
+    <Card.Body>
+      <Row>
+        <Col md={6}>
+          {SKELETON_FIELDS.map((field) => (
+            <Row key={field} className="mb-3 align-items-center">
+              <Placeholder as={Col} sm={4} animation="glow">
+                <Placeholder xs={10} className="rounded" style={LABEL_H} />
+              </Placeholder>
+              <Placeholder as={Col} sm={8} animation="glow">
+                <Placeholder xs={12} className="rounded" style={INPUT_H} />
+              </Placeholder>
+            </Row>
+          ))}
+        </Col>
+        <Col md={6}>
+          <Placeholder animation="glow" className="d-block">
+            <Placeholder xs={12} style={{ height: "16rem" }} />
+          </Placeholder>
+        </Col>
+      </Row>
+      {edit && (
+        <Row className="mt-3">
+          <Col className="d-flex justify-content-end gap-2">
+            <Placeholder animation="glow">
+              <Placeholder
+                className="rounded"
+                style={{ ...INPUT_H, width: "5.5rem" }}
+              />
+            </Placeholder>
+            <Placeholder animation="glow">
+              <Placeholder
+                className="rounded"
+                style={{ ...INPUT_H, width: "4.5rem" }}
+              />
+            </Placeholder>
+          </Col>
+        </Row>
+      )}
+    </Card.Body>
+  </Card>
+);
+
+export interface ScheduleDetails {
+  schedule: UiSchedule;
+}
+
+export interface ScheduleProperties {
+  details: Promise<ScheduleDetails> | ScheduleDetails;
+  apps: ApiAppRef[];
+  routings: ApiRoutingRef[];
+  routingsLoading?: boolean;
+  actions?: SaveAction<ApiScheduleEntry> & CancelAction<number>;
+  edit?: boolean;
+}
+
+export const Schedule: React.FC<ScheduleProperties> = ({
+  details,
+  apps,
+  routings,
+  routingsLoading = false,
+  actions = {},
+  edit = false,
+}) => {
+  const [t] = useTranslation(["schedule", "translation"]);
+  const resolved = details instanceof Promise ? use(details) : details;
+  const provided = resolved.schedule;
+  const [local, dispatch] = useReducer(ScheduleReducer, provided);
+  const [showRoutingModal, setShowRoutingModal] = useState(false);
+
+  const appOptions = useMemo(
+    () =>
+      apps
+        .map((a) => a.appName ?? "")
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b)),
+    [apps],
+  );
+
+  const textChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    dispatch({ type: "save", payload: { [name]: value } });
+  }, []);
+
+  const setField = useCallback(
+    <K extends keyof UiSchedule>(name: K, value: UiSchedule[K]) =>
+      dispatch({ type: "save", payload: { [name]: value } as UiSchedule }),
+    [],
+  );
+
+  const onEnabledChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) =>
+      setField("enabled", event.target.checked),
+    [setField],
+  );
+
+  const onExecutionChange = useCallback(
+    ({
+      startTime,
+      runInterval,
+    }: {
+      startTime: Date | undefined;
+      runInterval: string | undefined;
+    }) =>
+      dispatch({
+        type: "save",
+        payload: { startTime, runInterval },
+      }),
+    [],
+  );
+
+  const onSelectRouting = useCallback((ref: ApiRoutingRef) => {
+    dispatch({
+      type: "save",
+      payload: {
+        routingSpecId: ref.routingId,
+        routingSpecName: ref.name,
+      },
+    });
+  }, []);
+
+  const saveSchedule = useCallback(() => {
+    // The appName select is by name; resolve back to the API's appId before
+    // posting. The routing spec is already chosen via the modal which gives us
+    // both id and name on the local record.
+    const appRef = apps.find((a) => a.appName === local.appName);
+    actions.save?.({
+      ...local,
+      appId: appRef?.appId,
+      appName: appRef?.appName,
+    } as ApiScheduleEntry);
+  }, [actions, local, apps]);
+
+  const cancel = useCallback(() => {
+    if (provided.schedEntryId !== undefined) actions.cancel?.(provided.schedEntryId);
+  }, [actions, provided.schedEntryId]);
+
+  return (
+    <DetailFade skeleton={<ScheduleSkeleton edit={edit} />}>
+      <Card
+        className={["schedule-card", edit ? "schedule-card--edit" : null]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        <Card.Body>
+          <Row>
+            <Col md={6}>
+              <FormGroup as={Row} className="mb-3">
+                <Form.Label column sm={4} htmlFor="name">
+                  {t("schedule:name")}
+                </Form.Label>
+                <Col sm={8}>
+                  <Form.Control
+                    type="text"
+                    id="name"
+                    name="name"
+                    readOnly={!edit}
+                    defaultValue={local.name ?? ""}
+                    onChange={textChange}
+                  />
+                </Col>
+              </FormGroup>
+              <FormGroup as={Row} className="mb-3">
+                <Form.Label column sm={4} htmlFor="appName">
+                  {t("schedule:loading_app")}
+                </Form.Label>
+                <Col sm={8}>
+                  <Form.Select
+                    id="appName"
+                    aria-label={t("schedule:loading_app")}
+                    value={local.appName ?? ""}
+                    disabled={!edit}
+                    onChange={(e) => setField("appName", e.currentTarget.value)}
+                  >
+                    <option value="" />
+                    {appOptions.map((name) => (
+                      <option key={name} value={name}>
+                        {name}
+                      </option>
+                    ))}
+                  </Form.Select>
+                </Col>
+              </FormGroup>
+              <FormGroup as={Row} className="mb-3">
+                <Form.Label column sm={4} htmlFor="routingSpecName">
+                  {t("schedule:routing_spec")}
+                </Form.Label>
+                <Col sm={8}>
+                  {edit ? (
+                    <InputGroup>
+                      <Form.Control
+                        type="text"
+                        id="routingSpecName"
+                        name="routingSpecName"
+                        readOnly={true}
+                        disabled={true}
+                        value={local.routingSpecName ?? ""}
+                      />
+                      <Button
+                        variant="secondary"
+                        className="dt-button"
+                        aria-label={t("schedule:select_routing")}
+                        onClick={() => setShowRoutingModal(true)}
+                      >
+                        {t("translation:choose")}
+                      </Button>
+                    </InputGroup>
+                  ) : (
+                    <Form.Control
+                      type="text"
+                      id="routingSpecName"
+                      readOnly={true}
+                      value={local.routingSpecName ?? ""}
+                    />
+                  )}
+                </Col>
+              </FormGroup>
+              <FormGroup as={Row} className="mb-3 align-items-center">
+                <Form.Label column sm={4} htmlFor="enabled">
+                  {t("schedule:enabled")}
+                </Form.Label>
+                <Col sm={8}>
+                  <Form.Check
+                    id="enabled"
+                    name="enabled"
+                    disabled={!edit}
+                    checked={local.enabled ?? false}
+                    onChange={onEnabledChange}
+                  />
+                </Col>
+              </FormGroup>
+            </Col>
+            <Col md={6}>
+              <ExecutionSchedule
+                startTime={local.startTime}
+                runInterval={local.runInterval}
+                timeZone={local.timeZone}
+                edit={edit}
+                onChange={onExecutionChange}
+                onTimeZoneChange={(v) => setField("timeZone", v)}
+              />
+            </Col>
+          </Row>
+
+          {edit && (
+            <Row className="mt-3">
+              <Col className="d-flex justify-content-end gap-2">
+                <Button
+                  onClick={cancel}
+                  variant="secondary"
+                  aria-label={t("schedule:cancel_for", {
+                    id: provided.schedEntryId,
+                  })}
+                >
+                  <X /> {t("translation:cancel")}
+                </Button>
+                <Button
+                  onClick={saveSchedule}
+                  variant="primary"
+                  aria-label={t("schedule:save_schedule", {
+                    id: provided.schedEntryId,
+                  })}
+                >
+                  <Save /> {t("translation:save")}
+                </Button>
+              </Col>
+            </Row>
+          )}
+        </Card.Body>
+      </Card>
+      <RoutingSpecSelectModal
+        show={showRoutingModal}
+        onHide={() => setShowRoutingModal(false)}
+        onSelect={(r) => {
+          onSelectRouting(r);
+          setShowRoutingModal(false);
+        }}
+        routings={routings}
+        loading={routingsLoading}
+      />
+    </DetailFade>
+  );
+};
+
+export default Schedule;

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/ScheduleReducer.ts
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/ScheduleReducer.ts
@@ -1,0 +1,15 @@
+import type { ApiScheduleEntry } from "opendcs-api";
+
+export type UiSchedule = Partial<ApiScheduleEntry>;
+
+export type ScheduleAction = { type: "save"; payload: UiSchedule };
+
+export function ScheduleReducer(
+  current: UiSchedule,
+  action: ScheduleAction,
+): UiSchedule {
+  if (action.type === "save") {
+    return { ...current, ...action.payload };
+  }
+  return current;
+}

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/SchedulesPage.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/SchedulesPage.stories.tsx
@@ -1,0 +1,474 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { act } from "react";
+import { http, HttpResponse } from "msw";
+import type {
+  ApiAppRef,
+  ApiRoutingRef,
+  ApiScheduleEntry,
+  ApiScheduleEntryRef,
+} from "opendcs-api";
+import { expect, screen, waitFor, within } from "storybook/test";
+import { SchedulesPage } from "./SchedulesPage";
+
+const SCHEDULE_REFS: ApiScheduleEntryRef[] = [
+  {
+    schedEntryId: 9,
+    name: "goes1",
+    appName: "RoutingScheduler",
+    routingSpecName: "goes1",
+    enabled: true,
+    lastModified: new Date("2020-12-15T17:52:13.934Z"),
+  },
+  {
+    schedEntryId: 10,
+    name: "goes2",
+    appName: "RoutingScheduler",
+    routingSpecName: "goes2",
+    enabled: false,
+    lastModified: new Date("2020-12-15T17:53:06.043Z"),
+  },
+  {
+    schedEntryId: 17,
+    name: "no_app_assigned",
+    routingSpecName: "polltest",
+    enabled: false,
+    lastModified: new Date("2022-03-23T13:54:09.188Z"),
+  },
+];
+
+const FULL_SCHEDULES: Record<number, ApiScheduleEntry> = {
+  9: {
+    schedEntryId: 9,
+    name: "goes1",
+    appId: 1,
+    appName: "RoutingScheduler",
+    routingSpecId: 101,
+    routingSpecName: "goes1",
+    enabled: true,
+    startTime: new Date("2024-01-01T08:00:00Z"),
+    timeZone: "UTC",
+    runInterval: "1 hour",
+  },
+  10: {
+    schedEntryId: 10,
+    name: "goes2",
+    appId: 1,
+    appName: "RoutingScheduler",
+    routingSpecId: 102,
+    routingSpecName: "goes2",
+    enabled: false,
+    startTime: new Date("2024-02-15T12:30:00Z"),
+    timeZone: "America/New_York",
+    runInterval: "",
+  },
+  17: {
+    schedEntryId: 17,
+    name: "no_app_assigned",
+    routingSpecId: 103,
+    routingSpecName: "polltest",
+    enabled: false,
+    timeZone: "UTC",
+    runInterval: "",
+  },
+};
+
+const APP_REFS: ApiAppRef[] = [
+  { appId: 1, appName: "RoutingScheduler", appType: "routingscheduler" },
+  { appId: 2, appName: "compproc", appType: "computationprocess" },
+];
+
+const ROUTING_REFS: ApiRoutingRef[] = [
+  { routingId: 101, name: "goes1" },
+  { routingId: 102, name: "goes2" },
+  { routingId: 103, name: "polltest" },
+];
+
+const baseHandlers = {
+  scheduleRefs: http.get("/odcsapi/schedulerefs", () =>
+    HttpResponse.json<ApiScheduleEntryRef[]>(SCHEDULE_REFS),
+  ),
+  schedule: http.get("/odcsapi/schedule", ({ request }) => {
+    const url = new URL(request.url);
+    const id = Number(url.searchParams.get("scheduleid"));
+    return HttpResponse.json<ApiScheduleEntry>(
+      FULL_SCHEDULES[id] ?? { schedEntryId: id },
+    );
+  }),
+  postSchedule: http.post("/odcsapi/schedule", async () =>
+    HttpResponse.json<ApiScheduleEntry>({}),
+  ),
+  deleteSchedule: http.delete("/odcsapi/schedule", () => HttpResponse.json({})),
+  appRefs: http.get("/odcsapi/apprefs", () => HttpResponse.json<ApiAppRef[]>(APP_REFS)),
+  routingRefs: http.get("/odcsapi/routingrefs", () =>
+    HttpResponse.json<ApiRoutingRef[]>(ROUTING_REFS),
+  ),
+};
+
+const meta = {
+  component: SchedulesPage,
+} satisfies Meta<typeof SchedulesPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Default render: list comes back, all schedule entries show.
+export const Default: Story = {
+  parameters: { msw: { handlers: baseHandlers } },
+  play: async ({ mount }) => {
+    const canvas = await mount();
+    // Name and Routing Spec columns both render the entry's name when they
+    // happen to match, so each appears twice — query with All*.
+    expect((await canvas.findAllByText("goes1")).length).toBeGreaterThan(0);
+    expect((await canvas.findAllByText("goes2")).length).toBeGreaterThan(0);
+    expect(await canvas.findByText("no_app_assigned")).toBeInTheDocument();
+  },
+};
+
+// Empty state: API returns nothing — caption still renders.
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        ...baseHandlers,
+        scheduleRefs: http.get("/odcsapi/schedulerefs", () =>
+          HttpResponse.json<ApiScheduleEntryRef[]>([]),
+        ),
+      },
+    },
+  },
+  play: async ({ mount, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    expect(await canvas.findByText(i18n.t("schedule:title"))).toBeInTheDocument();
+  },
+};
+
+// Open a schedule row — detail loads, name prefilled, loading-app select and
+// routing-spec input both reflect the saved record. Routing spec is now a
+// chooser-modal trigger, so the display is a read-only text input — not a
+// <select>.
+export const OpenScheduleDetail: Story = {
+  parameters: { msw: { handlers: baseHandlers } },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    await act(async () => userEvent.click((await canvas.findAllByText("goes1"))[0]));
+    await waitFor(async () => {
+      const nameInput = (await canvas.findByLabelText(
+        i18n.t("schedule:name"),
+      )) as HTMLInputElement;
+      expect(nameInput.value).toEqual("goes1");
+    });
+    await waitFor(() => {
+      const app = canvas.getByRole("combobox", {
+        name: i18n.t("schedule:loading_app"),
+      }) as HTMLSelectElement;
+      expect(app.value).toEqual("RoutingScheduler");
+    });
+    await waitFor(() => {
+      const routing = canvas.getByLabelText(
+        i18n.t("schedule:routing_spec"),
+      ) as HTMLInputElement;
+      expect(routing.value).toEqual("goes1");
+    });
+  },
+};
+
+// Open in edit mode via the row edit-action; the Save button appears and the
+// name field becomes editable.
+export const EditMode: Story = {
+  parameters: { msw: { handlers: baseHandlers } },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:edit_schedule", { id: 9 }),
+    });
+    await act(async () => userEvent.click(editBtn));
+    await waitFor(() => {
+      expect(
+        canvas.getByRole("button", {
+          name: i18n.t("schedule:save_schedule", { id: 9 }),
+        }),
+      ).toBeInTheDocument();
+    });
+    const nameInput = canvas.getByLabelText(
+      i18n.t("schedule:name"),
+    ) as HTMLInputElement;
+    expect(nameInput.readOnly).toBe(false);
+  },
+};
+
+// Open in edit mode then cancel — the row closes and the cancel button goes away.
+export const EditAndCancel: Story = {
+  parameters: { msw: { handlers: baseHandlers } },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:edit_schedule", { id: 9 }),
+    });
+    await act(async () => userEvent.click(editBtn));
+    const cancelBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:cancel_for", { id: 9 }),
+    });
+    await act(async () => userEvent.click(cancelBtn));
+    await waitFor(() => {
+      expect(
+        canvas.queryByRole("button", {
+          name: i18n.t("schedule:cancel_for", { id: 9 }),
+        }),
+      ).not.toBeInTheDocument();
+    });
+  },
+};
+
+// The "+" header button appends a new editable schedule row.
+export const AddNewScheduleRow: Story = {
+  parameters: { msw: { handlers: baseHandlers } },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const addBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:add_schedule"),
+    });
+    await act(async () => userEvent.click(addBtn));
+    await waitFor(() => {
+      const nameInput = canvas.getByLabelText(
+        i18n.t("schedule:name"),
+      ) as HTMLInputElement;
+      expect(nameInput.value).toEqual("");
+      expect(nameInput.readOnly).toBe(false);
+    });
+  },
+};
+
+// `goes1` has both startTime and a parseable runInterval, so the editor should
+// derive the "Run Every" mode and populate the amount/unit inputs.
+export const RunEveryModeReflected: Story = {
+  parameters: { msw: { handlers: baseHandlers } },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    await act(async () => userEvent.click((await canvas.findAllByText("goes1"))[0]));
+    await waitFor(() => {
+      const every = canvas.getByRole("radio", {
+        name: i18n.t("schedule:run_every"),
+      }) as HTMLInputElement;
+      expect(every.checked).toBe(true);
+    });
+    const amount = canvas.getByLabelText(
+      i18n.t("schedule:run_amount"),
+    ) as HTMLInputElement;
+    expect(amount.value).toEqual("1");
+    const unit = canvas.getByLabelText(
+      i18n.t("schedule:run_unit"),
+    ) as HTMLSelectElement;
+    expect(unit.value).toEqual("hour");
+  },
+};
+
+// `goes2` has a startTime but no runInterval — "Run Once" mode. The amount
+// and unit selects should be disabled but the start-time picker stays
+// enabled (once the user opens for edit).
+export const RunOnceModeReflected: Story = {
+  parameters: { msw: { handlers: baseHandlers } },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:edit_schedule", { id: 10 }),
+    });
+    await act(async () => userEvent.click(editBtn));
+    await waitFor(() => {
+      const once = canvas.getByRole("radio", {
+        name: i18n.t("schedule:run_once"),
+      }) as HTMLInputElement;
+      expect(once.checked).toBe(true);
+    });
+    const start = canvas.getByLabelText(
+      i18n.t("schedule:start_time"),
+    ) as HTMLInputElement;
+    expect(start.disabled).toBe(false);
+    const amount = canvas.getByLabelText(
+      i18n.t("schedule:run_amount"),
+    ) as HTMLInputElement;
+    expect(amount.disabled).toBe(true);
+  },
+};
+
+// `no_app_assigned` has neither startTime nor runInterval — "Run Continuously"
+// mode. Start time and timezone are disabled because they have no effect.
+export const RunContinuouslyModeReflected: Story = {
+  parameters: { msw: { handlers: baseHandlers } },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:edit_schedule", { id: 17 }),
+    });
+    await act(async () => userEvent.click(editBtn));
+    await waitFor(() => {
+      const cont = canvas.getByRole("radio", {
+        name: i18n.t("schedule:run_continuously"),
+      }) as HTMLInputElement;
+      expect(cont.checked).toBe(true);
+    });
+    const start = canvas.getByLabelText(
+      i18n.t("schedule:start_time"),
+    ) as HTMLInputElement;
+    expect(start.disabled).toBe(true);
+    const tz = canvas.getByLabelText(i18n.t("schedule:timezone")) as HTMLSelectElement;
+    expect(tz.disabled).toBe(true);
+  },
+};
+
+// Editing a continuously-mode entry and selecting "Run Every" populates a
+// default start time (the input is no longer empty), enables the amount and
+// unit selects, and re-enables the timezone select.
+export const SwitchToRunEveryEnablesControls: Story = {
+  parameters: { msw: { handlers: baseHandlers } },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:edit_schedule", { id: 17 }),
+    });
+    await act(async () => userEvent.click(editBtn));
+    const every = await canvas.findByRole("radio", {
+      name: i18n.t("schedule:run_every"),
+    });
+    await act(async () => userEvent.click(every));
+    await waitFor(() => {
+      const amount = canvas.getByLabelText(
+        i18n.t("schedule:run_amount"),
+      ) as HTMLInputElement;
+      expect(amount.disabled).toBe(false);
+    });
+    const start = canvas.getByLabelText(
+      i18n.t("schedule:start_time"),
+    ) as HTMLInputElement;
+    expect(start.disabled).toBe(false);
+    expect(start.value).not.toEqual("");
+    const tz = canvas.getByLabelText(i18n.t("schedule:timezone")) as HTMLSelectElement;
+    expect(tz.disabled).toBe(false);
+  },
+};
+
+// Picking a routing spec via the modal updates the read-only display field.
+// Use the entry that already has `polltest` selected and switch it to `goes1`.
+export const PickRoutingSpecViaModal: Story = {
+  parameters: { msw: { handlers: baseHandlers } },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:edit_schedule", { id: 17 }),
+    });
+    await act(async () => userEvent.click(editBtn));
+    const chooseBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:select_routing"),
+    });
+    await act(async () => userEvent.click(chooseBtn));
+    // Modal portals to the body — query via the global screen.
+    const dialog = await screen.findByRole("dialog");
+    const row = await within(dialog).findByText("goes1");
+    await act(async () => userEvent.click(row));
+    const select = await within(dialog).findByRole("button", {
+      name: i18n.t("translation:select"),
+    });
+    await act(async () => userEvent.click(select));
+    await waitFor(() => {
+      const routing = canvas.getByLabelText(
+        i18n.t("schedule:routing_spec"),
+      ) as HTMLInputElement;
+      expect(routing.value).toEqual("goes1");
+    });
+  },
+};
+
+// Saving a row posts back to the API with the new mode encoded into the
+// startTime/runInterval pair. Open `goes1` in edit mode, switch to Run
+// Continuously, save, and assert the POST captured both fields as null/empty
+// (the Run Continuously contract) and the row collapsed back to show mode.
+export const SaveContinuouslyClearsScheduleFields: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        ...baseHandlers,
+        postSchedule: http.post("/odcsapi/schedule", async ({ request }) => {
+          const body = (await request.json()) as Partial<ApiScheduleEntry>;
+          (
+            globalThis as unknown as { __lastSchedulePost?: typeof body }
+          ).__lastSchedulePost = body;
+          return HttpResponse.json<ApiScheduleEntry>({});
+        }),
+      },
+    },
+  },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:edit_schedule", { id: 9 }),
+    });
+    await act(async () => userEvent.click(editBtn));
+    const cont = await canvas.findByRole("radio", {
+      name: i18n.t("schedule:run_continuously"),
+    });
+    await act(async () => userEvent.click(cont));
+    const saveBtn = canvas.getByRole("button", {
+      name: i18n.t("schedule:save_schedule", { id: 9 }),
+    });
+    await act(async () => userEvent.click(saveBtn));
+    // Row collapses back to show mode after the save settles.
+    await waitFor(() => {
+      expect(
+        canvas.queryByRole("button", {
+          name: i18n.t("schedule:save_schedule", { id: 9 }),
+        }),
+      ).not.toBeInTheDocument();
+    });
+    const captured = (
+      globalThis as unknown as { __lastSchedulePost?: Partial<ApiScheduleEntry> }
+    ).__lastSchedulePost;
+    expect(captured).toBeDefined();
+    expect(captured?.startTime ?? null).toBeNull();
+    expect(captured?.runInterval ?? null).toBeNull();
+  },
+};
+
+// Deleting a schedule fires the DELETE and the row drops out after the refetch.
+export const DeleteScheduleRow: Story = {
+  parameters: {
+    msw: {
+      handlers: (() => {
+        const list = [...SCHEDULE_REFS];
+        return {
+          ...baseHandlers,
+          scheduleRefs: http.get("/odcsapi/schedulerefs", () =>
+            HttpResponse.json<ApiScheduleEntryRef[]>(list),
+          ),
+          deleteSchedule: http.delete("/odcsapi/schedule", ({ request }) => {
+            const url = new URL(request.url);
+            const id = Number(url.searchParams.get("scheduleid"));
+            const idx = list.findIndex((s) => s.schedEntryId === id);
+            if (idx >= 0) list.splice(idx, 1);
+            return HttpResponse.json({});
+          }),
+        };
+      })(),
+    },
+  },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    expect((await canvas.findAllByText("goes2")).length).toBeGreaterThan(0);
+    const deleteBtn = await canvas.findByRole("button", {
+      name: i18n.t("schedule:delete_for", { id: 10 }),
+    });
+    await act(async () => userEvent.click(deleteBtn));
+    await waitFor(() => expect(canvas.queryAllByText("goes2")).toHaveLength(0));
+  },
+};

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/SchedulesPage.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/SchedulesPage.tsx
@@ -1,0 +1,39 @@
+import { SchedulesTable } from "./SchedulesTable";
+import {
+  useDeleteScheduleMutation,
+  useFetchSchedule,
+  useSaveScheduleMutation,
+  useScheduleRefsQuery,
+} from "../../queries/scheduleEntries";
+import { useAppRefsQuery } from "../../queries/apps";
+import { useRoutingsQuery } from "../../queries/routing";
+
+export const SchedulesPage: React.FC = () => {
+  const { data: schedules = [], isFetching } = useScheduleRefsQuery();
+  const { data: apps = [] } = useAppRefsQuery();
+  const { data: routings = [], isFetching: routingsFetching } = useRoutingsQuery();
+  const fetchSchedule = useFetchSchedule();
+  const saveSchedule = useSaveScheduleMutation();
+  const deleteSchedule = useDeleteScheduleMutation();
+
+  return (
+    <div className="content">
+      <SchedulesTable
+        schedules={schedules}
+        apps={apps}
+        routings={routings}
+        routingsLoading={routingsFetching}
+        loading={isFetching}
+        getSchedule={fetchSchedule}
+        actions={{
+          save: async (schedule) => {
+            await saveSchedule.mutateAsync(schedule);
+          },
+          remove: (schedEntryId) => deleteSchedule.mutate(schedEntryId),
+        }}
+      />
+    </div>
+  );
+};
+
+export default SchedulesPage;

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/SchedulesTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/SchedulesTable.tsx
@@ -1,0 +1,157 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type {
+  ApiAppRef,
+  ApiRoutingRef,
+  ApiScheduleEntry,
+  ApiScheduleEntryRef,
+} from "opendcs-api";
+import Schedule, { ScheduleSkeleton, type ScheduleDetails } from "./Schedule";
+import type { UiSchedule } from "./ScheduleReducer";
+import type { RemoveAction, SaveAction } from "../../util/Actions";
+import {
+  AppDataTable,
+  type ColumnDef,
+  type RowAction,
+} from "../../components/data-table";
+
+export type TableScheduleRef = Partial<ApiScheduleEntryRef>;
+
+export interface SchedulesTableProperties {
+  schedules: TableScheduleRef[];
+  apps: ApiAppRef[];
+  routings: ApiRoutingRef[];
+  routingsLoading?: boolean;
+  getSchedule?: (schedEntryId: number) => Promise<ApiScheduleEntry>;
+  actions?: SaveAction<ApiScheduleEntry> & RemoveAction<number>;
+  loading?: boolean;
+}
+
+export const SchedulesTable: React.FC<SchedulesTableProperties> = ({
+  schedules,
+  apps,
+  routings,
+  routingsLoading = false,
+  getSchedule,
+  actions = {},
+  loading = false,
+}) => {
+  const [t] = useTranslation(["schedule", "translation"]);
+
+  const columns = useMemo<ColumnDef<TableScheduleRef>[]>(
+    () => [
+      {
+        data: "schedEntryId",
+        header: t("schedule:header.Id"),
+        defaultContent: "new",
+        className: "dt-left",
+        type: "num",
+      },
+      { data: "name", header: t("schedule:header.Name"), type: "string" },
+      {
+        data: "appName",
+        header: t("schedule:header.LoadingApp"),
+        defaultContent: "",
+        type: "string",
+      },
+      {
+        data: "routingSpecName",
+        header: t("schedule:header.RoutingSpec"),
+        defaultContent: "",
+        type: "string",
+      },
+      {
+        data: "enabled",
+        header: t("schedule:header.Enabled"),
+        defaultContent: "",
+        className: "dt-center",
+        type: "num",
+        render: (data: unknown, type: string) => {
+          const enabled = Boolean(data);
+          if (type !== "display") return enabled ? 1 : 0;
+          return enabled ? "✓" : "";
+        },
+      },
+      {
+        data: "lastModified",
+        header: t("schedule:header.LastModified"),
+        defaultContent: "",
+        type: "date",
+        render: (data: unknown, type: string) => {
+          if (type !== "display") return data;
+          if (!data) return "";
+          const d = data instanceof Date ? data : new Date(data as string);
+          return Number.isNaN(d.getTime()) ? "" : d.toLocaleString();
+        },
+      },
+    ],
+    [t],
+  );
+
+  const rowActions = useMemo<RowAction<TableScheduleRef>[]>(
+    () => [
+      {
+        key: "edit",
+        icon: "bi-pencil",
+        variant: "warning",
+        aria: (row) => t("schedule:edit_schedule", { id: row.schedEntryId }),
+        onClick: ({ row, api }) => api.setMode(row, "edit"),
+      },
+      {
+        key: "delete",
+        icon: "bi-trash",
+        variant: "danger",
+        show: (row) => (row.schedEntryId ?? 0) > 0,
+        aria: (row) => t("schedule:delete_for", { id: row.schedEntryId }),
+        onClick: ({ row }) => {
+          if (row.schedEntryId !== undefined) actions.remove?.(row.schedEntryId);
+        },
+      },
+    ],
+    [t, actions],
+  );
+
+  return (
+    <AppDataTable<TableScheduleRef, number, ApiScheduleEntry>
+      data={schedules}
+      loading={loading}
+      getId={(s) => s.schedEntryId!}
+      columns={columns}
+      actionsLabel={t("translation:actions")}
+      rowActions={rowActions}
+      renderDetail={({ row, mode, actions: detailActions }) => {
+        const detailsPromise: Promise<ScheduleDetails> =
+          row.schedEntryId && row.schedEntryId > 0 && getSchedule
+            ? getSchedule(row.schedEntryId).then((schedule) => ({ schedule }))
+            : Promise.resolve({
+                schedule: { schedEntryId: row.schedEntryId } as UiSchedule,
+              });
+        return (
+          <Schedule
+            details={detailsPromise}
+            apps={apps}
+            routings={routings}
+            routingsLoading={routingsLoading}
+            actions={{
+              save: (s) => detailActions.save(s),
+              cancel: () => detailActions.cancel(),
+            }}
+            edit={mode !== "show"}
+          />
+        );
+      }}
+      renderSkeleton={({ mode }) => (
+        <ScheduleSkeleton edit={mode !== "show"} className="child-row-opening" />
+      )}
+      addNew={{
+        template: (id) => ({ schedEntryId: id, enabled: false }),
+        ariaLabel: t("schedule:add_schedule"),
+      }}
+      onSave={actions.save}
+      caption={t("schedule:title")}
+      tableId="schedulesTable"
+    />
+  );
+};
+
+export default SchedulesTable;

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/index.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/index.tsx
@@ -1,0 +1,4 @@
+export { SchedulesPage as Schedules } from "./SchedulesPage";
+export { SchedulesPage } from "./SchedulesPage";
+export { SchedulesTable } from "./SchedulesTable";
+export { Schedule as ScheduleDetail } from "./Schedule";

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/runInterval.test.ts
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/runInterval.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { formatRunInterval, parseRunInterval } from "./runInterval";
+
+// The Swing dbeditor emits `"<n> minute|hour|day"` (singular) but
+// `IntervalIncrement.parse` accepts singular and plural forms — these tests
+// pin that contract so the React component stays interoperable with records
+// written by either editor.
+
+describe("parseRunInterval", () => {
+  test("accepts the Swing singular form", () => {
+    expect(parseRunInterval("5 minute")).toEqual({ count: 5, unit: "minute" });
+    expect(parseRunInterval("2 hour")).toEqual({ count: 2, unit: "hour" });
+    expect(parseRunInterval("1 day")).toEqual({ count: 1, unit: "day" });
+  });
+
+  test("accepts the plural form the parser also produces", () => {
+    expect(parseRunInterval("15 minutes")).toEqual({ count: 15, unit: "minute" });
+    expect(parseRunInterval("3 hours")).toEqual({ count: 3, unit: "hour" });
+    expect(parseRunInterval("7 days")).toEqual({ count: 7, unit: "day" });
+  });
+
+  test("is case-insensitive and tolerates extra whitespace", () => {
+    expect(parseRunInterval("  10   HOURS  ")).toEqual({ count: 10, unit: "hour" });
+    expect(parseRunInterval("4Min")).toEqual({ count: 4, unit: "minute" });
+  });
+
+  test("returns null for empty, junk, or unknown-unit values", () => {
+    expect(parseRunInterval(undefined)).toBeNull();
+    expect(parseRunInterval("")).toBeNull();
+    expect(parseRunInterval("   ")).toBeNull();
+    expect(parseRunInterval("hour")).toBeNull();
+    expect(parseRunInterval("5 fortnights")).toBeNull();
+    expect(parseRunInterval("-3 hour")).toBeNull();
+  });
+});
+
+describe("formatRunInterval", () => {
+  test("round-trips through parseRunInterval", () => {
+    const original = "12 hours";
+    const parsed = parseRunInterval(original);
+    expect(parsed).not.toBeNull();
+    if (!parsed) return;
+    const formatted = formatRunInterval(parsed);
+    expect(formatted).toBe("12 hour");
+    // Parsing the formatted form yields the same structured value.
+    expect(parseRunInterval(formatted)).toEqual(parsed);
+  });
+});

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/runInterval.ts
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/runInterval.ts
@@ -1,0 +1,45 @@
+// Run-interval parsing for the schedule entry editor.
+//
+// The Swing dbeditor emits intervals as `<count> <unit>` strings, where unit
+// is the singular form `minute`, `hour`, or `day`. `IntervalIncrement.parse`
+// on the Java side accepts both singular and plural forms (and matches case-
+// insensitively), so the parser here is correspondingly forgiving and
+// serialization stays compatible with the legacy editor.
+
+export type RunUnit = "minute" | "hour" | "day";
+
+export interface RunIntervalParts {
+  count: number;
+  unit: RunUnit;
+}
+
+const UNIT_ALIASES: Record<string, RunUnit> = {
+  minute: "minute",
+  minutes: "minute",
+  min: "minute",
+  mins: "minute",
+  hour: "hour",
+  hours: "hour",
+  hr: "hour",
+  hrs: "hour",
+  day: "day",
+  days: "day",
+};
+
+export const parseRunInterval = (
+  value: string | undefined,
+): RunIntervalParts | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const match = /^(\d+)\s*([A-Za-z]+)$/.exec(trimmed);
+  if (!match) return null;
+  const count = Number(match[1]);
+  if (!Number.isFinite(count) || count < 0) return null;
+  const unit = UNIT_ALIASES[match[2].toLowerCase()];
+  if (!unit) return null;
+  return { count, unit };
+};
+
+export const formatRunInterval = (parts: RunIntervalParts): string =>
+  `${parts.count} ${parts.unit}`;

--- a/javascript/opendcs-web-ui-react/src/queries/keys.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/keys.ts
@@ -90,6 +90,13 @@ export const intervalKeys = {
   list: (org: string) => [...intervalKeys.all(org), "list"] as const,
 };
 
+export const scheduleKeys = {
+  all: (org: string) => ["schedules", org] as const,
+  list: (org: string) => [...scheduleKeys.all(org), "list"] as const,
+  detail: (org: string, schedEntryId: number) =>
+    [...scheduleKeys.all(org), "detail", schedEntryId] as const,
+};
+
 // Org list is global (not scoped to an org) — it's the source of truth that
 // drives the org switcher itself.
 export const orgKeys = {

--- a/javascript/opendcs-web-ui-react/src/queries/scheduleEntries.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/scheduleEntries.ts
@@ -1,0 +1,86 @@
+import { useMemo } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationOptions,
+} from "@tanstack/react-query";
+import {
+  RESTScheduleEntryMethodsApi,
+  type ApiScheduleEntry,
+  type ApiScheduleEntryRef,
+} from "opendcs-api";
+import { useApi } from "../contexts/app/ApiContext";
+import { scheduleKeys } from "./keys";
+
+const useScheduleApi = () => {
+  const api = useApi();
+  const scheduleApi = useMemo(
+    () => new RESTScheduleEntryMethodsApi(api.conf),
+    [api.conf],
+  );
+  return { scheduleApi, org: api.org };
+};
+
+export const useScheduleRefsQuery = () => {
+  const { scheduleApi, org } = useScheduleApi();
+  return useQuery<ApiScheduleEntryRef[]>({
+    queryKey: scheduleKeys.list(org),
+    queryFn: () => scheduleApi.getScheduleRefs(org),
+  });
+};
+
+export const useScheduleQuery = (schedEntryId: number | undefined) => {
+  const { scheduleApi, org } = useScheduleApi();
+  return useQuery<ApiScheduleEntry>({
+    queryKey: scheduleKeys.detail(org, schedEntryId ?? -1),
+    queryFn: () => scheduleApi.getSchedule(org, schedEntryId!),
+    enabled: schedEntryId !== undefined && schedEntryId > 0,
+  });
+};
+
+// Imperative variant for renderDetail callers feeding React 19's `use()`.
+// Reads from cache when fresh, falls back to network otherwise.
+export const useFetchSchedule = () => {
+  const { scheduleApi, org } = useScheduleApi();
+  const queryClient = useQueryClient();
+  return (schedEntryId: number) =>
+    queryClient.fetchQuery<ApiScheduleEntry>({
+      queryKey: scheduleKeys.detail(org, schedEntryId),
+      queryFn: () => scheduleApi.getSchedule(org, schedEntryId),
+    });
+};
+
+export const useSaveScheduleMutation = (
+  options?: Omit<UseMutationOptions<unknown, unknown, ApiScheduleEntry>, "mutationFn">,
+) => {
+  const { scheduleApi, org } = useScheduleApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (entry: ApiScheduleEntry) => {
+      const schedEntryId =
+        entry.schedEntryId && entry.schedEntryId > 0 ? entry.schedEntryId : undefined;
+      return scheduleApi.postSchedule(org, { ...entry, schedEntryId });
+    },
+    ...options,
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: scheduleKeys.all(org) });
+      options?.onSuccess?.(...args);
+    },
+  });
+};
+
+export const useDeleteScheduleMutation = (
+  options?: Omit<UseMutationOptions<unknown, unknown, number>, "mutationFn">,
+) => {
+  const { scheduleApi, org } = useScheduleApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (schedEntryId: number) => scheduleApi.deleteSchedule(org, schedEntryId),
+    ...options,
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: scheduleKeys.all(org) });
+      options?.onSuccess?.(...args);
+    },
+  });
+};

--- a/javascript/opendcs-web-ui-react/vite.config.ts
+++ b/javascript/opendcs-web-ui-react/vite.config.ts
@@ -77,6 +77,10 @@ export default defineConfig({
     },
   },
   test: {
+    // Hide console output from passing tests; still show it for failures so
+    // debugging context is preserved. Must live at the root test config — the
+    // reporter reads `silent` from ctx.config, not per-project settings.
+    silent: "passed-only",
     coverage: {
       enabled: true, // Ensure coverage is enabled
       provider: "istanbul", // Use 'istanbul' as the provider for LCOV output


### PR DESCRIPTION
## Problem Description

Add the schedule entries page to the react UI and set Vite test to only print on failed tests

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
