### PR TITLE
Update usgs-waterdata-api dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ monolith = { strictly = "7.0.5" }
 cwms-ratings = "1.1.0"
 nucleus = "4.10.0"
 flogger = "0.7.4"  # used by hec-monolith
-usgs-waterdata-api = "0.2.5"
+usgs-waterdata-api = "0.3.3"
 jdbi = "3.53.0"
 flywaydb = "11.20.1"
 sun-mailapi="2.0.2"
@@ -174,7 +174,7 @@ hec-nucleus-bom = { module = "mil.army.usace.hec:hec-nucleus-bom", version.ref =
 hec-nucleus-metadata = { module = "mil.army.usace.hec:hec-nucleus-metadata" }
 hec-nucleus-data = { module = "mil.army.usace.hec:hec-nucleus-data" }
 com-google-flogger = { module = "com.google.flogger:flogger", version.ref = "flogger" }
-usgs-waterdata-api = { module = "io.github.ktarbet:usgs-waterdata-api", version.ref = "usgs-waterdata-api" }
+usgs-waterdata-api = { module = "org.opendcs:usgs-waterdata-api", version.ref = "usgs-waterdata-api" }
 
 # test deps
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }

--- a/java/opendcs/src/main/java/decodes/datasource/UsgsWaterDataAdapter.java
+++ b/java/opendcs/src/main/java/decodes/datasource/UsgsWaterDataAdapter.java
@@ -32,12 +32,12 @@ import decodes.db.PlatformSensor;
 import ilex.util.TextUtil;
 import ilex.var.TimedVariable;
 import ilex.var.Variable;
-import ktarbet.usgs.waterdata.DailyValue;
-import ktarbet.usgs.waterdata.InstantaneousValue;
-import ktarbet.usgs.waterdata.TimeSeriesFilter;
-import ktarbet.usgs.waterdata.TimeSeriesMetadata;
-import ktarbet.usgs.waterdata.TimeSeries;
-import ktarbet.usgs.waterdata.UsgsWaterDataApi;
+import org.opendcs.usgs.waterdata.DailyValue;
+import org.opendcs.usgs.waterdata.InstantaneousValue;
+import org.opendcs.usgs.waterdata.TimeSeriesFilter;
+import org.opendcs.usgs.waterdata.TimeSeriesMetadata;
+import org.opendcs.usgs.waterdata.TimeSeries;
+import org.opendcs.usgs.waterdata.UsgsWaterDataApi;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
 

--- a/java/opendcs/src/test/java/decodes/datasource/UsgsWaterDataAdapterTest.java
+++ b/java/opendcs/src/test/java/decodes/datasource/UsgsWaterDataAdapterTest.java
@@ -31,10 +31,10 @@ import decodes.db.Platform;
 import decodes.db.PlatformConfig;
 import decodes.db.PlatformSensor;
 import ilex.var.TimedVariable;
-import ktarbet.usgs.waterdata.Parameter;
-import ktarbet.usgs.waterdata.Statistic;
-import ktarbet.usgs.waterdata.TestSite;
-import ktarbet.usgs.waterdata.TimeSeriesMetadata;
+import org.opendcs.usgs.waterdata.Parameter;
+import org.opendcs.usgs.waterdata.Statistic;
+import org.opendcs.usgs.waterdata.TestSite;
+import org.opendcs.usgs.waterdata.TimeSeriesMetadata;
 
 /**
  * Tests for {@link UsgsWaterDataAdapter} using the in-memory


### PR DESCRIPTION
This update allows USGS queries to overcome the 50,000 timestamp limit, by chunking longer time-ranges into parts.

ref: https://github.com/opendcs/opendcs/pull/1880

tag: @agilmore2 

