### PR TITLE
update OpenDcs gradle plugin to 1.0.0-M13

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,7 +10,7 @@ repositories {
 
 
 dependencies {
-    implementation 'org.opendcs.testing:gradle-plugin:1.0.0-M11'
+    implementation 'org.opendcs.testing:gradle-plugin:1.0.0-M13'
     implementation 'com.palantir.git-version:com.palantir.git-version.gradle.plugin:4.3.0'
 
     implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8'


### PR DESCRIPTION
Resolves a Github security warning