### PR TITLE
Use a map for setting instances so we don't keep expanding input para…

### DIFF
--- a/java/cwms-implementation/src/main/java/decodes/cwms/database/CwmsOracleProvider.java
+++ b/java/cwms-implementation/src/main/java/decodes/cwms/database/CwmsOracleProvider.java
@@ -38,6 +38,7 @@ import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.database.dai.IdentityProviderDao;
 import org.opendcs.database.dai.RolesDao;
+import org.opendcs.database.DatabaseQuerySettings;
 import org.opendcs.database.impl.cwms.dao.auth.CwmsIdentityProviderDaoImpl;
 import org.opendcs.database.impl.cwms.dao.auth.CwmsRolesDaoImpl;
 import org.opendcs.database.impl.cwms.jdbi.CwmsBoolean;
@@ -131,7 +132,7 @@ public class CwmsOracleProvider implements MigrationProvider
     @Override
     public void createUser(Jdbi jdbi, String username, String password, List<String> roles)
     {
-        final var context = new TransactionContextImpl(null, null, DatabaseEngine.POSTGRES, new CwmsDatabaseQuerySettings());
+        final var context = new TransactionContextImpl(null, Map.of(DatabaseQuerySettings.class, new CwmsDatabaseQuerySettings()), DatabaseEngine.POSTGRES);
         jdbi.useTransaction(h ->
         {
             var tx = new JdbiTransaction(h, context);

--- a/java/opendcs-implementation/src/main/java/opendcs/opentsdb/OpenTsdbProvider.java
+++ b/java/opendcs-implementation/src/main/java/opendcs/opentsdb/OpenTsdbProvider.java
@@ -1,5 +1,6 @@
 package opendcs.opentsdb;
 
+import java.util.Map;
 import java.util.Properties;
 
 import javax.sql.DataSource;
@@ -57,7 +58,7 @@ public class OpenTsdbProvider implements DatabaseProvider
     {
         Database decodesDb = getDecodesDatabase(dataSource, settings);
         OpenTsdb tsDb = new OpenTsdb(appName, dataSource, settings);
-        var db = new SimpleOpenDcsDatabaseWrapper(settings, decodesDb, tsDb, dataSource, DatabaseQuerySettings.DEFAULT_SETTINGS);
+        var db = new SimpleOpenDcsDatabaseWrapper(Map.of(DecodesSettings.class, settings, DatabaseQuerySettings.class, DatabaseQuerySettings.DEFAULT_SETTINGS), decodesDb, tsDb, dataSource);
         tsDb.setDcsDatabase(db);
         Database.setDb(decodesDb);
         try

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/OpenDcsPgProvider.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/OpenDcsPgProvider.java
@@ -116,7 +116,7 @@ public class OpenDcsPgProvider implements MigrationProvider
     @Override
     public void createUser(Jdbi jdbi, String username, String password, List<String> roles)
     {
-        final var context = new TransactionContextImpl(null, null, DatabaseEngine.POSTGRES, DatabaseQuerySettings.DEFAULT_SETTINGS);
+        final var context = new TransactionContextImpl(null, Map.of(DatabaseQuerySettings.class, DatabaseQuerySettings.DEFAULT_SETTINGS), DatabaseEngine.POSTGRES);
         jdbi.useTransaction(h ->
         {
             var tx = new JdbiTransaction(h, context);

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsDatabaseProvider.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsDatabaseProvider.java
@@ -1,10 +1,12 @@
 package decodes.cwms;
 
+import java.util.Map;
 import java.util.Properties;
 
 import javax.sql.DataSource;
 
 import org.opendcs.database.api.OpenDcsDatabase;
+import org.opendcs.database.DatabaseQuerySettings;
 import org.opendcs.database.SimpleOpenDcsDatabaseWrapper;
 import org.opendcs.spi.database.DatabaseProvider;
 
@@ -57,7 +59,7 @@ public class CwmsDatabaseProvider implements DatabaseProvider
             Database.setDb(decodesDb); // the CwmsSqlDatabaseIO constructor calls into the Database instance to verify things.
             decodesDb.setDbIo(new CwmsSqlDatabaseIO(dataSource, settings));
             CwmsTimeSeriesDb tsdb = new CwmsTimeSeriesDb(null, dataSource, settings);
-            var db = new SimpleOpenDcsDatabaseWrapper(settings, decodesDb, tsdb, dataSource, new CwmsDatabaseQuerySettings());
+            var db = new SimpleOpenDcsDatabaseWrapper(Map.of(DecodesSettings.class, settings, DatabaseQuerySettings.class, new CwmsDatabaseQuerySettings()), decodesDb, tsdb, dataSource);
             ((SqlDatabaseIO)decodesDb.getDbIo()).setDcsDatabase(db);
             decodesDb.init(settings);
             tsdb.setDcsDatabase(db);

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsLocationLevelDAO.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsLocationLevelDAO.java
@@ -4,10 +4,12 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import opendcs.dao.DatabaseConnectionOwner;
 import opendcs.dao.DaoHelper;
 import org.opendcs.database.dai.SiteReferenceMetaData;
+import org.opendcs.database.DatabaseQuerySettings;
 import org.opendcs.database.SimpleTransaction;
 import org.opendcs.database.TransactionContextImpl;
 import org.opendcs.database.api.DataTransaction;
@@ -101,9 +103,9 @@ public class CwmsLocationLevelDAO extends DaoBase implements SiteReferenceMetaDa
         {
             return new SimpleTransaction(db.getConnection(),
                                          new TransactionContextImpl(db.getKeyGenerator(),
-                                         DecodesSettings.instance(),
+                                         Map.of(DecodesSettings.class, DecodesSettings.instance(), DatabaseQuerySettings.class, new CwmsDatabaseQuerySettings()),
                                          db.isOracle() ? DatabaseEngine.ORACLE : DatabaseEngine.POSTGRES
-                                        , new CwmsDatabaseQuerySettings()));
+                                        ));
         }
         catch (SQLException ex)
         {

--- a/java/opendcs/src/main/java/decodes/xml/jdbc/XmlOpenDcsDatabaseWrapper.java
+++ b/java/opendcs/src/main/java/decodes/xml/jdbc/XmlOpenDcsDatabaseWrapper.java
@@ -1,6 +1,7 @@
 package decodes.xml.jdbc;
 
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Optional;
 
 import javax.sql.DataSource;
@@ -26,7 +27,7 @@ public final class XmlOpenDcsDatabaseWrapper extends SimpleOpenDcsDatabaseWrappe
 
     public XmlOpenDcsDatabaseWrapper(DecodesSettings settings, Database decodesDb, TimeSeriesDb tsDb, DataSource ds)
     {
-        super(settings, decodesDb, tsDb, ds, null);
+        super(Map.of(DecodesSettings.class, settings), decodesDb, tsDb, ds);
         enumCache = new DbObjectCache<>(1800_000L, false);
     }
 
@@ -51,7 +52,7 @@ public final class XmlOpenDcsDatabaseWrapper extends SimpleOpenDcsDatabaseWrappe
         try
         {
             return new SimpleTransaction(this.dataSource.getConnection(),
-                                         new TransactionContextImpl(keyGenerator, settings, dbEngine, querySettings));
+                                         new TransactionContextImpl(keyGenerator, settingsMap, dbEngine));
         }
         catch (SQLException ex)
         {

--- a/java/opendcs/src/main/java/opendcs/dao/EnumSqlDao.java
+++ b/java/opendcs/src/main/java/opendcs/dao/EnumSqlDao.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.jdbi.v3.core.Jdbi;
@@ -81,8 +82,8 @@ public class EnumSqlDao extends DaoBase implements EnumDAI
             return new JdbiTransaction(Jdbi.open(db.getConnection())
                                            .registerArgument(new DatabaseKeyArgumentFactory())
                                            .registerColumnMapper(new DatabaseKeyColumnMapper()),
-                                     new TransactionContextImpl(db.getKeyGenerator(), DecodesSettings.instance(),
-                                         db.isOracle() ? DatabaseEngine.ORACLE : DatabaseEngine.POSTGRES, null));
+                                     new TransactionContextImpl(db.getKeyGenerator(), Map.of(DecodesSettings.class, DecodesSettings.instance()),
+                                         db.isOracle() ? DatabaseEngine.ORACLE : DatabaseEngine.POSTGRES));
         }
         catch (SQLException ex)
         {

--- a/java/opendcs/src/main/java/org/opendcs/database/SimpleOpenDcsDatabaseWrapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/SimpleOpenDcsDatabaseWrapper.java
@@ -59,23 +59,24 @@ import decodes.util.DecodesSettings;
 public class SimpleOpenDcsDatabaseWrapper implements OpenDcsDatabase
 {
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
-    protected final DecodesSettings settings;
+    //protected final DecodesSettings settings;
     private final Database decodesDb;
     private final TimeSeriesDb timeSeriesDb;
     protected final DataSource dataSource;
     protected final Jdbi jdbi;
     protected final DatabaseEngine dbEngine;
     protected final KeyGenerator keyGenerator;
-    protected final DatabaseQuerySettings querySettings;
+    //protected final DatabaseQuerySettings querySettings;
+    protected final Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settingsMap = new HashMap<>();
     private final Map<Class<? extends OpenDcsDao>, DaoWrapper<? extends OpenDcsDao>> daoMap = new HashMap<>();
 
-    public SimpleOpenDcsDatabaseWrapper(DecodesSettings settings, Database decodesDb, TimeSeriesDb timeSeriesDb, DataSource dataSource, DatabaseQuerySettings querySettings)
+    public SimpleOpenDcsDatabaseWrapper(
+            Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settings, Database decodesDb, TimeSeriesDb timeSeriesDb, DataSource dataSource)
     {
-        this.settings = settings;
+        this.settingsMap.putAll(settings);
         this.decodesDb = decodesDb;
         this.timeSeriesDb = timeSeriesDb;
         this.dataSource = dataSource;
-        this.querySettings = querySettings;
         this.jdbi = Jdbi.create(dataSource);
         jdbi.registerArgument(new DatabaseKeyArgumentFactory())
             .registerColumnMapper(new DatabaseKeyColumnMapper())
@@ -98,13 +99,14 @@ public class SimpleOpenDcsDatabaseWrapper implements OpenDcsDatabase
             throw new IllegalStateException("Unable to determine database type", ex);
         }
 
+        DecodesSettings decodesSettings = (DecodesSettings)settingsMap.get(DecodesSettings.class);
         try
         {
-            keyGenerator = KeyGeneratorFactory.makeKeyGenerator(settings.sqlKeyGenerator);
+            keyGenerator = KeyGeneratorFactory.makeKeyGenerator(decodesSettings.sqlKeyGenerator);
         }
         catch (DatabaseException ex)
         {
-            throw new IllegalStateException("Unable to create key generator of type '" + settings.sqlKeyGenerator + "'", ex);
+            throw new IllegalStateException("Unable to create key generator of type '" + decodesSettings.sqlKeyGenerator + "'", ex);
         }
     }
 
@@ -217,7 +219,7 @@ public class SimpleOpenDcsDatabaseWrapper implements OpenDcsDatabase
      */
     private <T extends OpenDcsDao> Optional<DaoWrapper<T>> fromLookup(Class<T> dao)
     {
-        final String impl = this.settings.editDatabaseType;
+        final String impl = ((DecodesSettings)this.settingsMap.get(DecodesSettings.class)).editDatabaseType;
         final var implLookup = Lookups.forPath("dao/"+impl);
         var instance = implLookup.lookup(dao);
         if (instance == null)
@@ -294,7 +296,7 @@ public class SimpleOpenDcsDatabaseWrapper implements OpenDcsDatabase
             // This DataTransaction is auto closable and handles the closing of the
             // Jdbi Handle instance.
             return new JdbiTransaction(jdbi.open().begin(),
-                                       new TransactionContextImpl(keyGenerator, settings, dbEngine, querySettings)); // NOSONAR
+                                       new TransactionContextImpl(keyGenerator, settingsMap, dbEngine)); // NOSONAR
         }
         catch (JdbiException ex)
         {
@@ -333,18 +335,7 @@ public class SimpleOpenDcsDatabaseWrapper implements OpenDcsDatabase
     @Override
     public <T extends OpenDcsSettings> Optional<T> getSettings(Class<T> settingsClass)
     {
-        if (DecodesSettings.class.equals(settingsClass))
-        {
-            return Optional.of((T)settings);
-        }
-        else if(DatabaseQuerySettings.class.equals(settingsClass))
-        {
-            return Optional.ofNullable((T)querySettings);
-        }
-        else
-        {
-            return Optional.empty();
-        }
+        return Optional.ofNullable((T)settingsMap.get(settingsClass));
     }
 
     @Override

--- a/java/opendcs/src/main/java/org/opendcs/database/TransactionContextImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/TransactionContextImpl.java
@@ -1,5 +1,6 @@
 package org.opendcs.database;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.opendcs.database.api.DatabaseEngine;
@@ -8,21 +9,20 @@ import org.opendcs.database.api.TransactionContext;
 import org.opendcs.settings.api.OpenDcsSettings;
 
 import decodes.sql.KeyGenerator;
-import decodes.util.DecodesSettings;
 
 public class TransactionContextImpl implements TransactionContext
 {
     private final KeyGenerator keyGenerator;
-    private final DecodesSettings settings;
     private final DatabaseEngine databaseEngine;
-    private final DatabaseQuerySettings querySettings;
+    private final Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settingsMap;
 
-    public TransactionContextImpl(KeyGenerator keyGenerator, DecodesSettings settings, DatabaseEngine databaseEngine, DatabaseQuerySettings querySettings)
+    public TransactionContextImpl(KeyGenerator keyGenerator,
+            Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settingsMap, DatabaseEngine databaseEngine)
     {
         this.keyGenerator = keyGenerator;
-        this.settings = settings;
+        this. settingsMap = settingsMap;
         this.databaseEngine = databaseEngine;
-        this.querySettings = querySettings;
+        
     }
 
 
@@ -30,13 +30,6 @@ public class TransactionContextImpl implements TransactionContext
     {
         return this.keyGenerator;
     }
-
-
-    public DecodesSettings getSettings()
-    {
-        return this.settings;
-    }
-
 
     public DatabaseEngine getDatabaseEngine()
     {
@@ -63,18 +56,7 @@ public class TransactionContextImpl implements TransactionContext
     @Override
     public <T extends OpenDcsSettings> Optional<T> getSettings(Class<T> settingsClass)
     {
-        if (DecodesSettings.class.equals(settingsClass))
-        {
-            return Optional.of((T)settings);
-        }
-        else if (DatabaseQuerySettings.class.equals(settingsClass))
-        {
-            return Optional.ofNullable((T)querySettings);
-        }
-        else
-        {
-            return Optional.empty();
-        }
+        return Optional.ofNullable((T)settingsMap.get(settingsClass));
     }
 
 


### PR DESCRIPTION
…meters.

## Problem Description

During #1973 realized we needed yet-another-opendcs settings object to provide some key data required.

## Solution

Instead of adding another parameter, simplify to a `Map<Class<? extends OpenDcsSettings>, OpenDcsSettings>`

Also simplified the return requested settings logic.

## how you tested the change

Existing integration and other tests. No functional change, pure refactor.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
