### PR TITLE
Refactor/1991 database wrapper

### DIFF
--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/fixtures/TomcatServer.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/fixtures/TomcatServer.java
@@ -278,7 +278,7 @@ public final class TomcatServer implements AutoCloseable
 				when not matched then
 				  insert (prop_name, prop_value)
 				  values(input.prop_name, input.prop_value)
-				""").define("dual", tx.getContext().getDatabase() == DatabaseEngine.ORACLE ? "from dual" : ""))
+				""").define("dual", tx.getContext().getDatabaseEngine() == DatabaseEngine.ORACLE ? "from dual" : ""))
 			{
 				DecodesSettings settings = config.getOpenDcsDatabase()
 												.getSettings(DecodesSettings.class)
@@ -292,9 +292,9 @@ public final class TomcatServer implements AutoCloseable
 							.bind("value", value)
 							.add();
 				}
-				
+
 				upsertProp.execute();
-			
+
 			}
 		}
 		catch (Throwable ex)
@@ -414,7 +414,7 @@ public final class TomcatServer implements AutoCloseable
 
 	public static void setupTestUser(OpenDcsDatabase db) throws OpenDcsDataException
 	{
-		
+
 		var idpDao = db.getDao(IdentityProviderDao.class)
 					.orElseThrow(() -> new OpenDcsDataException("No Identity Provider DAO available for this implementation."));
 		var userDao = db.getDao(UsersDao.class)

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/regression_tests/SettingsTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/regression_tests/SettingsTestIT.java
@@ -6,7 +6,7 @@ import java.util.Properties;
 import org.jdbi.v3.core.Handle;
 import org.junit.jupiter.api.Test;
 import org.opendcs.database.DatabaseService;
-import org.opendcs.database.SimpleOpenDcsDatabaseWrapper;
+import org.opendcs.database.AbstractJdbiOpenDcsDatabaseWrapper;
 import org.opendcs.database.api.DatabaseEngine;
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.fixtures.AppTestBase;
@@ -47,7 +47,7 @@ class SettingsTestIT extends AppTestBase
                 // looks odd, need ro make surer the transaction closes it.
                 var conn = tx.connection(Handle.class).orElseThrow();
                 try (var upsertProp = conn.prepareBatch(MERGE_QUERY)
-                                          .define("dual", tx.getContext().getDatabase() == DatabaseEngine.ORACLE ? "from dual" : ""))
+                                          .define("dual", tx.getContext().getDatabaseEngine() == DatabaseEngine.ORACLE ? "from dual" : ""))
                 {
                     settings.saveToProps(props);
                     for(var k: props.keySet())
@@ -57,15 +57,15 @@ class SettingsTestIT extends AppTestBase
                                 .bind("value", value)
                                 .add();
                     }
-                    
+
                     upsertProp.execute();
-                
+
                 }
             }
         });
 
 
-        var ds = ((SimpleOpenDcsDatabaseWrapper)db).getDataSource();
+        var ds = ((AbstractJdbiOpenDcsDatabaseWrapper)db).getDataSource();
         assertDoesNotThrow(() -> DatabaseService.getDatabaseFor(ds));
     }
 }

--- a/java/cwms-implementation/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
+++ b/java/cwms-implementation/src/main/java/org/opendcs/database/impl/cwms/dao/CwmsSiteDaoImpl.java
@@ -101,12 +101,12 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
     {
     if (id == null)
     {
-      return Optional.empty(); 
+      return Optional.empty();
     }
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         var officeId = ctx.getSettings(DecodesSettings.class)
                           .orElseThrow(() -> new OpenDcsDataException("DecodesSettings are not available."))
                           .CwmsOfficeId;
@@ -357,7 +357,7 @@ public final class CwmsSiteDaoImpl extends OpenDcsSiteDaoImpl
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         var settings = ctx.getSettings(DecodesSettings.class)
                           .orElseThrow(() -> new OpenDcsDataException("No DecodesSettings are available?"));
         final var officeId = settings.CwmsOfficeId;

--- a/java/opendcs-api/src/main/java/org/opendcs/database/api/OpenDcsDatabase.java
+++ b/java/opendcs-api/src/main/java/org/opendcs/database/api/OpenDcsDatabase.java
@@ -3,12 +3,14 @@ package org.opendcs.database.api;
 
 import java.util.Optional;
 
-import org.opendcs.settings.api.OpenDcsSettings;
+import org.opendcs.settings.api.ProvidesOpenDcsSettings;
 
 /**
- * Basic interface of an "OpenDCS Database interface.""
+ * Basic interface of an "OpenDCS Database interface."
+ * Extension of {@see AbstractJdbiOpenDcsDatabaseWrapper} is recommend
+ * for integration into the baseline components.
  */
-public interface OpenDcsDatabase
+public interface OpenDcsDatabase extends ProvidesOpenDcsSettings
 {
     /**
      * Retrieve an instance of the given legacy database type.
@@ -36,18 +38,10 @@ public interface OpenDcsDatabase
     DataTransaction newTransaction() throws OpenDcsDataException;
 
     /**
-     * Retrieve Settings of a given type. All implementations must provide "DecodesSettings".
-     * Implementations may determine if a given set of settings are immutable at runtime.
-     * @param <T> Type of settings. Currently implemented is "DecodesSettings"
-     * @param settingsClass type of settings to get
-     * @return Optional&lt;T&gt; Settings if available, otherwise empty.
-     */
-    <T extends OpenDcsSettings> Optional<T> getSettings(Class<T> settingsClass);
-
-    /**
-     * Which database engine is this
+     * Which database engine (actual RDBMS) is this
      * @return
      */
-    DatabaseEngine getDatabase();
+    DatabaseEngine getDatabaseEngine();
 
+    /* settings retrieval defined by ProvidesOpenDcsSettings interface */
 }

--- a/java/opendcs-api/src/main/java/org/opendcs/database/api/TransactionContext.java
+++ b/java/opendcs-api/src/main/java/org/opendcs/database/api/TransactionContext.java
@@ -2,11 +2,10 @@ package org.opendcs.database.api;
 
 import java.util.Optional;
 
-import org.opendcs.settings.api.OpenDcsSettings;
+import org.opendcs.settings.api.ProvidesOpenDcsSettings;
 
-public interface TransactionContext
+public interface TransactionContext extends ProvidesOpenDcsSettings
 {
- 
     /**
      * KeyGenerator alternative to auto generated keys.
      * @return
@@ -14,17 +13,10 @@ public interface TransactionContext
     <T extends Generator> Optional<T> getGenerator(Class<T> generatorClass);
 
     /**
-     * Retrieve Settings of a given type. All implementations must provide "DecodesSettings".
-     * Implementations may determine if a given set of settings are immutable at runtime.
-     * @param <T> Type of settings. Currently implemented is "DecodesSettings"
-     * @param settingsClass type of settings to get
-     * @return Optional&lt;T&gt; Settings if available, otherwise empty.
-     */
-    <T extends OpenDcsSettings> Optional<T> getSettings(Class<T> settingsClass);
-
-    /**
      * Which database engine is this
      * @return
      */
-    DatabaseEngine getDatabase();
+    DatabaseEngine getDatabaseEngine();
+
+    /* settings retrieval defined by ProvidesOpenDcsSettings interface */
 }

--- a/java/opendcs-api/src/main/java/org/opendcs/settings/api/ProvidesOpenDcsSettings.java
+++ b/java/opendcs-api/src/main/java/org/opendcs/settings/api/ProvidesOpenDcsSettings.java
@@ -14,5 +14,5 @@ public interface ProvidesOpenDcsSettings
      * @param settingsClass type of settings to get
      * @return Optional&lt;T&gt; Settings if available, otherwise empty.
      */
-    public <T extends OpenDcsSettings> Optional<T> getSettings(Class<T> settingsClass);
+    <T extends OpenDcsSettings> Optional<T> getSettings(Class<T> settingsClass);
 }

--- a/java/opendcs-api/src/main/java/org/opendcs/settings/api/ProvidesOpenDcsSettings.java
+++ b/java/opendcs-api/src/main/java/org/opendcs/settings/api/ProvidesOpenDcsSettings.java
@@ -1,0 +1,18 @@
+package org.opendcs.settings.api;
+
+import java.util.Optional;
+
+public interface ProvidesOpenDcsSettings
+{
+    /**
+     * Retrieve Settings of a given type. All implementations must provide {@see DecodesSettings}
+     * and {@see DatabaseQuerySettings}. Other types of settings are optional.
+     *
+     * Implementations may determine if a given set of settings are immutable at runtime.
+     *
+     * @param <T> Type of settings. Currently implemented is "DecodesSettings"
+     * @param settingsClass type of settings to get
+     * @return Optional&lt;T&gt; Settings if available, otherwise empty.
+     */
+    public <T extends OpenDcsSettings> Optional<T> getSettings(Class<T> settingsClass);
+}

--- a/java/opendcs-implementation/src/main/java/opendcs/opentsdb/OpenDcsDatabaseWrapper.java
+++ b/java/opendcs-implementation/src/main/java/opendcs/opentsdb/OpenDcsDatabaseWrapper.java
@@ -1,0 +1,27 @@
+package opendcs.opentsdb;
+
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.opendcs.database.AbstractJdbiOpenDcsDatabaseWrapper;
+import org.opendcs.settings.api.OpenDcsSettings;
+
+import decodes.db.Database;
+import decodes.tsdb.TimeSeriesDb;
+
+public class OpenDcsDatabaseWrapper extends AbstractJdbiOpenDcsDatabaseWrapper
+{
+
+    public OpenDcsDatabaseWrapper(Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settings, Database decodesDb,
+            TimeSeriesDb timeSeriesDb, DataSource dataSource)
+    {
+        super(settings, decodesDb, timeSeriesDb, dataSource);
+    }
+
+    @Override
+    protected void initialSetup()
+    {
+        /* do nothing at this time. */
+    }
+}

--- a/java/opendcs-implementation/src/main/java/opendcs/opentsdb/OpenTsdbProvider.java
+++ b/java/opendcs-implementation/src/main/java/opendcs/opentsdb/OpenTsdbProvider.java
@@ -10,7 +10,6 @@ import org.opendcs.database.impl.opendcs.OpenDcsOracleProvider;
 import org.opendcs.database.impl.opendcs.OpenDcsPgProvider;
 import org.opendcs.database.DatabaseQuerySettings;
 import org.opendcs.database.SimpleDataSource;
-import org.opendcs.database.SimpleOpenDcsDatabaseWrapper;
 import org.opendcs.spi.database.DatabaseProvider;
 
 import decodes.db.Database;
@@ -26,7 +25,7 @@ public class OpenTsdbProvider implements DatabaseProvider
     @Override
     public boolean canCreate(DecodesSettings settings)
     {
-        return settings.editDatabaseTypeCode == DecodesSettings.DB_OPENTSDB 
+        return settings.editDatabaseTypeCode == DecodesSettings.DB_OPENTSDB
             || OpenDcsPgProvider.NAME.equals(settings.editDatabaseType)
             || OpenDcsOracleProvider.NAME.equals(settings.editDatabaseType)
         ;
@@ -48,7 +47,7 @@ public class OpenTsdbProvider implements DatabaseProvider
 
     private Database getDecodesDatabase(javax.sql.DataSource dataSource, DecodesSettings settings) throws DatabaseException
     {
-        Database db = new Database(true);            
+        Database db = new Database(true);
         db.setDbIo(new OpenTsdbSqlDbIO(dataSource, settings));
         return db;
     }
@@ -58,7 +57,7 @@ public class OpenTsdbProvider implements DatabaseProvider
     {
         Database decodesDb = getDecodesDatabase(dataSource, settings);
         OpenTsdb tsDb = new OpenTsdb(appName, dataSource, settings);
-        var db = new SimpleOpenDcsDatabaseWrapper(Map.of(DecodesSettings.class, settings, DatabaseQuerySettings.class, DatabaseQuerySettings.DEFAULT_SETTINGS), decodesDb, tsDb, dataSource);
+        var db = new OpenDcsDatabaseWrapper(Map.of(DecodesSettings.class, settings, DatabaseQuerySettings.class, DatabaseQuerySettings.DEFAULT_SETTINGS), decodesDb, tsDb, dataSource);
         tsDb.setDcsDatabase(db);
         Database.setDb(decodesDb);
         try

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DataSourceDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DataSourceDaoImpl.java
@@ -51,7 +51,7 @@ public class DataSourceDaoImpl implements DataSourceDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             return query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
@@ -71,7 +71,7 @@ public class DataSourceDaoImpl implements DataSourceDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             return query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
@@ -91,7 +91,7 @@ public class DataSourceDaoImpl implements DataSourceDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         var keyGen = ctx.getGenerator(KeyGenerator.class)
                 .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
         final String insertSql = """
@@ -177,7 +177,7 @@ public class DataSourceDaoImpl implements DataSourceDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DataTypeDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DataTypeDaoImpl.java
@@ -49,7 +49,7 @@ public class DataTypeDaoImpl implements DataTypeDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         var keyGen = ctx.getGenerator(KeyGenerator.class)
                 .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
         final String insertSql = """

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/DecodesConfigDaoImpl.java
@@ -129,7 +129,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
 
         try (var query = handle.createQuery(SELECT_QUERY))
         {
@@ -168,7 +168,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
@@ -446,7 +446,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
 
         // Lightweight refs-only query. The full getAll loads every joined sensor / script /
         // format-statement / unit-converter row per config, which OOMs / times out on databases
@@ -484,7 +484,7 @@ public class DecodesConfigDaoImpl implements DecodesConfigDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
 
         try (var query = handle.createQuery(SELECT_QUERY))
         {

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/EngineeringUnitDaoImp.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/EngineeringUnitDaoImp.java
@@ -27,8 +27,8 @@ public class EngineeringUnitDaoImp implements EngineeringUnitDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
-        
+        var dbEngine = ctx.getDatabaseEngine();
+
         final String insertSql = """
                 merge into engineeringunit eu
                 using (select :unitabbr unitabbr, :name name, :family family, :measures measures <dual>) input
@@ -69,8 +69,8 @@ public class EngineeringUnitDaoImp implements EngineeringUnitDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         final String querySql = """
-                    select unitabbr, name, family, measures 
-                      from engineeringunit 
+                    select unitabbr, name, family, measures
+                      from engineeringunit
                      where upper(unitabbr) = upper(:unit)
                         or name = :unit
                 """;
@@ -90,13 +90,12 @@ public class EngineeringUnitDaoImp implements EngineeringUnitDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         final String querySql = """
-                    select unitabbr, name, family, measures 
+                    select unitabbr, name, family, measures
                       from engineeringunit
                       order by unitabbr <collate> asc
                       <limit>
-
                 """;
-        var dbType = tx.getContext().getDatabase();
+        var dbType = tx.getContext().getDatabaseEngine();
         try (var query = handle.createQuery(querySql))
         {
             if (limit != -1)
@@ -115,5 +114,4 @@ public class EngineeringUnitDaoImp implements EngineeringUnitDao
                         .list();
         }
     }
-    
 }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/EnumDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/EnumDaoImpl.java
@@ -2,7 +2,6 @@ package org.opendcs.database.impl.opendcs.dao;
 
 import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.jdbi.v3.core.Handle;
 import org.opendcs.database.api.DataTransaction;
@@ -27,7 +26,7 @@ import decodes.sql.KeyGenerator;
 import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
 
 @ServiceProvider(service = EnumDao.class)
-public class EnumDaoImpl implements EnumDao 
+public class EnumDaoImpl implements EnumDao
 {
 
     @Override
@@ -118,7 +117,7 @@ public class EnumDaoImpl implements EnumDao
         var context = tx.getContext();
         var keyGen = context.getGenerator(KeyGenerator.class)
                             .orElseThrow(() -> new OpenDcsDataException("No Keygenerator configured."));
-        var dbEngine = context.getDatabase();
+        var dbEngine = context.getDatabaseEngine();
 
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/EquipmentModelImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/EquipmentModelImpl.java
@@ -69,7 +69,7 @@ public class EquipmentModelImpl implements EquipmentModelDao
         }
     }
 
-    
+
 
 
     @Override
@@ -152,7 +152,7 @@ public class EquipmentModelImpl implements EquipmentModelDao
                     values(input.id, input.name, input.model, input.company, input.description, input.equipmentType)
                 """;
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         var keyGen = ctx.getGenerator(KeyGenerator.class)
                         .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
         var insertPropsSql = "insert into equipmentproperty(equipmentid, name, prop_value) values (:equipmentid, :name, :value)";

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/LoadingAppDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/LoadingAppDaoImpl.java
@@ -55,7 +55,7 @@ public final class LoadingAppDaoImpl implements LoadingAppDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             return query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
@@ -76,7 +76,7 @@ public final class LoadingAppDaoImpl implements LoadingAppDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             return query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
@@ -97,7 +97,7 @@ public final class LoadingAppDaoImpl implements LoadingAppDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         var keyGen = ctx.getGenerator(KeyGenerator.class)
                 .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
         final String insertSql = """
@@ -184,7 +184,7 @@ public final class LoadingAppDaoImpl implements LoadingAppDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsIntervalDurationDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsIntervalDurationDaoImpl.java
@@ -44,7 +44,7 @@ public class OpenDcsIntervalDurationDaoImpl implements IntervalDurationDao
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
-        
+
         try (var query = handle.createQuery(SELECT_INTERVAL)
                                .define(SqlQueries.WHERE_CLAUSE, " where name = :name ")
                              )
@@ -54,7 +54,7 @@ public class OpenDcsIntervalDurationDaoImpl implements IntervalDurationDao
                         .mapTo(Interval.class)
                         .findOne();
         }
-        
+
     }
 
     @Override
@@ -62,7 +62,7 @@ public class OpenDcsIntervalDurationDaoImpl implements IntervalDurationDao
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
-        
+
         try (var query = handle.createQuery(SELECT_INTERVAL)
                                .define(SqlQueries.WHERE_CLAUSE, " where interval_id = :id ")
                              )
@@ -72,7 +72,7 @@ public class OpenDcsIntervalDurationDaoImpl implements IntervalDurationDao
                         .mapTo(Interval.class)
                         .findOne();
         }
-        
+
     }
 
     @Override
@@ -85,7 +85,7 @@ public class OpenDcsIntervalDurationDaoImpl implements IntervalDurationDao
             using (select :id id, :name name, :cal_constant cal_constant, :cal_multiplier cal_multiplier <dual>) input
             on (ic.interval_id = input.id)
             when matched then
-                update set 
+                update set
                     name = input.name,
                     cal_constant = input.cal_constant,
                     cal_multiplier = input.cal_multiplier
@@ -96,9 +96,9 @@ public class OpenDcsIntervalDurationDaoImpl implements IntervalDurationDao
         var ctx = tx.getContext();
         var keyGen = ctx.getGenerator(KeyGenerator.class)
                         .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
-        
+
         try (var query = handle.createUpdate(MERGE_SQL)
-                               .define("dual", ctx.getDatabase() == DatabaseEngine.ORACLE ? " from dual " : ""))
+                               .define("dual", ctx.getDatabaseEngine() == DatabaseEngine.ORACLE ? " from dual " : ""))
         {
             DbKey id = interval.getKey();
             var existing = findIntervalByName(tx, interval.getName());
@@ -138,7 +138,7 @@ public class OpenDcsIntervalDurationDaoImpl implements IntervalDurationDao
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
-        
+
         try (var query = handle.createQuery(SELECT_INTERVAL)
                                .define(SqlQueries.WHERE_CLAUSE, "")
                              )
@@ -183,5 +183,5 @@ public class OpenDcsIntervalDurationDaoImpl implements IntervalDurationDao
     {
         return findIntervalByName(tx, name);
     }
-    
+
 }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/OpenDcsSiteDaoImpl.java
@@ -108,7 +108,7 @@ public class OpenDcsSiteDaoImpl implements SiteDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         var preferredType = ctx.getSettings(DecodesSettings.class)
                               .map(ds -> ds.siteNameTypePreference)
                               .orElseGet(() -> "CWMS");
@@ -312,7 +312,7 @@ public class OpenDcsSiteDaoImpl implements SiteDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         var preferredType = ctx.getSettings(DecodesSettings.class)
                               .map(ds -> ds.siteNameTypePreference)
                               .orElseGet(() -> "CWMS");

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/PresentationGroupDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/PresentationGroupDaoImpl.java
@@ -101,7 +101,7 @@ public class PresentationGroupDaoImpl implements PresentationGroupDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
@@ -134,7 +134,7 @@ public class PresentationGroupDaoImpl implements PresentationGroupDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))
@@ -186,7 +186,7 @@ public class PresentationGroupDaoImpl implements PresentationGroupDao
                 """;
         try (var merge = handle.createUpdate(mergeSql)
                                .define("numeric_date", numericDate)
-                               .define("dual", ctx.getDatabase() == DatabaseEngine.ORACLE ? " from dual " : ""))
+                               .define("dual", ctx.getDatabaseEngine() == DatabaseEngine.ORACLE ? " from dual " : ""))
         {
             DbKey id = group.getId();
             var existing = getByName(tx, group.groupName);
@@ -284,7 +284,7 @@ public class PresentationGroupDaoImpl implements PresentationGroupDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var query = handle.createQuery(SELECT_QUERY))
         {
             query.define(SqlQueries.COLLATE_CLAUSE, SqlQueries.collateClauseFor(dbEngine))

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/UnitConverterDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/UnitConverterDaoImpl.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import java.util.Stack;
 import java.util.Vector;
 
-import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.stringtemplate4.StringTemplateEngine;
 import org.opendcs.annotations.api.InjectDao;
@@ -78,7 +77,7 @@ public class UnitConverterDaoImpl implements UnitConverterDao
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         var ctx = tx.getContext();
-        var dbEngine = ctx.getDatabase();
+        var dbEngine = ctx.getDatabaseEngine();
         var keyGen = ctx.getGenerator(KeyGenerator.class)
                 .orElseThrow(() -> new OpenDcsDataException("No key generator configured."));
         final String insertSql = """
@@ -186,7 +185,7 @@ public class UnitConverterDaoImpl implements UnitConverterDao
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
-        var dbType = tx.getContext().getDatabase();
+        var dbType = tx.getContext().getDatabaseEngine();
 
         final String querySql = """
                 select uc.id, uc.fromunitsabbr, uc.tounitsabbr, uc.algorithm, uc.a,uc.b,uc.c,uc.d,uc.e,uc.f,

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsDatabaseProvider.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsDatabaseProvider.java
@@ -7,7 +7,6 @@ import javax.sql.DataSource;
 
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.database.DatabaseQuerySettings;
-import org.opendcs.database.SimpleOpenDcsDatabaseWrapper;
 import org.opendcs.spi.database.DatabaseProvider;
 
 import decodes.db.Database;
@@ -35,12 +34,12 @@ public class CwmsDatabaseProvider implements DatabaseProvider
         try
         {
             CwmsConnectionInfo conInfo = new CwmsConnectionInfo();
-            ConnectionLoginInfoImpl info = new ConnectionLoginInfoImpl(settings.editDatabaseLocation, 
+            ConnectionLoginInfoImpl info = new ConnectionLoginInfoImpl(settings.editDatabaseLocation,
                                                                 credentials.getProperty("user", credentials.getProperty(("username"))),
                                                                 credentials.getProperty("password"),
                                                                 settings.CwmsOfficeId);
             conInfo.setLoginInfo(info);
-          
+
             DataSource dataSource = CwmsConnectionPool.getPoolFor(conInfo);
             return createDatabase(dataSource, settings);
         }
@@ -59,7 +58,7 @@ public class CwmsDatabaseProvider implements DatabaseProvider
             Database.setDb(decodesDb); // the CwmsSqlDatabaseIO constructor calls into the Database instance to verify things.
             decodesDb.setDbIo(new CwmsSqlDatabaseIO(dataSource, settings));
             CwmsTimeSeriesDb tsdb = new CwmsTimeSeriesDb(null, dataSource, settings);
-            var db = new SimpleOpenDcsDatabaseWrapper(Map.of(DecodesSettings.class, settings, DatabaseQuerySettings.class, new CwmsDatabaseQuerySettings()), decodesDb, tsdb, dataSource);
+            var db = new CwmsOpenDcsDatabaseWrapper(Map.of(DecodesSettings.class, settings, DatabaseQuerySettings.class, new CwmsDatabaseQuerySettings()), decodesDb, tsdb, dataSource);
             ((SqlDatabaseIO)decodesDb.getDbIo()).setDcsDatabase(db);
             decodesDb.init(settings);
             tsdb.setDcsDatabase(db);

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsOpenDcsDatabaseWrapper.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsOpenDcsDatabaseWrapper.java
@@ -1,0 +1,27 @@
+package decodes.cwms;
+
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.opendcs.database.AbstractJdbiOpenDcsDatabaseWrapper;
+import org.opendcs.settings.api.OpenDcsSettings;
+
+import decodes.db.Database;
+import decodes.tsdb.TimeSeriesDb;
+
+public class CwmsOpenDcsDatabaseWrapper extends AbstractJdbiOpenDcsDatabaseWrapper
+{
+
+    public CwmsOpenDcsDatabaseWrapper(Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settings,
+            Database decodesDb, TimeSeriesDb timeSeriesDb, DataSource dataSource)
+    {
+        super(settings, decodesDb, timeSeriesDb, dataSource);
+    }
+
+    @Override
+    protected void initialSetup()
+    {
+        /* do nothing at this time. */
+    }
+}

--- a/java/opendcs/src/main/java/decodes/xml/jdbc/XmlOpenDcsDatabaseWrapper.java
+++ b/java/opendcs/src/main/java/decodes/xml/jdbc/XmlOpenDcsDatabaseWrapper.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import javax.sql.DataSource;
 
-import org.opendcs.database.SimpleOpenDcsDatabaseWrapper;
+import org.opendcs.database.AbstractJdbiOpenDcsDatabaseWrapper;
 import org.opendcs.database.SimpleTransaction;
 import org.opendcs.database.TransactionContextImpl;
 import org.opendcs.database.api.DataTransaction;
@@ -21,7 +21,7 @@ import decodes.util.DecodesSettings;
 import opendcs.dai.EnumDAI;
 import opendcs.dao.DbObjectCache;
 
-public final class XmlOpenDcsDatabaseWrapper extends SimpleOpenDcsDatabaseWrapper
+public final class XmlOpenDcsDatabaseWrapper extends AbstractJdbiOpenDcsDatabaseWrapper
 {
     private final DbObjectCache<DbEnum> enumCache;
 
@@ -43,7 +43,6 @@ public final class XmlOpenDcsDatabaseWrapper extends SimpleOpenDcsDatabaseWrappe
         {
             return super.getDao(dao);
         }
-        
     }
 
     @Override
@@ -58,5 +57,11 @@ public final class XmlOpenDcsDatabaseWrapper extends SimpleOpenDcsDatabaseWrappe
         {
             throw new OpenDcsDataException("Unable to get JDBC Connection.", ex);
         }
+    }
+
+    @Override
+    protected void initialSetup()
+    {
+        /* do nothing */
     }
 }

--- a/java/opendcs/src/main/java/org/opendcs/authentication/identityprovider/impl/builtin/BuiltInIdentityProvider.java
+++ b/java/opendcs/src/main/java/org/opendcs/authentication/identityprovider/impl/builtin/BuiltInIdentityProvider.java
@@ -193,7 +193,7 @@ public final class BuiltInIdentityProvider implements IdentityProvider
                     // We should allow some control of these settings.
                     // However, the defaults are sane, it's easy to do wrong, and this PR is already large enough
                     var hashed = Password.hash(creds.password.getBytes()).addPepper().addRandomSalt().withArgon2();
-                    pwUpdate.define("dual", tx.getContext().getDatabase() == DatabaseEngine.ORACLE ? "from dual" : "")
+                    pwUpdate.define("dual", tx.getContext().getDatabaseEngine() == DatabaseEngine.ORACLE ? "from dual" : "")
                             .bind("id", user.id)
                             .bind("password", hashed.getResult())
                             .execute();

--- a/java/opendcs/src/main/java/org/opendcs/database/AbstractJdbiOpenDcsDatabaseWrapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/AbstractJdbiOpenDcsDatabaseWrapper.java
@@ -108,6 +108,7 @@ public abstract class AbstractJdbiOpenDcsDatabaseWrapper implements OpenDcsDatab
         {
             throw new IllegalStateException("Unable to create key generator of type '" + decodesSettings.sqlKeyGenerator + "'", ex);
         }
+        initialSetup();
     }
 
     /**

--- a/java/opendcs/src/main/java/org/opendcs/database/AbstractJdbiOpenDcsDatabaseWrapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/AbstractJdbiOpenDcsDatabaseWrapper.java
@@ -59,18 +59,16 @@ import decodes.util.DecodesSettings;
 public abstract class AbstractJdbiOpenDcsDatabaseWrapper implements OpenDcsDatabase
 {
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
-    //protected final DecodesSettings settings;
     private final Database decodesDb;
     private final TimeSeriesDb timeSeriesDb;
     protected final DataSource dataSource;
     protected final Jdbi jdbi;
     protected final DatabaseEngine dbEngine;
     protected final KeyGenerator keyGenerator;
-    //protected final DatabaseQuerySettings querySettings;
     protected final Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settingsMap = new HashMap<>();
     private final Map<Class<? extends OpenDcsDao>, DaoWrapper<? extends OpenDcsDao>> daoMap = new HashMap<>();
 
-    public AbstractJdbiOpenDcsDatabaseWrapper(
+    protected AbstractJdbiOpenDcsDatabaseWrapper(
             Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settings, Database decodesDb, TimeSeriesDb timeSeriesDb, DataSource dataSource)
     {
         this.settingsMap.putAll(settings);
@@ -164,25 +162,7 @@ public abstract class AbstractJdbiOpenDcsDatabaseWrapper implements OpenDcsDatab
                     if (daoMakeMethod.isPresent())
                     {
                         final Method m = daoMakeMethod.get();
-                        return new DaoWrapper<>(() ->
-                        {
-                            try
-                            {
-                                T ret = (T)m.invoke(timeSeriesDb);
-                                if (ret == null)
-                                {
-                                    log.atError().log("retrieval of DAO returned null instead of the expected DAO." + timeSeriesDb + " " + m.toGenericString());
-                                }
-                                return ret;
-                            }
-                            catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex)
-                            {
-                                log.atError()
-                                .setCause(ex)
-                                .log("Unable to retrieve DAO we should be able to get.");
-                                return null;
-                            }
-                        });
+                        return makeDaoWrapper(() -> timeSeriesDb, m);
                     }
                 }
                 DatabaseIO dbIo = this.decodesDb.getDbIo();
@@ -190,29 +170,39 @@ public abstract class AbstractJdbiOpenDcsDatabaseWrapper implements OpenDcsDatab
                 if (daoMakeMethod.isPresent())
                 {
                     final Method m = daoMakeMethod.get();
-                    return new DaoWrapper<>(() ->
-                    {
-                        try
-                        {
-                            T ret = (T)m.invoke(this.decodesDb.getDbIo());
-                            if (ret == null)
-                            {
-                                log.atError().log("retrieval of DAO returned null instead of the expected DAO." + this.decodesDb.getDbIo() + " " + m.toGenericString());
-                            }
-                            return ret;
-                        }
-                        catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex)
-                        {
-                            log.atError()
-                               .setCause(ex)
-                               .log("Unable to retrieve DAO we should be able to get.");
-                            return null;
-                        }
-                    });
+                    return makeDaoWrapper(() -> this.decodesDb.getDbIo(), m);
                 }
+
                 return new DaoWrapper<>(() -> null);
             });
         return Optional.ofNullable((T)wrapper.create());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T,K> DaoWrapper<T> makeDaoWrapper(Supplier<K> instance, Method method)
+    {
+        return new DaoWrapper<T>(() ->
+        {
+            try
+            {
+                T ret = (T)method.invoke(instance.get());
+                if (ret == null)
+                {
+                    log.atError()
+                       .log("retrieval of DAO returned null instead of the expected DAO. {}::{}",
+                            instance.get().getClass().getName(),
+                            method.toGenericString());
+                }
+                return ret;
+            }
+            catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex)
+            {
+                log.atError()
+                    .setCause(ex)
+                    .log("Unable to retrieve DAO we should be able to get.");
+                return null;
+            }
+        });
     }
 
     /**

--- a/java/opendcs/src/main/java/org/opendcs/database/AbstractJdbiOpenDcsDatabaseWrapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/AbstractJdbiOpenDcsDatabaseWrapper.java
@@ -56,7 +56,7 @@ import decodes.sql.KeyGeneratorFactory;
 import decodes.tsdb.TimeSeriesDb;
 import decodes.util.DecodesSettings;
 
-public class SimpleOpenDcsDatabaseWrapper implements OpenDcsDatabase
+public abstract class AbstractJdbiOpenDcsDatabaseWrapper implements OpenDcsDatabase
 {
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
     //protected final DecodesSettings settings;
@@ -70,7 +70,7 @@ public class SimpleOpenDcsDatabaseWrapper implements OpenDcsDatabase
     protected final Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settingsMap = new HashMap<>();
     private final Map<Class<? extends OpenDcsDao>, DaoWrapper<? extends OpenDcsDao>> daoMap = new HashMap<>();
 
-    public SimpleOpenDcsDatabaseWrapper(
+    public AbstractJdbiOpenDcsDatabaseWrapper(
             Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settings, Database decodesDb, TimeSeriesDb timeSeriesDb, DataSource dataSource)
     {
         this.settingsMap.putAll(settings);
@@ -109,6 +109,11 @@ public class SimpleOpenDcsDatabaseWrapper implements OpenDcsDatabase
             throw new IllegalStateException("Unable to create key generator of type '" + decodesSettings.sqlKeyGenerator + "'", ex);
         }
     }
+
+    /**
+     * Handle any additional setup or overrides to what was previously done.
+     */
+    protected abstract void initialSetup();
 
     @SuppressWarnings("unchecked") // class is checked before casting
     @Override
@@ -339,7 +344,7 @@ public class SimpleOpenDcsDatabaseWrapper implements OpenDcsDatabase
     }
 
     @Override
-    public DatabaseEngine getDatabase()
+    public DatabaseEngine getDatabaseEngine()
     {
         return this.dbEngine;
     }

--- a/java/opendcs/src/main/java/org/opendcs/database/AbstractJdbiOpenDcsDatabaseWrapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/AbstractJdbiOpenDcsDatabaseWrapper.java
@@ -71,6 +71,8 @@ public abstract class AbstractJdbiOpenDcsDatabaseWrapper implements OpenDcsDatab
     protected AbstractJdbiOpenDcsDatabaseWrapper(
             Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settings, Database decodesDb, TimeSeriesDb timeSeriesDb, DataSource dataSource)
     {
+        Objects.requireNonNull(settings.get(DecodesDatabaseSettings.class), 
+                               "All implementations are required to provide a `DecodesSettings` instance.");
         this.settingsMap.putAll(settings);
         this.decodesDb = decodesDb;
         this.timeSeriesDb = timeSeriesDb;

--- a/java/opendcs/src/main/java/org/opendcs/database/AbstractJdbiOpenDcsDatabaseWrapper.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/AbstractJdbiOpenDcsDatabaseWrapper.java
@@ -21,6 +21,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -71,7 +72,7 @@ public abstract class AbstractJdbiOpenDcsDatabaseWrapper implements OpenDcsDatab
     protected AbstractJdbiOpenDcsDatabaseWrapper(
             Map<Class<? extends OpenDcsSettings>, OpenDcsSettings> settings, Database decodesDb, TimeSeriesDb timeSeriesDb, DataSource dataSource)
     {
-        Objects.requireNonNull(settings.get(DecodesDatabaseSettings.class), 
+        Objects.requireNonNull(settings.get(DecodesSettings.class), 
                                "All implementations are required to provide a `DecodesSettings` instance.");
         this.settingsMap.putAll(settings);
         this.decodesDb = decodesDb;

--- a/java/opendcs/src/main/java/org/opendcs/database/TransactionContextImpl.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/TransactionContextImpl.java
@@ -22,20 +22,12 @@ public class TransactionContextImpl implements TransactionContext
         this.keyGenerator = keyGenerator;
         this. settingsMap = settingsMap;
         this.databaseEngine = databaseEngine;
-        
     }
-
 
     public KeyGenerator getKeyGenerator()
     {
         return this.keyGenerator;
     }
-
-    public DatabaseEngine getDatabaseEngine()
-    {
-        return this.databaseEngine;
-    }
-
 
     @SuppressWarnings("unchecked")
     @Override
@@ -61,7 +53,7 @@ public class TransactionContextImpl implements TransactionContext
 
 
     @Override
-    public DatabaseEngine getDatabase()
+    public DatabaseEngine getDatabaseEngine()
     {
         return this.databaseEngine;
     }

--- a/java/opendcs/src/test/java/org/opendcs/database/JdbiTransactionTest.java
+++ b/java/opendcs/src/test/java/org/opendcs/database/JdbiTransactionTest.java
@@ -39,9 +39,9 @@ class JdbiTransactionTest
         }
 
         @Override
-        public DatabaseEngine getDatabase()
+        public DatabaseEngine getDatabaseEngine()
         {
-            throw new UnsupportedOperationException("Unimplemented method 'getDatabase'");
+            throw new UnsupportedOperationException("Unimplemented method 'getDatabaseEngine'");
         }
     };
 


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #1991. 

NOTE: depends on #1990

## Solution

- Rename `SimpleOpenDcsDatabaseWrapper` to `AbstractJdbiOpenDcsDatabaseWrapper` to reflect 1) it's not actually simple, 2) the general intent.
- Rename `getDatabase` to `getDatabaseEngine` as we aren't actually getting a database instance.
- Move definition of `getSettings` to interface as the definition is shared by `OpenDcsDatabase` and `TransactionContext`
- Added abstract `initialSetup` method to `AbstractJdbiOpenDcsDatabaseWrapper` to handle any future 1 time init. (Can be used for things like defines that are engine specific to only do once, or registering specific ArgumentFactories or Mappers.)

## how you tested the change

Existing integration tests. No functional change. Just renaming and reorganization of things.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
