### PR TITLE
Rename OpenTsdbSetting, setup system to allow Implementation specific…

### DIFF
--- a/integrationtesting/opendcs-tests/build.gradle
+++ b/integrationtesting/opendcs-tests/build.gradle
@@ -138,10 +138,12 @@ testEngines.each { engine ->
         def install = project(":install")
         def stageDir = install.layout.getBuildDirectory().dir("install/${install.distributions.main.distributionBaseName.get()}").get()
         def classPath = (project(':opendcs').jar.outputs.files
+                    + project(":opendcs-implementation").configurations.runtimeClasspath
+                    + project(":opendcs-implementation").jar.outputs.files
+                    + project(":cwms-implementation").configurations.runtimeClasspath
+                    + project(":cwms-implementation").jar.outputs.files
                     + project(":opendcs").configurations.runtimeClasspath
                     + configurations.extra
-                    + project(":opendcs-implementation").configurations.runtimeClasspath
-                    + project(":cwms-implementation").configurations.runtimeClasspath
                     ).asPath
         inputs.property "opendcs.test.engine", engine
 

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsDbSettingsTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsDbSettingsTestIT.java
@@ -1,0 +1,31 @@
+package org.opendcs.dao.opendcs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.opendcs.database.api.OpenDcsDatabase;
+import org.opendcs.fixtures.AppTestBase;
+import org.opendcs.fixtures.annotations.ConfiguredField;
+import org.opendcs.fixtures.annotations.EnableIfTsDb;
+
+import opendcs.opentsdb.OffsetErrorAction;
+import opendcs.opentsdb.OpenDcsDbSettings;
+
+@EnableIfTsDb({"OpenDCS-Postgres", "OpenDCS-Oracle"})
+class OpenDcsDbSettingsTestIT extends AppTestBase
+{
+    @ConfiguredField
+    OpenDcsDatabase db;
+
+
+    @Test
+    void test_can_retrieve_settings()
+    {
+        var openDcsDbSettings = db.getSettings(OpenDcsDbSettings.class)
+                                  .orElseGet(() -> fail("Required settings not available"));
+        assertTrue(openDcsDbSettings.allowDstOffsetVariation);
+        assertEquals(OffsetErrorAction.ROUND, openDcsDbSettings.offsetErrorActionEnum);
+    }
+}

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSettingsTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSettingsTestIT.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
+import org.opendcs.cwms.CwmsSettings;
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.fixtures.AppTestBase;
 import org.opendcs.fixtures.annotations.ConfiguredField;
@@ -13,19 +14,28 @@ import org.opendcs.fixtures.annotations.EnableIfTsDb;
 import opendcs.opentsdb.OffsetErrorAction;
 import opendcs.opentsdb.OpenDcsDbSettings;
 
-@EnableIfTsDb({"OpenDCS-Postgres", "OpenDCS-Oracle"})
-class OpenDcsDbSettingsTestIT extends AppTestBase
+
+class OpenDcsSettingsTestIT extends AppTestBase
 {
     @ConfiguredField
     OpenDcsDatabase db;
 
 
     @Test
-    void test_can_retrieve_settings()
+    @EnableIfTsDb({"OpenDCS-Postgres", "OpenDCS-Oracle"})
+    void test_can_retrieve_settings_odcs()
     {
         var openDcsDbSettings = db.getSettings(OpenDcsDbSettings.class)
                                   .orElseGet(() -> fail("Required settings not available"));
         assertTrue(openDcsDbSettings.allowDstOffsetVariation);
         assertEquals(OffsetErrorAction.ROUND, openDcsDbSettings.offsetErrorActionEnum);
+    }
+
+    @EnableIfTsDb({"CWMS-Oracle"})
+    @Test
+    void test_can_retrieve_settings_cwms()
+    {
+        var cwmsSettings = db.getSettings(CwmsSettings.class);
+        assertTrue(cwmsSettings.isPresent());
     }
 }

--- a/java/cwms-implementation/build.gradle
+++ b/java/cwms-implementation/build.gradle
@@ -34,6 +34,25 @@ dependencies {
     implementation(libs.bundles.jdbi)
     implementation(libs.org.netbeans.lookup)
     implementation(libs.auto.service.annotations)
+
+    implementation(libs.cwms.db.jooq) {
+           exclude group: "org.jooq.pro", module: "jooq-meta"
+           exclude group: "org.jooq.pro", module: "jooq-codegen"
+           exclude group: "com.oracle.database.jdbc"
+           exclude group: "mil.army.usace.hec", module: "hec-monolith"
+    }
+    implementation(libs.cwms.db.codegen)
+    implementation(libs.cwms.db.aspects)
+    implementation(libs.cwms.db.dao) {
+        exclude group: "com.oracle.database.jdbc"
+        exclude group: "com.oracle.database.jdbc", module: "jmscommon"
+        exclude group: "mil.army.usace.hec", module: "hec-monolith"
+    }
+    implementation(libs.hec.db.jdbc) {
+        exclude group: "com.oracle.database.jdbc"
+        exclude group: "com.oracle.database.jdbc", module: "jmscommon"
+        exclude group: "mil.army.usace.hec", module: "hec-monolith"
+    }
 }
 
 

--- a/java/cwms-implementation/src/main/java/org/opendcs/cwms/CwmsDatabaseProvider.java
+++ b/java/cwms-implementation/src/main/java/org/opendcs/cwms/CwmsDatabaseProvider.java
@@ -7,6 +7,7 @@ import javax.sql.DataSource;
 
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.database.DatabaseQuerySettings;
+import org.opendcs.database.DatabaseService;
 import org.opendcs.spi.database.DatabaseProvider;
 
 import com.google.auto.service.AutoService;
@@ -63,8 +64,7 @@ public class CwmsDatabaseProvider implements DatabaseProvider
     {
         try
         {
-            Properties props = loadPropertiesTable(dataSource);
-            var cwmsSettings = new CwmsSettings(props);
+            var cwmsSettings = DatabaseService.loadSettingsFromProperties(dataSource, new CwmsSettings());
             var allSettings = Map.of(
                 DecodesSettings.class, settings,
                 DatabaseQuerySettings.class, new CwmsDatabaseQuerySettings(),

--- a/java/cwms-implementation/src/main/java/org/opendcs/cwms/CwmsDatabaseProvider.java
+++ b/java/cwms-implementation/src/main/java/org/opendcs/cwms/CwmsDatabaseProvider.java
@@ -1,4 +1,4 @@
-package decodes.cwms;
+package org.opendcs.cwms;
 
 import java.util.Map;
 import java.util.Properties;
@@ -9,6 +9,14 @@ import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.database.DatabaseQuerySettings;
 import org.opendcs.spi.database.DatabaseProvider;
 
+import com.google.auto.service.AutoService;
+
+import decodes.cwms.CwmsConnectionInfo;
+import decodes.cwms.CwmsConnectionPool;
+import decodes.cwms.CwmsDatabaseQuerySettings;
+import decodes.cwms.CwmsOpenDcsDatabaseWrapper;
+import decodes.cwms.CwmsSqlDatabaseIO;
+import decodes.cwms.CwmsTimeSeriesDb;
 import decodes.db.Database;
 import decodes.db.DatabaseException;
 import decodes.sql.SqlDatabaseIO;
@@ -17,6 +25,7 @@ import decodes.util.DecodesException;
 import decodes.util.DecodesSettings;
 import usace.cwms.db.dao.util.connection.ConnectionLoginInfoImpl;
 
+@AutoService(DatabaseProvider.class)
 public class CwmsDatabaseProvider implements DatabaseProvider
 {
 
@@ -54,11 +63,18 @@ public class CwmsDatabaseProvider implements DatabaseProvider
     {
         try
         {
+            Properties props = loadPropertiesTable(dataSource);
+            var cwmsSettings = new CwmsSettings(props);
+            var allSettings = Map.of(
+                DecodesSettings.class, settings,
+                DatabaseQuerySettings.class, new CwmsDatabaseQuerySettings(),
+                CwmsSettings.class, cwmsSettings
+            );
             Database decodesDb = new Database(true);
             Database.setDb(decodesDb); // the CwmsSqlDatabaseIO constructor calls into the Database instance to verify things.
             decodesDb.setDbIo(new CwmsSqlDatabaseIO(dataSource, settings));
             CwmsTimeSeriesDb tsdb = new CwmsTimeSeriesDb(null, dataSource, settings);
-            var db = new CwmsOpenDcsDatabaseWrapper(Map.of(DecodesSettings.class, settings, DatabaseQuerySettings.class, new CwmsDatabaseQuerySettings()), decodesDb, tsdb, dataSource);
+            var db = new CwmsOpenDcsDatabaseWrapper(allSettings, decodesDb, tsdb, dataSource);
             ((SqlDatabaseIO)decodesDb.getDbIo()).setDcsDatabase(db);
             decodesDb.init(settings);
             tsdb.setDcsDatabase(db);

--- a/java/cwms-implementation/src/main/java/org/opendcs/cwms/CwmsSettings.java
+++ b/java/cwms-implementation/src/main/java/org/opendcs/cwms/CwmsSettings.java
@@ -1,0 +1,36 @@
+package org.opendcs.cwms;
+
+import java.util.Properties;
+
+import org.opendcs.settings.api.OpenDcsSettings;
+
+import decodes.util.PropertiesOwner;
+import decodes.util.PropertySpec;
+
+/**
+ * Hold any CWMS Specific operational settings.
+ * 
+ * NOTE: Inentionally empty. Placehodler for future work.
+ */
+public final class CwmsSettings implements PropertiesOwner, OpenDcsSettings
+{
+
+    @SuppressWarnings("java:S1172") // future work
+    public CwmsSettings(Properties props)
+    {
+        // Future work.
+    }
+
+    @Override
+    public PropertySpec[] getSupportedProps()
+    {
+        return new PropertySpec[0];
+    }
+
+    @Override
+    public boolean additionalPropsAllowed()
+    {
+        return false;
+    }
+    
+}

--- a/java/cwms-implementation/src/main/java/org/opendcs/cwms/CwmsSettings.java
+++ b/java/cwms-implementation/src/main/java/org/opendcs/cwms/CwmsSettings.java
@@ -21,6 +21,10 @@ public final class CwmsSettings implements PropertiesOwner, OpenDcsSettings
         // Future work.
     }
 
+    public CwmsSettings()
+    {
+    }
+
     @Override
     public PropertySpec[] getSupportedProps()
     {

--- a/java/cwms-implementation/src/main/java/org/opendcs/cwms/CwmsSettings.java
+++ b/java/cwms-implementation/src/main/java/org/opendcs/cwms/CwmsSettings.java
@@ -10,7 +10,7 @@ import decodes.util.PropertySpec;
 /**
  * Hold any CWMS Specific operational settings.
  * 
- * NOTE: Inentionally empty. Placehodler for future work.
+ * NOTE: Intentionally empty. Placeholder for future work.
  */
 public final class CwmsSettings implements PropertiesOwner, OpenDcsSettings
 {

--- a/java/opendcs-implementation/src/main/java/opendcs/opentsdb/OpenTsdbProvider.java
+++ b/java/opendcs-implementation/src/main/java/opendcs/opentsdb/OpenTsdbProvider.java
@@ -9,6 +9,7 @@ import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.database.impl.opendcs.OpenDcsOracleProvider;
 import org.opendcs.database.impl.opendcs.OpenDcsPgProvider;
 import org.opendcs.database.DatabaseQuerySettings;
+import org.opendcs.database.DatabaseService;
 import org.opendcs.database.SimpleDataSource;
 import org.opendcs.spi.database.DatabaseProvider;
 
@@ -60,9 +61,8 @@ public class OpenTsdbProvider implements DatabaseProvider
     {
         Database decodesDb = getDecodesDatabase(dataSource, settings);
         OpenTsdb tsDb = new OpenTsdb(appName, dataSource, settings);
-        var props = loadPropertiesTable(dataSource);
 
-        var dbSettings = new OpenDcsDbSettings(props);
+        var dbSettings = DatabaseService.loadSettingsFromProperties(dataSource, new OpenDcsDbSettings());
 
         var allSettings = Map.of(
             DecodesSettings.class, settings,

--- a/java/opendcs-implementation/src/main/java/opendcs/opentsdb/OpenTsdbProvider.java
+++ b/java/opendcs-implementation/src/main/java/opendcs/opentsdb/OpenTsdbProvider.java
@@ -12,12 +12,15 @@ import org.opendcs.database.DatabaseQuerySettings;
 import org.opendcs.database.SimpleDataSource;
 import org.opendcs.spi.database.DatabaseProvider;
 
+import com.google.auto.service.AutoService;
+
 import decodes.db.Database;
 import decodes.db.DatabaseException;
 import decodes.sql.SqlDatabaseIO;
 import decodes.util.DecodesException;
 import decodes.util.DecodesSettings;
 
+@AutoService(DatabaseProvider.class)
 public class OpenTsdbProvider implements DatabaseProvider
 {
     private String appName = null;
@@ -57,7 +60,16 @@ public class OpenTsdbProvider implements DatabaseProvider
     {
         Database decodesDb = getDecodesDatabase(dataSource, settings);
         OpenTsdb tsDb = new OpenTsdb(appName, dataSource, settings);
-        var db = new OpenDcsDatabaseWrapper(Map.of(DecodesSettings.class, settings, DatabaseQuerySettings.class, DatabaseQuerySettings.DEFAULT_SETTINGS), decodesDb, tsDb, dataSource);
+        var props = loadPropertiesTable(dataSource);
+
+        var dbSettings = new OpenDcsDbSettings(props);
+
+        var allSettings = Map.of(
+            DecodesSettings.class, settings,
+            DatabaseQuerySettings.class, DatabaseQuerySettings.DEFAULT_SETTINGS,
+            OpenDcsDbSettings.class, dbSettings
+        );
+        var db = new OpenDcsDatabaseWrapper(allSettings, decodesDb, tsDb, dataSource);
         tsDb.setDcsDatabase(db);
         Database.setDb(decodesDb);
         try

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/PropSpecHelper.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/PropSpecHelper.java
@@ -154,7 +154,7 @@ public final class PropSpecHelper
 		SCREENING_ALGORITHM("decodes.cwms.validation.ScreeningAlgorithm"),
 		DECODES_SETTINGS("decodes.util.DecodesSettings"),
 		LRGS_CONFIG("lrgs.lrgsmain.LrgsConfig"),
-		OPEN_TSDB_SETTINGS("opendcs.opentsdb.OpenTsdbSettings");
+		OPEN_DCS_DB_SETTINGS("opendcs.opentsdb.OpenDcsDbSettings");
 
 		private final String className;
 

--- a/java/opendcs/src/main/java/decodes/tsdb/groupedit/TsListFrame.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/groupedit/TsListFrame.java
@@ -16,7 +16,7 @@
 package decodes.tsdb.groupedit;
 
 import ilex.util.LoadResourceBundle;
-import opendcs.opentsdb.OpenTsdbSettings;
+import opendcs.opentsdb.OpenDcsDbSettings;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -145,14 +145,14 @@ public class TsListFrame extends TopFrame
 			JOptionPane.showMessageDialog(this, "Changing TSDB Properties will require restart "
 				+ "of any background processes using these properties.");
 		}
-		Properties props = OpenTsdbSettings.instance().getPropertiesSet();
+		Properties props = OpenDcsDbSettings.instance().getPropertiesSet();
 		PropertiesEditDialog dlg = new PropertiesEditDialog(
 			groupResources.getString("TsdbListPanel.TsdbProperties"), props);
-		dlg.setPropertiesOwner(OpenTsdbSettings.instance());
+		dlg.setPropertiesOwner(OpenDcsDbSettings.instance());
 		launchDialog(dlg);
 		if (dlg.isOkPressed())
 		{
-			OpenTsdbSettings.instance().setFromProperties(props);
+			OpenDcsDbSettings.instance().setFromProperties(props);
 			try
 			{
 				theDb.writeTsdbProperties(props);

--- a/java/opendcs/src/main/java/decodes/tsdb/groupedit/TsListFrame.java
+++ b/java/opendcs/src/main/java/decodes/tsdb/groupedit/TsListFrame.java
@@ -152,7 +152,7 @@ public class TsListFrame extends TopFrame
 		launchDialog(dlg);
 		if (dlg.isOkPressed())
 		{
-			OpenDcsDbSettings.instance().setFromProperties(props);
+			OpenDcsDbSettings.instance().loadFromProperties(props);
 			try
 			{
 				theDb.writeTsdbProperties(props);

--- a/java/opendcs/src/main/java/decodes/util/PropertiesOwner.java
+++ b/java/opendcs/src/main/java/decodes/util/PropertiesOwner.java
@@ -1,5 +1,7 @@
 package decodes.util;
 
+import java.util.Properties;
+
 /**
  * Used by classes that can take properties to control their actions.
  * They must support this interface returning specifications for their
@@ -13,11 +15,20 @@ public interface PropertiesOwner
 	/**
 	 * @return specifications of supported properties.
 	 */
-	public PropertySpec[] getSupportedProps();
+	PropertySpec[] getSupportedProps();
 	
 	/**
 	 * @return true if additional unnamed props are allowed, falis if only the
 	 * ones returned by getSupportedProps are allowed.
 	 */
-	public boolean additionalPropsAllowed();
+	boolean additionalPropsAllowed();
+
+	/**
+	 * Some objects support 
+	 * @param properties
+	 */
+	default void loadFromProperties(Properties properties)
+	{
+
+	}
 }

--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenDcsDbSettings.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenDcsDbSettings.java
@@ -69,10 +69,10 @@ public class OpenDcsDbSettings implements PropertiesOwner, OpenDcsSettings
 
 	public OpenDcsDbSettings(Properties props)
 	{
-		setFromProperties(props);
+		loadFromProperties(props);
 	}
 
-	public void setFromProperties(Properties props)
+	public void loadFromProperties(Properties props)
 	{
 		this.props = props;
 		PropertiesUtil.loadFromProps(this, props);

--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenDcsDbSettings.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenDcsDbSettings.java
@@ -17,6 +17,7 @@ package opendcs.opentsdb;
 
 import java.util.Properties;
 
+import org.opendcs.settings.api.OpenDcsSettings;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
 
@@ -29,10 +30,10 @@ import ilex.util.PropertiesUtil;
  * @author mmaloney Mike Maloney, Cove Software LLC
  *
  */
-public class OpenTsdbSettings implements PropertiesOwner
+public class OpenDcsDbSettings implements PropertiesOwner, OpenDcsSettings
 {
 	private static final Logger log = OpenDcsLoggerFactory.getLogger();
-	private static OpenTsdbSettings _instance = null;
+	private static OpenDcsDbSettings INSTANCE = null;
 
 	/** Allow the UTC Offset of time series to vary by an hour over DST change. */
 	public boolean allowDstOffsetVariation = true;
@@ -61,6 +62,16 @@ public class OpenTsdbSettings implements PropertiesOwner
 			"(default=false) Set to true to enable debugs on database connection management."),
 	};
 
+	public OpenDcsDbSettings()
+	{
+		/* do nothing */
+	}
+
+	public OpenDcsDbSettings(Properties props)
+	{
+		setFromProperties(props);
+	}
+
 	public void setFromProperties(Properties props)
 	{
 		this.props = props;
@@ -74,7 +85,7 @@ public class OpenTsdbSettings implements PropertiesOwner
 		{
 			log.atWarn()
 			   .setCause(ex)
-			   .log("OpenTsdbSettings: Bad offsetErrorAction '{}': defaulting to round.", offsetErrorAction);
+			   .log("Bad offsetErrorAction '{}': defaulting to round.", offsetErrorAction);
 			offsetErrorActionEnum = OffsetErrorAction.ROUND;
 		}
 	}
@@ -91,11 +102,11 @@ public class OpenTsdbSettings implements PropertiesOwner
 		return ret;
 	}
 
-	public static OpenTsdbSettings instance()
+	public static OpenDcsDbSettings instance()
 	{
-		if (_instance == null)
-			_instance = new OpenTsdbSettings();
-		return _instance;
+		if (INSTANCE == null)
+			INSTANCE = new OpenDcsDbSettings();
+		return INSTANCE;
 	}
 
 	@Override

--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenDcsDbSettings.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenDcsDbSettings.java
@@ -35,6 +35,18 @@ public class OpenDcsDbSettings implements PropertiesOwner, OpenDcsSettings
 	private static final Logger log = OpenDcsLoggerFactory.getLogger();
 	private static OpenDcsDbSettings INSTANCE = null;
 
+	private static PropertySpec[] propSpecs =
+	{
+		new PropertySpec("allowDstOffsetVariation", PropertySpec.BOOLEAN,
+			"(default=true) allows daylight time offset variation in time series data."),
+		new PropertySpec("offsetErrorAction", PropertySpec.JAVA_ENUM+"opendcs.opentsdb.OffsetErrorAction",
+			"Action when UTC Offset is detected when storing data. One of IGNORE, REJECT, ROUND."),
+		new PropertySpec("storagePresentationGroup", PropertySpec.STRING,
+			"Name of presentation group that determines storage units for each data type."),
+		new PropertySpec("traceConnections", PropertySpec.BOOLEAN,
+			"(default=false) Set to true to enable debugs on database connection management."),
+	};
+
 	/** Allow the UTC Offset of time series to vary by an hour over DST change. */
 	public boolean allowDstOffsetVariation = true;
 
@@ -50,18 +62,6 @@ public class OpenDcsDbSettings implements PropertiesOwner, OpenDcsSettings
 
 	public Properties props = new Properties();
 
-	private static PropertySpec propSpecs[] =
-	{
-		new PropertySpec("allowDstOffsetVariation", PropertySpec.BOOLEAN,
-			"(default=true) allows daylight time offset variation in time series data."),
-		new PropertySpec("offsetErrorAction", PropertySpec.JAVA_ENUM+"opendcs.opentsdb.OffsetErrorAction",
-			"Action when UTC Offset is detected when storing data. One of IGNORE, REJECT, ROUND."),
-		new PropertySpec("storagePresentationGroup", PropertySpec.STRING,
-			"Name of presentation group that determines storage units for each data type."),
-		new PropertySpec("traceConnections", PropertySpec.BOOLEAN,
-			"(default=false) Set to true to enable debugs on database connection management."),
-	};
-
 	public OpenDcsDbSettings()
 	{
 		/* do nothing */
@@ -72,6 +72,7 @@ public class OpenDcsDbSettings implements PropertiesOwner, OpenDcsSettings
 		loadFromProperties(props);
 	}
 
+	@Override
 	public void loadFromProperties(Properties props)
 	{
 		this.props = props;

--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenTimeSeriesDAO.java
@@ -1016,7 +1016,7 @@ public class OpenTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 
 		OffsetErrorAction offsetErrorAction = tsid.getOffsetErrorAction();
 		if (offsetErrorAction == null)
-			offsetErrorAction = OpenTsdbSettings.instance().offsetErrorActionEnum;
+			offsetErrorAction = OpenDcsDbSettings.instance().offsetErrorActionEnum;
 
 		// If (ignore) then just return true. Don't bother with checking.
 		if (offsetErrorAction == OffsetErrorAction.IGNORE)
@@ -1388,7 +1388,7 @@ public class OpenTimeSeriesDAO extends DaoBase implements TimeSeriesDAI
 		if (storageUnits == null)
 		{
 			decodes.db.Database db = decodes.db.Database.getDb();
-			String pgName = OpenTsdbSettings.instance().storagePresentationGroup;
+			String pgName = OpenDcsDbSettings.instance().storagePresentationGroup;
 			PresentationGroup dbpg = db.presentationGroupList.find(pgName);
 			if (dbpg == null)
 				throw new DbIoException("No such storagePresentationGroup '"

--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenTsdb.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenTsdb.java
@@ -483,7 +483,7 @@ public class OpenTsdb extends TimeSeriesDb
 
 	public String getStorageUnitsForDataType(DataType dt)
 	{
-		String pgname = OpenTsdbSettings.instance().storagePresentationGroup;
+		String pgname = OpenDcsDbSettings.instance().storagePresentationGroup;
 
 		PresentationGroup pg = Database.getDb().presentationGroupList.find(pgname);
 		if (pg == null)

--- a/java/opendcs/src/main/java/org/opendcs/database/DatabaseService.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/DatabaseService.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -16,6 +17,8 @@ import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.settings.api.OpenDcsSettings;
 import org.opendcs.spi.authentication.AuthSource;
 import org.opendcs.spi.database.DatabaseProvider;
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.slf4j.Logger;
 
 import decodes.db.DatabaseException;
 import decodes.util.DecodesSettings;
@@ -24,6 +27,7 @@ import ilex.util.AuthException;
 
 public class DatabaseService
 {
+    private static final Logger log = OpenDcsLoggerFactory.getLogger();
     private static ServiceLoader<DatabaseProvider> loader = ServiceLoader.load(DatabaseProvider.class);
 
     public static OpenDcsDatabase getDatabaseFor(String appName, DecodesSettings settings) throws DatabaseException
@@ -45,10 +49,12 @@ public class DatabaseService
 
     public static OpenDcsDatabase getDatabaseFor(String appName, DecodesSettings settings, Properties credentials) throws DatabaseException
     {
+        loader.reload();
         final Iterator<DatabaseProvider> providers = loader.iterator();
+        ArrayList<String> attemptedProviders = new ArrayList<>();
         while (providers.hasNext())
         {
-            final DatabaseProvider provider = providers.next();
+            final DatabaseProvider provider = providers.next();            
             if (provider.canCreate(settings))
             {
                 try
@@ -60,8 +66,12 @@ public class DatabaseService
                     throw new DatabaseException("Unable to create database instance.", ex);
                 }
             }
+            attemptedProviders.add(provider.getClass().getName());
         }
-        throw new DatabaseException("No provider found for database type  " + settings.editDatabaseType);
+        
+        throw new DatabaseException(String.format("""
+                No provider found for database type  %s. Availabled types are %s.        
+                """, settings.editDatabaseType, String.join(",", attemptedProviders)));
     }
 
     /**
@@ -92,7 +102,9 @@ public class DatabaseService
 
     private static OpenDcsDatabase createDatabaseFromSettings(DataSource dataSource, DecodesSettings settings) throws DatabaseException
     {
+        loader.reload();
         final Iterator<DatabaseProvider> providers = loader.iterator();
+        ArrayList<String> attemptedProviders = new ArrayList<>();
         while (providers.hasNext())
         {
             final DatabaseProvider provider = providers.next();
@@ -101,7 +113,9 @@ public class DatabaseService
                 return provider.createDatabase(dataSource, settings);
             }
         }
-        throw new DatabaseException("No provider for database type " + settings.editDatabaseType);
+        throw new DatabaseException(String.format("""
+                No provider found for database type  %s. Availabled types are %s.        
+                """, settings.editDatabaseType, String.join(",", attemptedProviders)));
     }
 
     /**
@@ -113,9 +127,8 @@ public class DatabaseService
      */
     private static DecodesSettings decodesSettingsFromJdbc(DataSource dataSource, Properties props) throws DatabaseException
     {
-
         DecodesSettings settings = new DecodesSettings();
-        return loadSettingsFromProperties(dataSource, settings);
+        return loadSettingsFromProperties(dataSource, settings, props);
     }
 
     /**
@@ -123,12 +136,25 @@ public class DatabaseService
      * @param <T> Type of Setttings
      * @param dataSource
      * @param settings settings instance on which to load data
-     * @param props previously loaded properties that may
      * @return the passed in settings object
      */
     public static <T extends PropertiesOwner & OpenDcsSettings> T loadSettingsFromProperties(DataSource dataSource, T settings) throws DatabaseException
     {
+        return loadSettingsFromProperties(dataSource, settings, new Properties());
+    }
+
+    /**
+     * NOTE: This will mutate the provided settings instance.
+     * @param <T> Type of Setttings
+     * @param dataSource
+     * @param settings settings instance on which to load data
+     * @param props previously loaded properties that may be required
+     * @return the passed in settings object
+     */
+    public static <T extends PropertiesOwner & OpenDcsSettings> T loadSettingsFromProperties(DataSource dataSource, T settings, Properties existingProps) throws DatabaseException
+    {
         Properties props = new Properties();
+        props.putAll(existingProps);
         try (Connection conn = dataSource.getConnection();
              PreparedStatement stmt = conn.prepareStatement("select prop_name,prop_value from tsdb_property");
              ResultSet rs = stmt.executeQuery())

--- a/java/opendcs/src/main/java/org/opendcs/database/DatabaseService.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/DatabaseService.java
@@ -6,7 +6,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.ServiceLoader;
 
@@ -29,7 +28,6 @@ import opendcs.util.functional.ThrowingFunction;
 
 public class DatabaseService
 {
-    private static final Logger log = OpenDcsLoggerFactory.getLogger();
     private static ServiceLoader<DatabaseProvider> loader = ServiceLoader.load(DatabaseProvider.class);
 
     public static OpenDcsDatabase getDatabaseFor(String appName, DecodesSettings settings) throws DatabaseException

--- a/java/opendcs/src/main/java/org/opendcs/database/DatabaseService.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/DatabaseService.java
@@ -17,8 +17,6 @@ import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.settings.api.OpenDcsSettings;
 import org.opendcs.spi.authentication.AuthSource;
 import org.opendcs.spi.database.DatabaseProvider;
-import org.opendcs.utils.logging.OpenDcsLoggerFactory;
-import org.slf4j.Logger;
 
 import decodes.db.DatabaseException;
 import decodes.util.DecodesSettings;

--- a/java/opendcs/src/main/java/org/opendcs/database/DatabaseService.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/DatabaseService.java
@@ -13,11 +13,13 @@ import javax.sql.DataSource;
 import org.opendcs.authentication.AuthSourceService;
 import org.opendcs.authentication.impl.NoOpAuthSourceProvider;
 import org.opendcs.database.api.OpenDcsDatabase;
+import org.opendcs.settings.api.OpenDcsSettings;
 import org.opendcs.spi.authentication.AuthSource;
 import org.opendcs.spi.database.DatabaseProvider;
 
 import decodes.db.DatabaseException;
 import decodes.util.DecodesSettings;
+import decodes.util.PropertiesOwner;
 import ilex.util.AuthException;
 
 public class DatabaseService
@@ -111,7 +113,22 @@ public class DatabaseService
      */
     private static DecodesSettings decodesSettingsFromJdbc(DataSource dataSource, Properties props) throws DatabaseException
     {
+
         DecodesSettings settings = new DecodesSettings();
+        return loadSettingsFromProperties(dataSource, settings);
+    }
+
+    /**
+     * NOTE: This will mutate the provided settings instance.
+     * @param <T> Type of Setttings
+     * @param dataSource
+     * @param settings settings instance on which to load data
+     * @param props previously loaded properties that may
+     * @return the passed in settings object
+     */
+    public static <T extends PropertiesOwner & OpenDcsSettings> T loadSettingsFromProperties(DataSource dataSource, T settings) throws DatabaseException
+    {
+        Properties props = new Properties();
         try (Connection conn = dataSource.getConnection();
              PreparedStatement stmt = conn.prepareStatement("select prop_name,prop_value from tsdb_property");
              ResultSet rs = stmt.executeQuery())
@@ -126,12 +143,11 @@ public class DatabaseService
                 }
             }
             settings.loadFromProperties(props);
+            return settings;
         }
         catch (SQLException ex)
         {
             throw new DatabaseException("Error retrieving settings data.", ex);
         }
-
-        return settings;
     }
 }

--- a/java/opendcs/src/main/java/org/opendcs/database/DatabaseService.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/DatabaseService.java
@@ -6,6 +6,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.ServiceLoader;
 
@@ -24,6 +25,7 @@ import decodes.db.DatabaseException;
 import decodes.util.DecodesSettings;
 import decodes.util.PropertiesOwner;
 import ilex.util.AuthException;
+import opendcs.util.functional.ThrowingFunction;
 
 public class DatabaseService
 {
@@ -49,34 +51,46 @@ public class DatabaseService
 
     public static OpenDcsDatabase getDatabaseFor(String appName, DecodesSettings settings, Properties credentials) throws DatabaseException
     {
+        return getDatabaseFor(settings, provider -> provider.createDatabase(appName, settings, credentials));
+    }
+
+    /**
+     * Handles the actual logic of looping through the providers
+     * @param settings
+     * @param createFunc function to apply once a valid provided is found.
+     * @return
+     * @throws DatabaseException
+     */
+    private static OpenDcsDatabase getDatabaseFor(DecodesSettings settings, ThrowingFunction<DatabaseProvider, OpenDcsDatabase, Exception> createFunc) throws DatabaseException
+    {
         loader.reload();
         final Iterator<DatabaseProvider> providers = loader.iterator();
         ArrayList<String> attemptedProviders = new ArrayList<>();
         while (providers.hasNext())
         {
-            final DatabaseProvider provider = providers.next();            
+            final DatabaseProvider provider = providers.next();
+            attemptedProviders.add(provider.getClass().getName());
             if (provider.canCreate(settings))
             {
                 try
                 {
-                    return provider.createDatabase(appName, settings, credentials);
+                    return createFunc.accept(provider);
                 }
                 catch (Exception ex)
                 {
                     throw new DatabaseException("Unable to create database instance.", ex);
                 }
             }
-            attemptedProviders.add(provider.getClass().getName());
         }
-        
+
         throw new DatabaseException(String.format("""
-                No provider found for database type  %s. Availabled types are %s.        
+                No provider found for database type  %s. Available types are %s.
                 """, settings.editDatabaseType, String.join(",", attemptedProviders)));
     }
 
     /**
      * Create database given a valid DataSource. Will load settings from the database.
-     * @param dataSource any valid javax.sql.DataSource. However, a connection pool is expected as multiple connections 
+     * @param dataSource any valid javax.sql.DataSource. However, a connection pool is expected as multiple connections
      *                   may be needed
      * @return
      * @throws DatabaseException any error with class initialization or loading of properties
@@ -102,20 +116,7 @@ public class DatabaseService
 
     private static OpenDcsDatabase createDatabaseFromSettings(DataSource dataSource, DecodesSettings settings) throws DatabaseException
     {
-        loader.reload();
-        final Iterator<DatabaseProvider> providers = loader.iterator();
-        ArrayList<String> attemptedProviders = new ArrayList<>();
-        while (providers.hasNext())
-        {
-            final DatabaseProvider provider = providers.next();
-            if (provider.canCreate(settings))
-            {
-                return provider.createDatabase(dataSource, settings);
-            }
-        }
-        throw new DatabaseException(String.format("""
-                No provider found for database type  %s. Availabled types are %s.        
-                """, settings.editDatabaseType, String.join(",", attemptedProviders)));
+        return getDatabaseFor(settings, provider -> provider.createDatabase(dataSource, settings));
     }
 
     /**

--- a/java/opendcs/src/main/java/org/opendcs/spi/database/DatabaseProvider.java
+++ b/java/opendcs/src/main/java/org/opendcs/spi/database/DatabaseProvider.java
@@ -3,7 +3,6 @@ package org.opendcs.spi.database;
 import decodes.db.DatabaseException;
 import decodes.util.DecodesSettings;
 
-import java.sql.SQLException;
 import java.util.Properties;
 
 import org.opendcs.database.api.OpenDcsDatabase;

--- a/java/opendcs/src/main/java/org/opendcs/spi/database/DatabaseProvider.java
+++ b/java/opendcs/src/main/java/org/opendcs/spi/database/DatabaseProvider.java
@@ -66,7 +66,10 @@ public interface DatabaseProvider
             {
                 var key = rs.getString("prop_name");
                 var value = rs.getString("prop_value");
-                props.put(key, value);
+                if (value != null || !rs.wasNull())
+                {
+                    props.put(key, value);
+                }
             }
         }
         catch (SQLException ex)

--- a/java/opendcs/src/main/java/org/opendcs/spi/database/DatabaseProvider.java
+++ b/java/opendcs/src/main/java/org/opendcs/spi/database/DatabaseProvider.java
@@ -49,33 +49,4 @@ public interface DatabaseProvider
      */
     OpenDcsDatabase createDatabase(javax.sql.DataSource dataSource, DecodesSettings settings) throws DatabaseException;
 
-    /**
-     * Load the tsdb_property table to a properties object.
-     * @param dataSource
-     * @return
-     * @throws DatabaseException
-     */
-    default Properties loadPropertiesTable(javax.sql.DataSource dataSource) throws DatabaseException
-    {
-        Properties props = new Properties();
-        try (var c = dataSource.getConnection();
-             var getProps = c.prepareStatement("select prop_name, prop_value from tsdb_property");
-             var rs = getProps.executeQuery())
-        {
-            while(rs.next())
-            {
-                var key = rs.getString("prop_name");
-                var value = rs.getString("prop_value");
-                if (value != null || !rs.wasNull())
-                {
-                    props.put(key, value);
-                }
-            }
-        }
-        catch (SQLException ex)
-        {
-            throw new DatabaseException("Unable to load properties.", ex);
-        }
-        return props;
-    }
 }

--- a/java/opendcs/src/main/java/org/opendcs/spi/database/DatabaseProvider.java
+++ b/java/opendcs/src/main/java/org/opendcs/spi/database/DatabaseProvider.java
@@ -3,6 +3,7 @@ package org.opendcs.spi.database;
 import decodes.db.DatabaseException;
 import decodes.util.DecodesSettings;
 
+import java.sql.SQLException;
 import java.util.Properties;
 
 import org.opendcs.database.api.OpenDcsDatabase;
@@ -47,4 +48,31 @@ public interface DatabaseProvider
      * @throws DatabaseException
      */
     OpenDcsDatabase createDatabase(javax.sql.DataSource dataSource, DecodesSettings settings) throws DatabaseException;
+
+    /**
+     * Load the tsdb_property table to a properties object.
+     * @param dataSource
+     * @return
+     * @throws DatabaseException
+     */
+    default Properties loadPropertiesTable(javax.sql.DataSource dataSource) throws DatabaseException
+    {
+        Properties props = new Properties();
+        try (var c = dataSource.getConnection();
+             var getProps = c.prepareStatement("select prop_name, prop_value from tsdb_property");
+             var rs = getProps.executeQuery())
+        {
+            while(rs.next())
+            {
+                var key = rs.getString("prop_name");
+                var value = rs.getString("prop_value");
+                props.put(key, value);
+            }
+        }
+        catch (SQLException ex)
+        {
+            throw new DatabaseException("Unable to load properties.", ex);
+        }
+        return props;
+    }
 }

--- a/java/opendcs/src/main/resources/META-INF/services/org.opendcs.spi.database.DatabaseProvider
+++ b/java/opendcs/src/main/resources/META-INF/services/org.opendcs.spi.database.DatabaseProvider
@@ -1,3 +1,1 @@
-opendcs.opentsdb.OpenTsdbProvider
 decodes.xml.jdbc.XmlDatabaseProvider
-decodes.cwms.CwmsDatabaseProvider


### PR DESCRIPTION
… settings to be loaded and set appropriate instances.

## Problem Description

While working on #1973 realized there were some settings we needed access to that we couldn't readily get.

## Solution

- Setup Implementation Specific Setting object and method to load values from the tsdb_property table.
- Also did some additional cleanup. Renaming class, using AutoService for meta-inf entries.

## how you tested the change

Existing integration tests. No functional change... wait should probably verify we can get the object. will add the test in a bit.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
