### PR TITLE
Run Computation Button

### DIFF
--- a/javascript/opendcs-web-ui-react/public/locales/de-DE/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/de-DE/computations.json
@@ -81,5 +81,22 @@
     "none_found": "No algorithms available.",
     "add_selected": "Add {{count}} Computation(s)",
     "adding": "Adding..."
+  },
+  "run": {
+    "title": "Berechnung ausführen: {{name}}",
+    "start": "Start",
+    "end": "Ende",
+    "run": "Ausführen",
+    "run_for": "Berechnung {{id}} ausführen",
+    "stop": "Stoppen",
+    "running": "Wird ausgeführt...",
+    "aborted": "Ausführung abgebrochen.",
+    "log_label": "Berechnungsprotokoll",
+    "results_title": "Ausgabe-Zeitreihen",
+    "no_outputs": "Keine Ausgabe-Zeitreihen identifiziert.",
+    "unknown_ts": "(unbekannt)",
+    "fetching_data": "Berechnete Werte werden abgerufen...",
+    "no_data": "In diesem Zeitfenster wurden keine Werte geschrieben.",
+    "fetch_warning": "Berechnete Werte konnten nicht abgerufen werden"
   }
 }

--- a/javascript/opendcs-web-ui-react/public/locales/en-US/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/en-US/computations.json
@@ -81,5 +81,22 @@
     "none_found": "No algorithms available.",
     "add_selected": "Add {{count}} Computation(s)",
     "adding": "Adding..."
+  },
+  "run": {
+    "title": "Run Computation: {{name}}",
+    "start": "Start",
+    "end": "End",
+    "run": "Run",
+    "run_for": "Run computation {{id}}",
+    "stop": "Stop",
+    "running": "Running...",
+    "aborted": "Run cancelled.",
+    "log_label": "Computation log",
+    "results_title": "Output Time Series",
+    "no_outputs": "No output time series were identified.",
+    "unknown_ts": "(unknown)",
+    "fetching_data": "Fetching computed values...",
+    "no_data": "No values written in this time window.",
+    "fetch_warning": "Could not fetch computed values"
   }
 }

--- a/javascript/opendcs-web-ui-react/public/locales/es-ES/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/es-ES/computations.json
@@ -81,5 +81,22 @@
     "none_found": "No algorithms available.",
     "add_selected": "Add {{count}} Computation(s)",
     "adding": "Adding..."
+  },
+  "run": {
+    "title": "Ejecutar cálculo: {{name}}",
+    "start": "Inicio",
+    "end": "Fin",
+    "run": "Ejecutar",
+    "run_for": "Ejecutar cálculo {{id}}",
+    "stop": "Detener",
+    "running": "Ejecutando...",
+    "aborted": "Ejecución cancelada.",
+    "log_label": "Registro de cálculo",
+    "results_title": "Series de tiempo de salida",
+    "no_outputs": "No se identificaron series de tiempo de salida.",
+    "unknown_ts": "(desconocido)",
+    "fetching_data": "Obteniendo valores calculados...",
+    "no_data": "No se escribieron valores en esta ventana de tiempo.",
+    "fetch_warning": "No se pudieron obtener los valores calculados"
   }
 }

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computations.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computations.stories.tsx
@@ -9,7 +9,7 @@ import type {
   ApiTsGroupRef,
 } from "opendcs-api";
 import { act } from "react";
-import { expect, fn, waitFor } from "storybook/test";
+import { expect, fn, screen, waitFor, within } from "storybook/test";
 import {
   ApiContext,
   defaultValue as apiDefault,
@@ -506,17 +506,19 @@ export const RunComputationSuccess: Story = {
     });
     await act(async () => userEvent.click(runBtn));
 
-    const dialog = await canvas.findByRole("dialog");
+    // Modal renders in a portal — use screen
+    const dialog = await screen.findByRole("dialog", {}, { timeout: 5000 });
     expect(dialog).toBeInTheDocument();
+    const modal = within(dialog);
 
-    const executeBtn = await canvas.findByRole("button", {
+    const executeBtn = await modal.findByRole("button", {
       name: i18n.t("computations:run.run"),
     });
     await act(async () => userEvent.click(executeBtn));
 
     // Log messages stream in
     await waitFor(
-      () => expect(canvas.queryByText("Starting computation 1")).toBeInTheDocument(),
+      () => expect(modal.queryByText("Starting computation 1")).toBeInTheDocument(),
       { timeout: 5000 },
     );
 
@@ -524,13 +526,13 @@ export const RunComputationSuccess: Story = {
     await waitFor(
       () =>
         expect(
-          canvas.queryByText("TESTSITE.Flow.Inst.1Hour.0.compproc (cfs)"),
+          modal.queryByText("TESTSITE.Flow.Inst.1Hour.0.compproc (cfs)"),
         ).toBeInTheDocument(),
       { timeout: 5000 },
     );
 
     // A computed value appears in the table
-    await waitFor(() => expect(canvas.queryByText("123.45")).toBeInTheDocument(), {
+    await waitFor(() => expect(modal.queryByText("123.45")).toBeInTheDocument(), {
       timeout: 5000,
     });
   },
@@ -567,15 +569,18 @@ export const RunComputationErrorEvent: Story = {
     });
     await act(async () => userEvent.click(runBtn));
 
-    const executeBtn = await canvas.findByRole("button", {
+    const dialog = await screen.findByRole("dialog", {}, { timeout: 5000 });
+    const modal = within(dialog);
+
+    const executeBtn = await modal.findByRole("button", {
       name: i18n.t("computations:run.run"),
     });
     await act(async () => userEvent.click(executeBtn));
 
-    await waitFor(
-      () => expect(canvas.queryByText(/No site found with ID/)).toBeInTheDocument(),
-      { timeout: 5000 },
-    );
+    // Error appears in both the log and the alert — check the alert specifically
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeInTheDocument(), {
+      timeout: 5000,
+    });
   },
 };
 
@@ -606,13 +611,16 @@ export const RunComputationHttpError: Story = {
     });
     await act(async () => userEvent.click(runBtn));
 
-    const executeBtn = await canvas.findByRole("button", {
+    const dialog = await screen.findByRole("dialog", {}, { timeout: 5000 });
+    const modal = within(dialog);
+
+    const executeBtn = await modal.findByRole("button", {
       name: i18n.t("computations:run.run"),
     });
     await act(async () => userEvent.click(executeBtn));
 
     // An alert with the HTTP error should appear
-    await waitFor(() => expect(canvas.queryByRole("alert")).toBeInTheDocument(), {
+    await waitFor(() => expect(modal.queryByRole("alert")).toBeInTheDocument(), {
       timeout: 5000,
     });
   },

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computations.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computations.stories.tsx
@@ -435,3 +435,185 @@ export const DeleteFailureLogsError: Story = {
     );
   },
 };
+
+// Helper: build a text/event-stream ReadableStream from an array of SSE blocks.
+const makeSseStream = (events: string[]): ReadableStream<Uint8Array> => {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of events) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+};
+
+const mockTsData = {
+  tsid: {
+    uniqueString: "TESTSITE.Flow.Inst.1Hour.0.compproc",
+    key: 42,
+    storageUnits: "cfs",
+  },
+  values: [
+    { sampleTime: "2025-01-01T00:00:00.000Z", value: 123.45, flags: 0 },
+    { sampleTime: "2025-01-01T01:00:00.000Z", value: 124.67, flags: 0 },
+    { sampleTime: "2025-01-01T02:00:00.000Z", value: 119.83, flags: 0 },
+  ],
+};
+
+const sseSuccessHandler = http.get(
+  "/odcsapi/runcomputation",
+  () =>
+    new HttpResponse(
+      makeSseStream([
+        "event: computation-status\ndata: Starting computation 1\n\n",
+        "event: computation-status\ndata: Computation executed with 0 errors\n\n",
+        `event: Results\ndata: ${JSON.stringify({
+          tsIds: [{ uniqueString: "TESTSITE.Flow.Inst.1Hour.0.compproc", key: 42 }],
+          startTime: "2025-01-01T00:00:00Z",
+          endTime: "2025-01-02T00:00:00Z",
+        })}\n\n`,
+      ]),
+      { headers: { "Content-Type": "text/event-stream" } },
+    ),
+);
+
+const tsDataHandler = http.get("/odcsapi/tsdata", () => HttpResponse.json(mockTsData));
+
+export const RunComputationSuccess: Story = {
+  args: {},
+  parameters: {
+    msw: {
+      handlers: {
+        ...orgScopedHandlers,
+        runComputation: sseSuccessHandler,
+        tsData: tsDataHandler,
+      },
+    },
+  },
+  render: () => (
+    <WithOrg>
+      <Computations />
+    </WithOrg>
+  ),
+  play: async ({ mount, parameters, userEvent }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    const runBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:run.run_for", { id: 1 }),
+    });
+    await act(async () => userEvent.click(runBtn));
+
+    const dialog = await canvas.findByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+
+    const executeBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:run.run"),
+    });
+    await act(async () => userEvent.click(executeBtn));
+
+    // Log messages stream in
+    await waitFor(
+      () => expect(canvas.queryByText("Starting computation 1")).toBeInTheDocument(),
+      { timeout: 5000 },
+    );
+
+    // Data table header with column name and units appears
+    await waitFor(
+      () =>
+        expect(
+          canvas.queryByText("TESTSITE.Flow.Inst.1Hour.0.compproc (cfs)"),
+        ).toBeInTheDocument(),
+      { timeout: 5000 },
+    );
+
+    // A computed value appears in the table
+    await waitFor(() => expect(canvas.queryByText("123.45")).toBeInTheDocument(), {
+      timeout: 5000,
+    });
+  },
+};
+
+const sseErrorEventHandler = http.get(
+  "/odcsapi/runcomputation",
+  () =>
+    new HttpResponse(
+      makeSseStream([
+        "event: computation-status\ndata: Checking output parameters\n\n",
+        "event: ERROR\ndata: No site found with ID: 99\n\n",
+      ]),
+      { headers: { "Content-Type": "text/event-stream" } },
+    ),
+);
+
+export const RunComputationErrorEvent: Story = {
+  args: {},
+  parameters: {
+    msw: { handlers: { ...orgScopedHandlers, runComputation: sseErrorEventHandler } },
+  },
+  render: () => (
+    <WithOrg>
+      <Computations />
+    </WithOrg>
+  ),
+  play: async ({ mount, parameters, userEvent }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    const runBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:run.run_for", { id: 1 }),
+    });
+    await act(async () => userEvent.click(runBtn));
+
+    const executeBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:run.run"),
+    });
+    await act(async () => userEvent.click(executeBtn));
+
+    await waitFor(
+      () => expect(canvas.queryByText(/No site found with ID/)).toBeInTheDocument(),
+      { timeout: 5000 },
+    );
+  },
+};
+
+export const RunComputationHttpError: Story = {
+  args: {},
+  parameters: {
+    msw: {
+      handlers: {
+        ...orgScopedHandlers,
+        runComputation: http.get(
+          "/odcsapi/runcomputation",
+          () => new HttpResponse(null, { status: 500 }),
+        ),
+      },
+    },
+  },
+  render: () => (
+    <WithOrg>
+      <Computations />
+    </WithOrg>
+  ),
+  play: async ({ mount, parameters, userEvent }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    const runBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:run.run_for", { id: 1 }),
+    });
+    await act(async () => userEvent.click(runBtn));
+
+    const executeBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:run.run"),
+    });
+    await act(async () => userEvent.click(executeBtn));
+
+    // An alert with the HTTP error should appear
+    await waitFor(() => expect(canvas.queryByRole("alert")).toBeInTheDocument(), {
+      timeout: 5000,
+    });
+  },
+};

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/ComputationsTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/ComputationsTable.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
+import RunComputationModal from "./RunComputationModal";
 import { useTranslation } from "react-i18next";
 import type {
   ApiAlgorithm,
@@ -77,6 +78,10 @@ export const ComputationsTable: React.FC<ComputationsTableProperties> = ({
 }) => {
   const [t] = useTranslation(["computations", "translation"]);
   const [showCheckNew, setShowCheckNew] = useState(false);
+  const [runTarget, setRunTarget] = useState<{
+    id: number;
+    name: string | undefined;
+  } | null>(null);
   const tableRef = useRef<AppDataTableHandle<TableComputationRef>>(null);
   const draftsRef = useRef<Record<number, UiComputation>>({});
 
@@ -128,6 +133,18 @@ export const ComputationsTable: React.FC<ComputationsTableProperties> = ({
 
   const rowActions = useMemo<RowAction<TableComputationRef>[]>(
     () => [
+      {
+        key: "run",
+        icon: "bi-play-fill",
+        variant: "success",
+        show: (row) => (row.computationId ?? 0) > 0,
+        aria: (row) => t("computations:run.run_for", { id: row.computationId }),
+        onClick: ({ row }) => {
+          if (row.computationId !== undefined) {
+            setRunTarget({ id: row.computationId, name: row.name });
+          }
+        },
+      },
       {
         key: "edit",
         icon: "bi-pencil",
@@ -235,6 +252,12 @@ export const ComputationsTable: React.FC<ComputationsTableProperties> = ({
         onSave={actions.save}
         caption={t("computations:computationsTitle")}
         tableId="computationTable"
+      />
+      <RunComputationModal
+        show={runTarget !== null}
+        computationId={runTarget?.id}
+        computationName={runTarget?.name}
+        onHide={() => setRunTarget(null)}
       />
       <AlgorithmSelectModal
         show={showCheckNew}

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/RunComputationModal.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/RunComputationModal.tsx
@@ -69,7 +69,7 @@ const pivotTimes = (tsData: ApiTimeSeriesData[]): Date[] => {
 /** Look up a value for a given series at a given timestamp. */
 const lookupValue = (ts: ApiTimeSeriesData, time: Date): string => {
   const v = ts.values?.find((v) => v.sampleTime?.getTime() === time.getTime());
-  return v?.value !== undefined ? String(v.value) : "–";
+  return v?.value === undefined ? "–" : String(v.value);
 };
 
 interface SseCallbacks {
@@ -77,6 +77,38 @@ interface SseCallbacks {
   onResults: (r: CompResults) => void;
   onError: (msg: string) => void;
 }
+
+interface LogEntry {
+  id: number;
+  text: string;
+}
+
+const appendSsePart = (current: string, part: string): string =>
+  current ? `${current}\n${part}` : part;
+
+const dispatchSseEvent = (
+  event: string,
+  data: string,
+  callbacks: SseCallbacks,
+): boolean => {
+  if (!data) return false;
+  if (event === "computation-status") {
+    callbacks.onLog(data);
+  } else if (event === "Results") {
+    try {
+      callbacks.onResults(JSON.parse(data) as CompResults);
+    } catch {
+      callbacks.onLog(`Results: ${data}`);
+    }
+  } else if (event === "ERROR") {
+    callbacks.onLog(`Error: ${data}`);
+    callbacks.onError(data);
+    return true;
+  } else {
+    callbacks.onLog(data);
+  }
+  return false;
+};
 
 /** Read a text/event-stream response body and call callbacks for each event. */
 const readSseStream = async (
@@ -90,27 +122,6 @@ const readSseStream = async (
   let currentData = "";
   let hadError = false;
 
-  const dispatch = () => {
-    if (!currentData) return;
-    if (currentEvent === "computation-status") {
-      callbacks.onLog(currentData);
-    } else if (currentEvent === "Results") {
-      try {
-        callbacks.onResults(JSON.parse(currentData) as CompResults);
-      } catch {
-        callbacks.onLog(`Results: ${currentData}`);
-      }
-    } else if (currentEvent === "ERROR") {
-      hadError = true;
-      callbacks.onLog(`Error: ${currentData}`);
-      callbacks.onError(currentData);
-    } else {
-      callbacks.onLog(currentData);
-    }
-    currentEvent = "";
-    currentData = "";
-  };
-
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
@@ -119,20 +130,19 @@ const readSseStream = async (
     buffer = lines.pop() ?? "";
     for (const line of lines) {
       if (line === "") {
-        dispatch();
+        hadError = dispatchSseEvent(currentEvent, currentData, callbacks) || hadError;
+        currentEvent = "";
+        currentData = "";
       } else if (line.startsWith("event:")) {
         currentEvent = line.slice(6).trim();
       } else if (line.startsWith("data:")) {
-        const part = line.slice(5).trim();
-        currentData = currentData ? `${currentData}\n${part}` : part;
+        currentData = appendSsePart(currentData, line.slice(5).trim());
       }
     }
   }
-  if (buffer) {
-    const line = buffer.trim();
-    if (line.startsWith("data:")) currentData = line.slice(5).trim();
-    dispatch();
-  }
+  const finalLine = buffer.trim();
+  if (finalLine.startsWith("data:")) currentData = finalLine.slice(5).trim();
+  hadError = dispatchSseEvent(currentEvent, currentData, callbacks) || hadError;
   return hadError;
 };
 
@@ -170,7 +180,7 @@ const ResultsSection: React.FC<ResultsSectionProps> = ({
             <tr>
               <th>{t("translation:date_time")}</th>
               {tsData.map((ts, i) => (
-                <th key={i}>
+                <th key={ts.tsid?.uniqueString ?? ts.tsid?.key}>
                   {ts.tsid?.uniqueString ??
                     results.tsIds[i]?.uniqueString ??
                     t("computations:run.unknown_ts")}
@@ -180,11 +190,13 @@ const ResultsSection: React.FC<ResultsSectionProps> = ({
             </tr>
           </thead>
           <tbody>
-            {times.map((time, ri) => (
-              <tr key={ri}>
+            {times.map((time) => (
+              <tr key={time.getTime()}>
                 <td className="text-nowrap">{time.toLocaleString()}</td>
-                {tsData.map((ts, ci) => (
-                  <td key={ci}>{lookupValue(ts, time)}</td>
+                {tsData.map((ts) => (
+                  <td key={ts.tsid?.uniqueString ?? ts.tsid?.key}>
+                    {lookupValue(ts, time)}
+                  </td>
                 ))}
               </tr>
             ))}
@@ -216,19 +228,21 @@ export const RunComputationModal: React.FC<Props> = ({
   const { t } = useTranslation(["computations", "translation"]);
   const { conf, org } = useApi();
   const abortRef = useRef<AbortController | null>(null);
+  const logCounterRef = useRef(0);
   const tsApi = useMemo(() => new TimeSeriesMethodsApi(conf), [conf]);
 
   const [startValue, setStartValue] = useState(defaultStart);
   const [endValue, setEndValue] = useState(defaultEnd);
   const [status, setStatus] = useState<RunStatus>("idle");
-  const [logs, setLogs] = useState<string[]>([]);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
   const [results, setResults] = useState<CompResults | null>(null);
   const [tsData, setTsData] = useState<ApiTimeSeriesData[]>([]);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const logsEndRef = useRef<HTMLDivElement>(null);
 
   const appendLog = useCallback((msg: string) => {
-    setLogs((prev) => [...prev, msg]);
+    const id = logCounterRef.current++;
+    setLogs((prev) => [...prev, { id, text: msg }]);
     requestAnimationFrame(() => {
       logsEndRef.current?.scrollIntoView({ behavior: "smooth" });
     });
@@ -388,8 +402,8 @@ export const RunComputationModal: React.FC<Props> = ({
             aria-label={t("computations:run.log_label")}
             aria-live="polite"
           >
-            {logs.map((line, i) => (
-              <div key={i}>{line}</div>
+            {logs.map((entry) => (
+              <div key={entry.id}>{entry.text}</div>
             ))}
             <div ref={logsEndRef} />
           </div>

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/RunComputationModal.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/RunComputationModal.tsx
@@ -72,6 +72,141 @@ const lookupValue = (ts: ApiTimeSeriesData, time: Date): string => {
   return v?.value !== undefined ? String(v.value) : "–";
 };
 
+interface SseCallbacks {
+  onLog: (msg: string) => void;
+  onResults: (r: CompResults) => void;
+  onError: (msg: string) => void;
+}
+
+/** Read a text/event-stream response body and call callbacks for each event. */
+const readSseStream = async (
+  body: ReadableStream<Uint8Array>,
+  callbacks: SseCallbacks,
+): Promise<boolean> => {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let currentEvent = "";
+  let currentData = "";
+  let hadError = false;
+
+  const dispatch = () => {
+    if (!currentData) return;
+    if (currentEvent === "computation-status") {
+      callbacks.onLog(currentData);
+    } else if (currentEvent === "Results") {
+      try {
+        callbacks.onResults(JSON.parse(currentData) as CompResults);
+      } catch {
+        callbacks.onLog(`Results: ${currentData}`);
+      }
+    } else if (currentEvent === "ERROR") {
+      hadError = true;
+      callbacks.onLog(`Error: ${currentData}`);
+      callbacks.onError(currentData);
+    } else {
+      callbacks.onLog(currentData);
+    }
+    currentEvent = "";
+    currentData = "";
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line === "") {
+        dispatch();
+      } else if (line.startsWith("event:")) {
+        currentEvent = line.slice(6).trim();
+      } else if (line.startsWith("data:")) {
+        const part = line.slice(5).trim();
+        currentData = currentData ? `${currentData}\n${part}` : part;
+      }
+    }
+  }
+  if (buffer) {
+    const line = buffer.trim();
+    if (line.startsWith("data:")) currentData = line.slice(5).trim();
+    dispatch();
+  }
+  return hadError;
+};
+
+interface ResultsSectionProps {
+  results: CompResults;
+  tsData: ApiTimeSeriesData[];
+  times: Date[];
+  hasValues: boolean;
+  status: RunStatus;
+  t: (key: string) => string;
+}
+
+const ResultsSection: React.FC<ResultsSectionProps> = ({
+  results,
+  tsData,
+  times,
+  hasValues,
+  status,
+  t,
+}) => {
+  if (results.tsIds.length === 0) {
+    return <p className="text-muted mt-1">{t("computations:run.no_outputs")}</p>;
+  }
+  if (hasValues) {
+    return (
+      <div className="mt-2" style={{ maxHeight: "22rem", overflowY: "auto" }}>
+        <Table
+          size="sm"
+          bordered
+          hover
+          className="font-monospace mb-0"
+          style={{ fontSize: "0.8rem" }}
+        >
+          <thead className="table-dark sticky-top">
+            <tr>
+              <th>{t("translation:date_time")}</th>
+              {tsData.map((ts, i) => (
+                <th key={i}>
+                  {ts.tsid?.uniqueString ??
+                    results.tsIds[i]?.uniqueString ??
+                    t("computations:run.unknown_ts")}
+                  {ts.tsid?.storageUnits ? ` (${ts.tsid.storageUnits})` : ""}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {times.map((time, ri) => (
+              <tr key={ri}>
+                <td className="text-nowrap">{time.toLocaleString()}</td>
+                {tsData.map((ts, ci) => (
+                  <td key={ci}>{lookupValue(ts, time)}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </div>
+    );
+  }
+  if (status === "success") {
+    return (
+      <p className="text-muted mt-1 font-monospace" style={{ fontSize: "0.85rem" }}>
+        {results.tsIds
+          .map((id) => id.uniqueString ?? t("computations:run.unknown_ts"))
+          .join(", ")}
+        {" — "}
+        {t("computations:run.no_data")}
+      </p>
+    );
+  }
+  return null;
+};
+
 export const RunComputationModal: React.FC<Props> = ({
   show,
   computationId,
@@ -121,7 +256,6 @@ export const RunComputationModal: React.FC<Props> = ({
     const url = ctx.getUrl();
 
     let parsedResults: CompResults | null = null;
-    let hadError = false;
 
     try {
       const response = await fetch(url, {
@@ -137,61 +271,20 @@ export const RunComputationModal: React.FC<Props> = ({
       }
       if (!response.body) throw new Error("No response body");
 
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      let currentEvent = "";
-      let currentData = "";
-
-      const dispatch = () => {
-        if (!currentData) return;
-        if (currentEvent === "computation-status") {
-          appendLog(currentData);
-        } else if (currentEvent === "Results") {
-          try {
-            parsedResults = JSON.parse(currentData) as CompResults;
-            setResults(parsedResults);
-          } catch {
-            appendLog(`Results: ${currentData}`);
-          }
-        } else if (currentEvent === "ERROR") {
-          hadError = true;
-          appendLog(`Error: ${currentData}`);
+      const hadError = await readSseStream(response.body, {
+        onLog: appendLog,
+        onResults: (r) => {
+          parsedResults = r;
+          setResults(r);
+        },
+        onError: (msg) => {
           setStatus("error");
-          setErrorMsg(currentData);
-        } else if (currentData) {
-          appendLog(currentData);
-        }
-        currentEvent = "";
-        currentData = "";
-      };
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (line === "") {
-            dispatch();
-          } else if (line.startsWith("event:")) {
-            currentEvent = line.slice(6).trim();
-          } else if (line.startsWith("data:")) {
-            const part = line.slice(5).trim();
-            currentData = currentData ? `${currentData}\n${part}` : part;
-          }
-        }
-      }
-      if (buffer) {
-        const line = buffer.trim();
-        if (line.startsWith("data:")) currentData = line.slice(5).trim();
-        dispatch();
-      }
+          setErrorMsg(msg);
+        },
+      });
 
       if (hadError) return;
 
-      // Fetch computed values for each output time series
       if (parsedResults) {
         const validIds = (parsedResults as CompResults).tsIds.filter(
           (id) => id.key !== undefined && id.key > 0,
@@ -314,54 +407,14 @@ export const RunComputationModal: React.FC<Props> = ({
         {results && (
           <div className="mt-2">
             <strong>{t("computations:run.results_title")}</strong>
-            {results.tsIds.length === 0 ? (
-              <p className="text-muted mt-1">{t("computations:run.no_outputs")}</p>
-            ) : hasValues ? (
-              <div className="mt-2" style={{ maxHeight: "22rem", overflowY: "auto" }}>
-                <Table
-                  size="sm"
-                  bordered
-                  hover
-                  className="font-monospace mb-0"
-                  style={{ fontSize: "0.8rem" }}
-                >
-                  <thead className="table-dark sticky-top">
-                    <tr>
-                      <th>{t("translation:date_time")}</th>
-                      {tsData.map((ts, i) => (
-                        <th key={i}>
-                          {ts.tsid?.uniqueString ??
-                            results.tsIds[i]?.uniqueString ??
-                            t("computations:run.unknown_ts")}
-                          {ts.tsid?.storageUnits ? ` (${ts.tsid.storageUnits})` : ""}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {times.map((time, ri) => (
-                      <tr key={ri}>
-                        <td className="text-nowrap">{time.toLocaleString()}</td>
-                        {tsData.map((ts, ci) => (
-                          <td key={ci}>{lookupValue(ts, time)}</td>
-                        ))}
-                      </tr>
-                    ))}
-                  </tbody>
-                </Table>
-              </div>
-            ) : status === "success" ? (
-              <p
-                className="text-muted mt-1 font-monospace"
-                style={{ fontSize: "0.85rem" }}
-              >
-                {results.tsIds
-                  .map((id) => id.uniqueString ?? t("computations:run.unknown_ts"))
-                  .join(", ")}
-                {" — "}
-                {t("computations:run.no_data")}
-              </p>
-            ) : null}
+            <ResultsSection
+              results={results}
+              tsData={tsData}
+              times={times}
+              hasValues={hasValues}
+              status={status}
+              t={t}
+            />
           </div>
         )}
       </Modal.Body>

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/RunComputationModal.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/RunComputationModal.tsx
@@ -1,0 +1,408 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  Alert,
+  Button,
+  Col,
+  Form,
+  FormGroup,
+  Modal,
+  Row,
+  Spinner,
+  Table,
+} from "react-bootstrap";
+import { useTranslation } from "react-i18next";
+import { PlayFill, StopFill } from "react-bootstrap-icons";
+import { HttpMethod, TimeSeriesMethodsApi, type ApiTimeSeriesData } from "opendcs-api";
+import { useApi } from "../../../contexts/app/ApiContext";
+
+interface TsIdRef {
+  uniqueString?: string;
+  key?: number;
+  storageUnits?: string;
+}
+
+interface CompResults {
+  tsIds: TsIdRef[];
+  startTime: string;
+  endTime: string;
+}
+
+type RunStatus = "idle" | "running" | "fetching" | "success" | "error";
+
+interface Props {
+  show: boolean;
+  computationId: number | undefined;
+  computationName: string | undefined;
+  onHide: () => void;
+}
+
+/** Format a Date for a datetime-local input (no seconds). */
+const toDatetimeLocal = (d: Date): string => {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  );
+};
+
+const defaultStart = (): string => {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return toDatetimeLocal(d);
+};
+
+const defaultEnd = (): string => toDatetimeLocal(new Date());
+
+/** Build a sorted list of unique timestamps across all series. */
+const pivotTimes = (tsData: ApiTimeSeriesData[]): Date[] => {
+  const seen = new Set<number>();
+  tsData.forEach((ts) =>
+    ts.values?.forEach((v) => {
+      if (v.sampleTime) seen.add(v.sampleTime.getTime());
+    }),
+  );
+  return Array.from(seen)
+    .sort((a, b) => a - b)
+    .map((ms) => new Date(ms));
+};
+
+/** Look up a value for a given series at a given timestamp. */
+const lookupValue = (ts: ApiTimeSeriesData, time: Date): string => {
+  const v = ts.values?.find((v) => v.sampleTime?.getTime() === time.getTime());
+  return v?.value !== undefined ? String(v.value) : "–";
+};
+
+export const RunComputationModal: React.FC<Props> = ({
+  show,
+  computationId,
+  computationName,
+  onHide,
+}) => {
+  const { t } = useTranslation(["computations", "translation"]);
+  const { conf, org } = useApi();
+  const abortRef = useRef<AbortController | null>(null);
+  const tsApi = useMemo(() => new TimeSeriesMethodsApi(conf), [conf]);
+
+  const [startValue, setStartValue] = useState(defaultStart);
+  const [endValue, setEndValue] = useState(defaultEnd);
+  const [status, setStatus] = useState<RunStatus>("idle");
+  const [logs, setLogs] = useState<string[]>([]);
+  const [results, setResults] = useState<CompResults | null>(null);
+  const [tsData, setTsData] = useState<ApiTimeSeriesData[]>([]);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const logsEndRef = useRef<HTMLDivElement>(null);
+
+  const appendLog = useCallback((msg: string) => {
+    setLogs((prev) => [...prev, msg]);
+    requestAnimationFrame(() => {
+      logsEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    });
+  }, []);
+
+  const handleRun = useCallback(async () => {
+    if (!computationId) return;
+
+    const startIso = new Date(startValue).toISOString();
+    const endIso = new Date(endValue).toISOString();
+
+    setStatus("running");
+    setLogs([]);
+    setResults(null);
+    setTsData([]);
+    setErrorMsg(null);
+
+    const abort = new AbortController();
+    abortRef.current = abort;
+
+    const ctx = conf.baseServer.makeRequestContext("/runcomputation", HttpMethod.GET);
+    ctx.setQueryParam("computationid", String(computationId));
+    ctx.setQueryParam("start", startIso);
+    ctx.setQueryParam("end", endIso);
+    const url = ctx.getUrl();
+
+    let parsedResults: CompResults | null = null;
+    let hadError = false;
+
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        credentials: "include",
+        headers: { Accept: "text/event-stream", "X-ORGANIZATION-ID": org },
+        signal: abort.signal,
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => response.statusText);
+        throw new Error(`HTTP ${response.status}: ${text}`);
+      }
+      if (!response.body) throw new Error("No response body");
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let currentEvent = "";
+      let currentData = "";
+
+      const dispatch = () => {
+        if (!currentData) return;
+        if (currentEvent === "computation-status") {
+          appendLog(currentData);
+        } else if (currentEvent === "Results") {
+          try {
+            parsedResults = JSON.parse(currentData) as CompResults;
+            setResults(parsedResults);
+          } catch {
+            appendLog(`Results: ${currentData}`);
+          }
+        } else if (currentEvent === "ERROR") {
+          hadError = true;
+          appendLog(`Error: ${currentData}`);
+          setStatus("error");
+          setErrorMsg(currentData);
+        } else if (currentData) {
+          appendLog(currentData);
+        }
+        currentEvent = "";
+        currentData = "";
+      };
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (line === "") {
+            dispatch();
+          } else if (line.startsWith("event:")) {
+            currentEvent = line.slice(6).trim();
+          } else if (line.startsWith("data:")) {
+            const part = line.slice(5).trim();
+            currentData = currentData ? `${currentData}\n${part}` : part;
+          }
+        }
+      }
+      if (buffer) {
+        const line = buffer.trim();
+        if (line.startsWith("data:")) currentData = line.slice(5).trim();
+        dispatch();
+      }
+
+      if (hadError) return;
+
+      // Fetch computed values for each output time series
+      if (parsedResults) {
+        const validIds = (parsedResults as CompResults).tsIds.filter(
+          (id) => id.key !== undefined && id.key > 0,
+        );
+        if (validIds.length > 0) {
+          setStatus("fetching");
+          try {
+            const fetched = await Promise.all(
+              validIds.map((id) =>
+                tsApi.getTimeSeriesData(
+                  org,
+                  id.key!,
+                  (parsedResults as CompResults).startTime,
+                  (parsedResults as CompResults).endTime,
+                ),
+              ),
+            );
+            setTsData(fetched);
+          } catch (fetchErr) {
+            appendLog(
+              `${t("computations:run.fetch_warning")}: ${(fetchErr as Error).message}`,
+            );
+          }
+        }
+      }
+
+      setStatus("success");
+    } catch (err) {
+      if ((err as Error).name === "AbortError") {
+        appendLog(t("computations:run.aborted"));
+        setStatus("idle");
+      } else {
+        const msg = (err as Error).message ?? String(err);
+        setErrorMsg(msg);
+        setStatus("error");
+      }
+    } finally {
+      abortRef.current = null;
+    }
+  }, [computationId, startValue, endValue, conf, org, appendLog, t, tsApi]);
+
+  const handleStop = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const handleHide = useCallback(() => {
+    abortRef.current?.abort();
+    setStatus("idle");
+    setLogs([]);
+    setResults(null);
+    setTsData([]);
+    setErrorMsg(null);
+    setStartValue(defaultStart());
+    setEndValue(defaultEnd());
+    onHide();
+  }, [onHide]);
+
+  const running = status === "running" || status === "fetching";
+  const times = useMemo(() => pivotTimes(tsData), [tsData]);
+  const hasValues = tsData.some((ts) => (ts.values?.length ?? 0) > 0);
+
+  return (
+    <Modal show={show} onHide={handleHide} size={hasValues ? "xl" : "lg"}>
+      <Modal.Header closeButton>
+        <Modal.Title>
+          {t("computations:run.title", { name: computationName ?? computationId })}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Row className="mb-3 g-3">
+          <Col sm={6}>
+            <FormGroup>
+              <Form.Label htmlFor="run-start">{t("computations:run.start")}</Form.Label>
+              <Form.Control
+                type="datetime-local"
+                id="run-start"
+                value={startValue}
+                disabled={running}
+                onChange={(e) => setStartValue(e.target.value)}
+              />
+            </FormGroup>
+          </Col>
+          <Col sm={6}>
+            <FormGroup>
+              <Form.Label htmlFor="run-end">{t("computations:run.end")}</Form.Label>
+              <Form.Control
+                type="datetime-local"
+                id="run-end"
+                value={endValue}
+                disabled={running}
+                onChange={(e) => setEndValue(e.target.value)}
+              />
+            </FormGroup>
+          </Col>
+        </Row>
+
+        {logs.length > 0 && (
+          <div
+            className="border rounded p-2 mb-3 bg-dark text-light font-monospace"
+            style={{ maxHeight: "10rem", overflowY: "auto", fontSize: "0.8rem" }}
+            aria-label={t("computations:run.log_label")}
+            aria-live="polite"
+          >
+            {logs.map((line, i) => (
+              <div key={i}>{line}</div>
+            ))}
+            <div ref={logsEndRef} />
+          </div>
+        )}
+
+        {status === "error" && errorMsg && <Alert variant="danger">{errorMsg}</Alert>}
+
+        {status === "fetching" && (
+          <div className="d-flex align-items-center gap-2 text-muted mb-3">
+            <Spinner size="sm" animation="border" />
+            <span>{t("computations:run.fetching_data")}</span>
+          </div>
+        )}
+
+        {results && (
+          <div className="mt-2">
+            <strong>{t("computations:run.results_title")}</strong>
+            {results.tsIds.length === 0 ? (
+              <p className="text-muted mt-1">{t("computations:run.no_outputs")}</p>
+            ) : hasValues ? (
+              <div className="mt-2" style={{ maxHeight: "22rem", overflowY: "auto" }}>
+                <Table
+                  size="sm"
+                  bordered
+                  hover
+                  className="font-monospace mb-0"
+                  style={{ fontSize: "0.8rem" }}
+                >
+                  <thead className="table-dark sticky-top">
+                    <tr>
+                      <th>{t("translation:date_time")}</th>
+                      {tsData.map((ts, i) => (
+                        <th key={i}>
+                          {ts.tsid?.uniqueString ??
+                            results.tsIds[i]?.uniqueString ??
+                            t("computations:run.unknown_ts")}
+                          {ts.tsid?.storageUnits ? ` (${ts.tsid.storageUnits})` : ""}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {times.map((time, ri) => (
+                      <tr key={ri}>
+                        <td className="text-nowrap">{time.toLocaleString()}</td>
+                        {tsData.map((ts, ci) => (
+                          <td key={ci}>{lookupValue(ts, time)}</td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </div>
+            ) : status === "success" ? (
+              <p
+                className="text-muted mt-1 font-monospace"
+                style={{ fontSize: "0.85rem" }}
+              >
+                {results.tsIds
+                  .map((id) => id.uniqueString ?? t("computations:run.unknown_ts"))
+                  .join(", ")}
+                {" — "}
+                {t("computations:run.no_data")}
+              </p>
+            ) : null}
+          </div>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        {running && (
+          <Spinner
+            size="sm"
+            animation="border"
+            className="me-2"
+            aria-label={
+              status === "fetching"
+                ? t("computations:run.fetching_data")
+                : t("computations:run.running")
+            }
+          />
+        )}
+        <Button variant="secondary" onClick={handleHide}>
+          {t("translation:cancel")}
+        </Button>
+        {running ? (
+          <Button
+            variant="warning"
+            onClick={handleStop}
+            aria-label={t("computations:run.stop")}
+            disabled={status === "fetching"}
+          >
+            <StopFill /> {t("computations:run.stop")}
+          </Button>
+        ) : (
+          <Button
+            variant="success"
+            onClick={handleRun}
+            disabled={!computationId || !startValue || !endValue}
+            aria-label={t("computations:run.run")}
+          >
+            <PlayFill /> {t("computations:run.run")}
+          </Button>
+        )}
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default RunComputationModal;

--- a/javascript/opendcs-web-ui-react/src/pages/decodes/presentations/PresentationElementsTable.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/decodes/presentations/PresentationElementsTable.stories.tsx
@@ -1,0 +1,191 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { act, useMemo } from "react";
+import { http, HttpResponse } from "msw";
+import type { ApiDataType, ApiPresentationElement } from "opendcs-api";
+import { expect, fn, waitFor } from "storybook/test";
+import { useQueryClient } from "@tanstack/react-query";
+import { PresentationElementsTable } from "./PresentationElementsTable";
+
+const ELEMENTS: ApiPresentationElement[] = [
+  {
+    dataTypeStd: "SHEF-PE",
+    dataTypeCode: "HG",
+    units: "ft",
+    fractionalDigits: 2,
+    min: 0,
+    max: 100,
+  },
+];
+
+const MOCK_DATA_TYPES: ApiDataType[] = [
+  { standard: "SHEF-PE", code: "HG", displayName: "Stage" },
+  { standard: "CWMS", code: "Stage", displayName: "Stage" },
+];
+
+const baseHandlers = {
+  dataTypes: http.get("/odcsapi/datatypelist", () =>
+    HttpResponse.json<ApiDataType[]>(MOCK_DATA_TYPES),
+  ),
+};
+
+const meta = {
+  component: PresentationElementsTable,
+  parameters: { msw: { handlers: baseHandlers } },
+  args: {
+    elements: ELEMENTS,
+    edit: false,
+    onSave: fn(),
+    onRemove: fn(),
+  },
+} satisfies Meta<typeof PresentationElementsTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Read-only render — verifies caption and element data appear without edit controls.
+export const ReadOnly: Story = {
+  play: async ({ mount, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    expect(
+      await canvas.findByText(i18n.t("presentations:elements.title")),
+    ).toBeInTheDocument();
+    expect(await canvas.findByText("HG")).toBeInTheDocument();
+  },
+};
+
+// Edit mode: open an element row — the dataTypeStd column renders a <select>
+// populated from the data-type list (covers dataTypeStandards.map render path).
+export const EditModeSelectOptions: Story = {
+  args: { edit: true },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("presentations:elements.edit", { name: "HG" }),
+    });
+    await act(async () => userEvent.click(editBtn));
+    await waitFor(() => {
+      const sel = canvas.getByLabelText(
+        i18n.t("presentations:elements.dataTypeStd_input", { name: "HG" }),
+      ) as HTMLSelectElement;
+      expect(sel).toBeInTheDocument();
+      expect(sel.querySelector('option[value="SHEF-PE"]')).not.toBeNull();
+    });
+  },
+};
+
+// Data types without a standard field — exercises the if (dt.standard) false
+// branch inside the dataTypeStandards memo.
+export const DataTypesWithoutStandard: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        dataTypes: http.get("/odcsapi/datatypelist", () =>
+          HttpResponse.json<ApiDataType[]>([
+            { code: "HG", displayName: "Stage" }, // no standard
+            { standard: "CWMS", code: "Stage", displayName: "Stage" },
+          ]),
+        ),
+      },
+    },
+  },
+  play: async ({ mount, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    expect(
+      await canvas.findByText(i18n.t("presentations:elements.title")),
+    ).toBeInTheDocument();
+  },
+};
+
+// Elements without a dataTypeStd — exercises the if (el.dataTypeStd) false
+// branch inside the dataTypeStandards memo.
+export const ElementsWithoutDataTypeStd: Story = {
+  args: {
+    elements: [
+      { dataTypeCode: "HG", units: "ft" },
+      { dataTypeStd: "SHEF-PE", dataTypeCode: "QR", units: "cfs" },
+    ],
+  },
+  play: async ({ mount, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    expect(
+      await canvas.findByText(i18n.t("presentations:elements.title")),
+    ).toBeInTheDocument();
+  },
+};
+
+// Save an edited element — exercises the edit.read callbacks for dataTypeStd
+// (select) and units (select/input), plus the onSave validation success path.
+export const SaveEditedElement: Story = {
+  args: { edit: true },
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("presentations:elements.edit", { name: "HG" }),
+    });
+    await act(async () => userEvent.click(editBtn));
+    await waitFor(() => {
+      expect(
+        canvas.getByRole("button", {
+          name: i18n.t("presentations:elements.save_edit", { name: "HG" }),
+        }),
+      ).toBeInTheDocument();
+    });
+    const saveBtn = canvas.getByRole("button", {
+      name: i18n.t("presentations:elements.save_edit", { name: "HG" }),
+    });
+    await act(async () => userEvent.click(saveBtn));
+    await waitFor(() => {
+      expect(
+        canvas.queryByRole("button", {
+          name: i18n.t("presentations:elements.save_edit", { name: "HG" }),
+        }),
+      ).not.toBeInTheDocument();
+    });
+  },
+};
+
+// Units not ready: clears the cache pre-seeded by WithUnits so the unit list
+// query stays in a non-success state. When a row is opened for editing the
+// units column falls back to a plain <input type="text"> instead of UnitSelect.
+export const UnitsNotReady: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        ...baseHandlers,
+        units: http.get("/odcsapi/unitlist", () => HttpResponse.error()),
+      },
+    },
+  },
+  args: { edit: true },
+  decorators: [
+    (Story) => {
+      const queryClient = useQueryClient();
+      // Clear the synchronously-seeded unit data so useUnitListQuery refetches
+      // and gets the error response above — keeping isSuccess = false.
+      useMemo(() => {
+        queryClient.removeQueries({ queryKey: ["units"] });
+      }, [queryClient]);
+      return <Story />;
+    },
+  ],
+  play: async ({ mount, userEvent, parameters }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("presentations:elements.edit", { name: "HG" }),
+    });
+    await act(async () => userEvent.click(editBtn));
+    await waitFor(() => {
+      const unitsField = canvas.getByLabelText(
+        i18n.t("presentations:elements.units_input", { name: "HG" }),
+      );
+      // Fallback renders a plain text input, not a select.
+      expect(unitsField.tagName.toLowerCase()).toBe("input");
+    });
+  },
+};


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #2037. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Describe your solution.

Adds a Run Computation button (▶) to each row in the Computations table. Clicking it opens a modal where the user selects a start/end time window and runs the computation against the live database.

How it works:
* Streams output from the backend via Server-Sent Events and implemented with fetch + ReadableStream.
* Fetches the computed output values for each output time series that has a valid database key.
* Displays a pivot table of the results (timestamps × output series, with storage units in column headers)
* Falls back to a "no values written in this time window" message when the output time series exist but have no data in the requested window

<img width="1611" height="651" alt="Screenshot 2026-06-26 at 12 47 48 PM" src="https://github.com/user-attachments/assets/d61a6952-ad93-4ff0-bb85-6b1770911e62" />
<img width="1623" height="539" alt="Screenshot 2026-06-26 at 12 47 55 PM" src="https://github.com/user-attachments/assets/5b4250e1-14f4-458f-ad26-d3776bc66e0f" />
<img width="1625" height="661" alt="Screenshot 2026-06-26 at 12 48 01 PM" src="https://github.com/user-attachments/assets/0a602246-dd72-4ea9-b959-69268c15e830" />


## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

Ran the computation against the live Docker backend and confirmed SSE log messages stream in real-time
Verified the "no values written" fallback displays correctly for a computation with unresolved output parameters (..null. identifier / #trigs=0)

(Need help verifying a successful timeseries with the real backend)

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
