### PR TITLE
Fix Copy/Create new computation

### DIFF
--- a/javascript/opendcs-web-ui-react/public/locales/de-DE/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/de-DE/computations.json
@@ -84,9 +84,9 @@
     "adding": "Adding..."
   },
   "run": {
-    "title": "Berechnung ausführen: {{name}}",
-    "start": "Start",
-    "end": "Ende",
+    "title": "Zeitbereich auswählen",
+    "start": "Von:",
+    "end": "Bis:",
     "run": "Ausführen",
     "run_for": "Berechnung {{id}} ausführen",
     "stop": "Stoppen",

--- a/javascript/opendcs-web-ui-react/public/locales/de-DE/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/de-DE/computations.json
@@ -35,7 +35,8 @@
     "now": "Jetzt",
     "now_minus": "Jetzt −",
     "calendar": "Kalender",
-    "interval": "Intervall"
+    "interval": "Intervall",
+    "save_error": "Speichern fehlgeschlagen. Bitte Eingaben prüfen und erneut versuchen."
   },
   "parms": {
     "title": "Parameter",

--- a/javascript/opendcs-web-ui-react/public/locales/en-US/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/en-US/computations.json
@@ -35,7 +35,8 @@
     "now": "Now",
     "now_minus": "Now −",
     "calendar": "Calendar",
-    "interval": "Interval"
+    "interval": "Interval",
+    "save_error": "Save failed. Please check your entries and try again."
   },
   "parms": {
     "title": "Parameters",

--- a/javascript/opendcs-web-ui-react/public/locales/en-US/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/en-US/computations.json
@@ -84,9 +84,9 @@
     "adding": "Adding..."
   },
   "run": {
-    "title": "Run Computation: {{name}}",
-    "start": "Start",
-    "end": "End",
+    "title": "Select Time Range",
+    "start": "From:",
+    "end": "To:",
     "run": "Run",
     "run_for": "Run computation {{id}}",
     "stop": "Stop",

--- a/javascript/opendcs-web-ui-react/public/locales/es-ES/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/es-ES/computations.json
@@ -35,7 +35,8 @@
     "now": "Ahora",
     "now_minus": "Ahora −",
     "calendar": "Calendario",
-    "interval": "Intervalo"
+    "interval": "Intervalo",
+    "save_error": "Error al guardar. Por favor verifique sus entradas e intente de nuevo."
   },
   "parms": {
     "title": "Parámetros",

--- a/javascript/opendcs-web-ui-react/public/locales/es-ES/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/es-ES/computations.json
@@ -84,9 +84,9 @@
     "adding": "Adding..."
   },
   "run": {
-    "title": "Ejecutar cálculo: {{name}}",
-    "start": "Inicio",
-    "end": "Fin",
+    "title": "Seleccionar intervalo de tiempo",
+    "start": "Desde:",
+    "end": "Hasta:",
     "run": "Ejecutar",
     "run_for": "Ejecutar cálculo {{id}}",
     "stop": "Detener",

--- a/javascript/opendcs-web-ui-react/src/components/data-table/AppDataTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/data-table/AppDataTable.tsx
@@ -694,9 +694,12 @@ export function AppDataTable<T, TId extends string | number, TSave = T>(
           // `await` works on thenables and passes through non-promises unchanged.
           try {
             await onSave?.(updated);
-          } catch {
-            // Caller reported the error; don't swallow here, but also
-            // don't block the UI transition — close the row regardless.
+          } catch (err) {
+            // For new local items, re-throw so the caller can display the
+            // error and the row stays in edit mode (the user hasn't lost their
+            // work). For existing server rows, closing is safe — they remain
+            // in the data list with their last-saved values.
+            if (isNewLocal) throw err;
           }
           if (isNewLocal) pendingNavRef.current = true;
           setLocalItems((prev) => withoutId(prev, id, idOf));

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computation.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computation.stories.tsx
@@ -594,6 +594,50 @@ export const EditEffectiveStartToCalendar: Story = {
   },
 };
 
+export const SaveErrorShowsDismissibleAlert: Story = {
+  args: {
+    computation: sampleComputation,
+    edit: true,
+    processOptions: sampleProcessOptions,
+    groupOptions: sampleGroupOptions,
+  },
+  render: (args) => (
+    <Computation
+      computation={args.computation as ApiComputation}
+      algorithm={args.algorithm as ApiAlgorithm}
+      edit={true}
+      actions={{
+        save: async () => {
+          throw new Error("simulated save failure");
+        },
+      }}
+      processOptions={args.processOptions}
+      groupOptions={args.groupOptions}
+    />
+  ),
+  play: async ({ mount, parameters, userEvent }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    const saveBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:editor.save_for", { id: 1 }),
+    });
+    await userEvent.click(saveBtn);
+
+    const alert = await canvas.findByText(i18n.t("computations:editor.save_error"));
+    expect(alert).toBeInTheDocument();
+
+    const dismissBtn = await canvas.findByRole("button", { name: /close/i });
+    await userEvent.click(dismissBtn);
+
+    await waitFor(() =>
+      expect(
+        canvas.queryByText(i18n.t("computations:editor.save_error")),
+      ).not.toBeInTheDocument(),
+    );
+  },
+};
+
 export const ComputationFromPromise: Story = {
   args: {
     computation: sampleComputation,

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computation.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computation.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Button,
   Card,
   Col,
@@ -211,6 +212,7 @@ export const Computation: React.FC<ComputationProperties> = ({
   );
   const [showAlgorithmModal, setShowAlgorithmModal] = useState(false);
   const [nameError, setNameError] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const handleAlgorithmSelected = useCallback(
     async (ref: ApiAlgorithmRef) => {
@@ -270,12 +272,17 @@ export const Computation: React.FC<ComputationProperties> = ({
         return;
       }
       setNameError(false);
-      actions.save?.({
-        ...(comp as ApiComputation),
-        parmList: localParms.map(prepareParmForSave),
-      });
+      setSaveError(null);
+      try {
+        await actions.save?.({
+          ...(comp as ApiComputation),
+          parmList: localParms.map(prepareParmForSave),
+        });
+      } catch (err) {
+        setSaveError(t("computations:editor.save_error"));
+      }
     },
-    [actions, localParms],
+    [actions, localParms, t],
   );
 
   const inputChange = useCallback(
@@ -557,6 +564,16 @@ export const Computation: React.FC<ComputationProperties> = ({
             />
           </Col>
         </Row>
+        {saveError && (
+          <Alert
+            variant="danger"
+            dismissible
+            onClose={() => setSaveError(null)}
+            className="mt-3"
+          >
+            {saveError}
+          </Alert>
+        )}
         {edit && (
           <Row className="mt-3">
             <Col className="d-flex justify-content-end gap-2">

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computation.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computation.tsx
@@ -279,6 +279,7 @@ export const Computation: React.FC<ComputationProperties> = ({
           parmList: localParms.map(prepareParmForSave),
         });
       } catch (err) {
+        console.warn("Computation save failed", err);
         setSaveError(t("computations:editor.save_error"));
       }
     },

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/ComputationsTable.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/ComputationsTable.stories.tsx
@@ -204,6 +204,59 @@ const ComputationsTableWrapper: React.FC<{ initialComps: ApiComputation[] }> = (
   );
 };
 
+const ComputationsTableWrapperWithSaveControl: React.FC<{
+  initialComps: ApiComputation[];
+  shouldFail: (comp: ApiComputation) => boolean;
+}> = ({ initialComps, shouldFail }) => {
+  const [localComps, setLocalComps] = useState<ApiComputation[]>(initialComps);
+  const localCompsRef = useRef(localComps);
+
+  useEffect(() => {
+    localCompsRef.current = localComps;
+  }, [localComps]);
+
+  const computationRefs = useMemo(() => toComputationRefs(localComps), [localComps]);
+
+  const localGetComputation = useCallback(
+    (id: number) => getComputationFromList(localCompsRef.current)(id),
+    [],
+  );
+  const localGetAlgorithm = useCallback(
+    (id: number) => getAlgorithmFromList(sharedAlgorithms)(id),
+    [],
+  );
+
+  const saveComputation = useCallback(
+    async (comp: ApiComputation) => {
+      if (shouldFail(comp)) {
+        throw new Error("simulated save failure");
+      }
+      setLocalComps((prev) => {
+        if (comp.computationId! < 0) {
+          return [...prev, { ...comp, computationId: nextSavedId++ }];
+        }
+        return prev.map((c) => (c.computationId === comp.computationId ? comp : c));
+      });
+    },
+    [shouldFail],
+  );
+
+  const removeComputation = useCallback((computationId: number) => {
+    setLocalComps((prev) => prev.filter((c) => c.computationId !== computationId));
+  }, []);
+
+  return (
+    <ComputationsTable
+      computations={computationRefs}
+      getComputation={localGetComputation}
+      getAlgorithm={localGetAlgorithm}
+      actions={{ save: saveComputation, remove: removeComputation }}
+      processOptions={sampleProcessOptions}
+      groupOptions={sampleGroupOptions}
+    />
+  );
+};
+
 const StoryRender: ArgsStoryFn<ReactRenderer, StoryArgs> = (args) => {
   const initialComps = sharedComputations.filter((c) =>
     (args.computations as ApiComputationRef[]).some(
@@ -330,6 +383,104 @@ export const CopyComputation: Story = {
       },
       { timeout: 5000 },
     );
+  },
+};
+
+// New rows that fail to save stay open in edit mode with the error surfaced,
+// so the user doesn't lose what they typed (see AppDataTable's `isNewLocal`
+// rethrow and Computation's save-error Alert).
+export const AddComputationSaveFails: Story = {
+  args: { computations: toComputationRefs(sharedComputations) },
+  render: (args) => {
+    const initialComps = sharedComputations.filter((c) =>
+      (args.computations as ApiComputationRef[]).some(
+        (ref) => ref.computationId === c.computationId,
+      ),
+    );
+    return (
+      <ComputationsTableWrapperWithSaveControl
+        initialComps={initialComps}
+        shouldFail={(comp) => (comp.computationId ?? 0) < 0}
+      />
+    );
+  },
+  play: async ({ mount, parameters, userEvent }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    const addBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:add_computation"),
+    });
+    await act(async () => userEvent.click(addBtn));
+
+    const nameInput = await canvas.findByRole(
+      "textbox",
+      { name: i18n.t("computations:editor.name") },
+      { timeout: 5000 },
+    );
+    await userEvent.type(nameInput, "NewComputation");
+
+    const saveBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:editor.save_for", { id: -1 }),
+    });
+    await act(async () => userEvent.click(saveBtn));
+
+    expect(
+      await canvas.findByText(i18n.t("computations:editor.save_error")),
+    ).toBeInTheDocument();
+
+    // Row stays in edit mode — the save button for id -1 is still present.
+    expect(
+      await canvas.findByRole("button", {
+        name: i18n.t("computations:editor.save_for", { id: -1 }),
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Existing rows that fail to save still close back to "show" mode — closing
+// is safe since the row keeps its last-saved values — so no error is shown.
+export const EditComputationSaveFails: Story = {
+  args: { computations: toComputationRefs(sharedComputations) },
+  render: (args) => {
+    const initialComps = sharedComputations.filter((c) =>
+      (args.computations as ApiComputationRef[]).some(
+        (ref) => ref.computationId === c.computationId,
+      ),
+    );
+    return (
+      <ComputationsTableWrapperWithSaveControl
+        initialComps={initialComps}
+        shouldFail={() => true}
+      />
+    );
+  },
+  play: async ({ mount, parameters, userEvent }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    const editBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:editor.edit_for", { id: 1 }),
+    });
+    await act(async () => userEvent.click(editBtn));
+
+    const saveBtn = await canvas.findByRole(
+      "button",
+      { name: i18n.t("computations:editor.save_for", { id: 1 }) },
+      { timeout: 5000 },
+    );
+    await act(async () => userEvent.click(saveBtn));
+
+    await waitFor(async () => {
+      const editBtnAfter = await canvas.findByRole("button", {
+        name: i18n.t("computations:editor.edit_for", { id: 1 }),
+      });
+      expect(editBtnAfter).toBeInTheDocument();
+    });
+
+    expect(
+      canvas.queryByText(i18n.t("computations:editor.save_error")),
+    ).not.toBeInTheDocument();
   },
 };
 


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #2036. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Describe your solution.
I believed AppDataTable's detail-save handler caught all errors from `onSave` and had removed the local draft item from the list.

AppDataTable.tsx re-throws the error when the failing row is a new
local item. New drafts stay in edit mode so the user
doesn't lose their work.

saveComputation now awaits actions.save and
catches the re-thrown error. 

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

Able to add a new computation and it populates the list. 
The copy button copies an existing computation and adds a new entry, leaving just the name slot open. Adding from algorithm also worked. 

## Where the following done:

- [x] Tests. Check all that apply:
   - [x] Unit tests created or modified that run during ant test.
   - [x] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [x] Test procedure descriptions for manual testing
- [x] Was relevant documentation updated?
- [x] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
