### PR TITLE
Add additional test to verify lat/long are saved and retrieved when c…

### DIFF
--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsSiteDaoTestIT.java
@@ -49,6 +49,8 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             site.setPublicName("A site that exists to test the new DAO");
             site.setElevation(50.0);
             site.setElevationUnits("ft");
+            site.latitude = "50.5";
+            site.longitude = "-178.5";
 
             site.setProperty("test_prop_1", "test_value_1");
             site.setProperty("test_prop_2", "test_value_2");
@@ -59,6 +61,9 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
 
             assertEquals("Bob's ville", site.nearestCity);
             assertTrue(siteOut.getLastModifyTime().getTime() >= timeSaved.getTime());
+
+            assertEquals(site.latitude, siteOut.latitude);
+            assertEquals(site.longitude, siteOut.longitude);
 
             final var siteByName2 = dao.getBySiteName(tx, siteName);
             assertTrue(siteByName2.isPresent());
@@ -71,6 +76,17 @@ class OpenDcsSiteDaoTestIT extends AppTestBase
             final var updateSiteOut = dao.save(tx, updateSiteIn);
             assertEquals("Bob's Town", updateSiteOut.nearestCity);
             assertEquals(updateSiteIn.getDisplayName(), updateSiteOut.getDisplayName());
+
+
+            var siteIn2 = new Site();
+            siteIn2.copyFrom(siteOut);
+
+            siteIn2.latitude = "15.5";
+
+            var siteUpdated = dao.save(tx, siteIn2);
+
+            assertEquals(siteIn2.latitude, siteUpdated.latitude);
+
 
             
             dao.delete(tx, siteOut.getId());


### PR DESCRIPTION
…reating or updating a location.

## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Check for #2025. 


## Solution

Implement additional test of the new DAO to verify lat/long information is saved and retrieved

## how you tested the change

No functional change, only new test.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
