### PR TITLE
Run Group Computations

### DIFF
--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/TimeSeriesResourcesIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/TimeSeriesResourcesIT.java
@@ -39,6 +39,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opendcs.odcsapi.util.DTOMappers.mapSite;
 
@@ -598,6 +599,78 @@ final class TimeSeriesResourcesIT extends BaseApiIT
 			}
 		}
 		assertEquals(expectedSiteList.size(), siteCount);
+	}
+
+	@Test
+	void testExpandGroup()
+	{
+		var response = given()
+			.log().ifValidationFails(LogDetail.ALL, true)
+			.accept(MediaType.APPLICATION_JSON)
+			.spec(authSpec)
+			.queryParam("groupid", tsGroupId)
+		.when()
+			.redirects().follow(true)
+			.redirects().max(3)
+			.get("expandgroup")
+		.then()
+			.log().ifValidationFails(LogDetail.ALL, true)
+		.assertThat()
+			.statusCode(is(Response.Status.OK.getStatusCode()))
+			.extract()
+		;
+
+		List<Map<String, Object>> expanded = response.body().jsonPath().getList("");
+		assertFalse(expanded.isEmpty(), "Expanded group should contain at least one time series");
+		// Every entry must have a uniqueString and a key
+		for (Map<String, Object> entry : expanded)
+		{
+			assertNotNull(entry.get("uniqueString"), "Each expanded TS must have a uniqueString");
+			assertNotNull(entry.get("key"), "Each expanded TS must have a key");
+		}
+		// The explicitly-listed active TS from the group fixture must appear in the expansion
+		String expectedTs = tsId.getUniqueString();
+		assertTrue(
+			expanded.stream().anyMatch(ts -> expectedTs.equals(ts.get("uniqueString"))),
+			"Active TS from group definition must appear in expanded list"
+		);
+	}
+
+	@Test
+	void testExpandGroupNotFound()
+	{
+		given()
+			.log().ifValidationFails(LogDetail.ALL, true)
+			.accept(MediaType.APPLICATION_JSON)
+			.spec(authSpec)
+			.queryParam("groupid", Long.MAX_VALUE)
+		.when()
+			.redirects().follow(true)
+			.redirects().max(3)
+			.get("expandgroup")
+		.then()
+			.log().ifValidationFails(LogDetail.ALL, true)
+		.assertThat()
+			.statusCode(is(Response.Status.NOT_FOUND.getStatusCode()))
+		;
+	}
+
+	@Test
+	void testExpandGroupMissingParam()
+	{
+		given()
+			.log().ifValidationFails(LogDetail.ALL, true)
+			.accept(MediaType.APPLICATION_JSON)
+			.spec(authSpec)
+		.when()
+			.redirects().follow(true)
+			.redirects().max(3)
+			.get("expandgroup")
+		.then()
+			.log().ifValidationFails(LogDetail.ALL, true)
+		.assertThat()
+			.statusCode(is(Response.Status.BAD_REQUEST.getStatusCode()))
+		;
 	}
 
 	@Test

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/TimeSeriesResourcesIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/TimeSeriesResourcesIT.java
@@ -628,10 +628,14 @@ final class TimeSeriesResourcesIT extends BaseApiIT
 			assertNotNull(entry.get("uniqueString"), "Each expanded TS must have a uniqueString");
 			assertNotNull(entry.get("key"), "Each expanded TS must have a key");
 		}
-		// The explicitly-listed active TS from the group fixture must appear in the expansion
-		String expectedTs = tsId.getUniqueString();
+		// The explicitly-listed active TS from the group fixture must appear in the expansion.
+		// Compare by key rather than uniqueString: the group's TS member list is cached as-written
+		// by the tsgroup POST (see TsGroupDAO#writeTsGroup), so uniqueString reflects the fixture's
+		// placeholder value rather than the value recomputed from the live TS, but the key is authoritative.
+		long expectedKey = tsId.getKey().getValue();
 		assertTrue(
-			expanded.stream().anyMatch(ts -> expectedTs.equals(ts.get("uniqueString"))),
+			expanded.stream().anyMatch(ts -> ts.get("key") != null
+				&& ((Number) ts.get("key")).longValue() == expectedKey),
 			"Active TS from group definition must appear in expanded list"
 		);
 	}

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppExceptionMapper.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppExceptionMapper.java
@@ -19,6 +19,7 @@ import decodes.tsdb.ConstraintException;
 import decodes.tsdb.TsdbException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
@@ -58,6 +59,7 @@ public final class AppExceptionMapper implements ExceptionMapper<Throwable>
 		Status status = new Status("Bad Request.  There was an issue with the request, please try again or contact your system administrator.");
 		return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
 				.entity(status)
+				.type(MediaType.APPLICATION_JSON)
 				.build();
 	}
 
@@ -66,6 +68,7 @@ public final class AppExceptionMapper implements ExceptionMapper<Throwable>
 		log.atWarn().setCause(wae).log("Unsupported endpoint");
 		return Response.status(Response.Status.NOT_IMPLEMENTED)
 				.entity(new Status(wae.getMessage()))
+				.type(MediaType.APPLICATION_JSON)
 				.build();
 	}
 
@@ -80,6 +83,7 @@ public final class AppExceptionMapper implements ExceptionMapper<Throwable>
 		int status = wae.getResponse().getStatus();
 		return Response.status(status)
 				.entity(new Status(message))
+				.type(MediaType.APPLICATION_JSON)
 				.build();
 	}
 
@@ -103,6 +107,7 @@ public final class AppExceptionMapper implements ExceptionMapper<Throwable>
 		log.atWarn().setCause(dbex).log(returnErrMsg);
 		return Response.status(Response.Status.BAD_REQUEST)
 				.entity(new Status(returnErrMsg))
+				.type(MediaType.APPLICATION_JSON)
 				.build();
 	}
 
@@ -127,6 +132,7 @@ public final class AppExceptionMapper implements ExceptionMapper<Throwable>
 
 		return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
 				.entity(new Status(INTERNAL_ERROR))
+				.type(MediaType.APPLICATION_JSON)
 				.build();
 	}
 
@@ -148,6 +154,7 @@ public final class AppExceptionMapper implements ExceptionMapper<Throwable>
 		}
 		return Response.status(Response.Status.BAD_REQUEST)
 				.entity(new Status(INTERNAL_ERROR))
+				.type(MediaType.APPLICATION_JSON)
 				.build();
 	}
 
@@ -164,6 +171,7 @@ public final class AppExceptionMapper implements ExceptionMapper<Throwable>
 		}
 		return Response.status(wae.getStatus())
 				.entity(new Status(wae.getMessage()))
+				.type(MediaType.APPLICATION_JSON)
 				.build();
 	}
 

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
@@ -64,6 +64,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
+import opendcs.dai.CompDependsDAI;
 import opendcs.dai.ComputationDAI;
 import opendcs.dai.SiteDAI;
 import opendcs.dai.TimeSeriesDAI;
@@ -292,7 +293,9 @@ public final class ComputationResources extends OpenDcsResource
 			summary = "Execute an Existing OpenDCS Computation",
 			description = "Endpoint takes in a computation name and a list of timeseries IDs to execute a computation. "
 					+ "Optionally takes in a start and end date for a time window to use for the computation. "
-					+ "For group computations, supply the tsid parameter to run against a specific input time series.",
+					+ "For group computations, supply the tsid parameter to run against a specific input time series. "
+					+ "If tsid is omitted for a group computation, the computation is expanded and run against "
+					+ "every time series that can currently trigger it.",
 			tags = {"REST - Computation Methods"},
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Successfully initiated execution of computation",
@@ -315,7 +318,9 @@ public final class ComputationResources extends OpenDcsResource
 					schema = @Schema(implementation = Instant.class, example = "2025-10-25T12:00:00Z"))
 			@QueryParam("end") String end,
 			@Parameter(description = "Time series key to use as the group computation input. "
-					+ "When provided the group computation is resolved against this specific time series.",
+					+ "When provided the group computation is resolved against this specific time series. "
+					+ "When omitted for a group computation, the computation is expanded against every "
+					+ "time series that can currently trigger it.",
 					schema = @Schema(implementation = Long.class))
 			@QueryParam("tsid") Long tsId)
 			throws DbException, WebAppException
@@ -329,17 +334,13 @@ public final class ComputationResources extends OpenDcsResource
 
 		try(ComputationDAI dai = getLegacyTimeseriesDB().makeComputationDAO();
 			TimeSeriesDAI tsDai = getLegacyTimeseriesDB().makeTimeSeriesDAO();
-			SiteDAI siteDai = getLegacyTimeseriesDB().makeSiteDAO())
+			SiteDAI siteDai = getLegacyTimeseriesDB().makeSiteDAO();
+			CompDependsDAI compDependsDai = getLegacyTimeseriesDB().makeCompDependsDAO())
 		{
 			DbComputation comp = dai.getComputationById(DbKey.createDbKey(computationId));
 
-			if (tsId != null && comp.hasGroupInput())
-			{
-				TimeSeriesIdentifier inputTsid = tsDai.getTimeSeriesIdentifier(DbKey.createDbKey(tsId));
-				comp = DbCompResolver.makeConcrete(getLegacyTimeseriesDB(), tsDai, inputTsid, comp, true);
-			}
+			List<DbComputation> resolvedComps = resolveComputations(comp, computationId, tsId, tsDai, compDependsDai);
 
-			final DbComputation resolvedComp = comp;
 			String taskID = UUID.randomUUID().toString();
 
 			final Instant startTime = Instant.parse(start);
@@ -347,7 +348,11 @@ public final class ComputationResources extends OpenDcsResource
 			Date startDate = Date.from(startTime);
 			Date endDate = Date.from(endTime);
 
-			List<TimeSeriesIdentifier> outputList = processOutputTsIds(resolvedComp, tsDai, siteDai, computationId, taskID, sse, eventSink);
+			List<TimeSeriesIdentifier> outputList = new ArrayList<>();
+			for(DbComputation resolvedComp : resolvedComps)
+			{
+				outputList.addAll(processOutputTsIds(resolvedComp, tsDai, siteDai, computationId, taskID, sse, eventSink));
+			}
 
 			final var contextMap = MDC.getCopyOfContextMap();
 			CompletableFuture.runAsync(() ->
@@ -366,7 +371,7 @@ public final class ComputationResources extends OpenDcsResource
 					{
 						MDC.setContextMap(contextMap);
 					}
-					executeAndPublishResult(computationId, resolvedComp, startDate, endDate, sse, eventSink, compStatus, taskID);
+					executeAndPublishResult(computationId, resolvedComps, startDate, endDate, sse, eventSink, compStatus, taskID);
 				}
 				catch (RuntimeException ex)
 				{
@@ -408,6 +413,49 @@ public final class ComputationResources extends OpenDcsResource
 		{
 			throw new DbException(String.format("Error retrieving computation to execute by ID: %s", computationId), ex);
 		}
+	}
+
+	/**
+	 * Resolves the computation(s) that should actually be executed. Non-group computations
+	 * run as-is. Group computations are made concrete against either the single supplied
+	 * tsid, or -- if none was supplied -- against every time series currently known to
+	 * trigger the computation, mirroring the expansion the thick-client comp-run tool performs.
+	 */
+	private List<DbComputation> resolveComputations(DbComputation comp, Long computationId, Long tsId,
+			TimeSeriesDAI tsDai, CompDependsDAI compDependsDai) throws DbIoException, NoSuchObjectException
+	{
+		if (!comp.hasGroupInput())
+		{
+			return List.of(comp);
+		}
+
+		if (tsId != null)
+		{
+			TimeSeriesIdentifier inputTsid = tsDai.getTimeSeriesIdentifier(DbKey.createDbKey(tsId));
+			return List.of(DbCompResolver.makeConcrete(getLegacyTimeseriesDB(), tsDai, inputTsid, comp, true));
+		}
+
+		DbCompResolver resolver = new DbCompResolver(getLegacyTimeseriesDB());
+		List<DbComputation> resolvedComps = new ArrayList<>();
+		for(TimeSeriesIdentifier trigger : compDependsDai.getTriggersFor(DbKey.createDbKey(computationId)))
+		{
+			try
+			{
+				DbComputation concrete = DbCompResolver.makeConcrete(getLegacyTimeseriesDB(), tsDai, trigger, comp, true);
+				resolver.addToResults(resolvedComps, concrete, null);
+			}
+			catch(NoSuchObjectException ex)
+			{
+				log.warn("Skipping trigger '{}' for group computation ID: {} -- {}",
+						trigger.getUniqueString(), computationId, ex.getMessage());
+			}
+		}
+		if (resolvedComps.isEmpty())
+		{
+			throw new NoSuchObjectException(
+					String.format("No resolvable input time series found for group computation ID: %s", computationId));
+		}
+		return resolvedComps;
 	}
 
 	private List<TimeSeriesIdentifier> processOutputTsIds(DbComputation comp, TimeSeriesDAI tsDai, SiteDAI siteDai,
@@ -490,13 +538,13 @@ public final class ComputationResources extends OpenDcsResource
 		return outputList;
 	}
 
-	private void executeAndPublishResult(Long computationId, DbComputation comp, Date startDate, Date endDate,
+	private void executeAndPublishResult(Long computationId, List<DbComputation> comps, Date startDate, Date endDate,
 			Sse sse, SseEventSink eventSink, String compStatus, String taskID)
 	{
 		try (ComputationExecution execution = new ComputationExecution(createDb()))
 		{
 			SseProgressListener listener = new SseProgressListener(eventSink, sse, compStatus, taskID);
-			ComputationExecution.CompResults results = execution.execute(List.of(comp), new DataCollection(), startDate, endDate, listener);
+			ComputationExecution.CompResults results = execution.execute(comps, new DataCollection(), startDate, endDate, listener);
 
 			OutboundSseEvent event = sse.newEventBuilder()
 					.name(compStatus)

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
@@ -208,11 +208,14 @@ public final class ComputationResources extends OpenDcsResource
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing OpenDCS Computation",
-			description = "The Computation POST method takes a single OpenDCS Computation Record in JSON format,"
-					+ " as described above for GET.  \n\n"
-					+ "For creating a new record, leave computationId out of the passed data structure.  \n\n"
-					+ "For overwriting an existing one, include the computationId that was previously returned. "
-					+ "The computation in the database is replaced with the one sent.",
+			description = """
+					The Computation POST method takes a single OpenDCS Computation Record in JSON format, \
+					as described above for GET. \s
+
+					For creating a new record, leave computationId out of the passed data structure. \s
+
+					For overwriting an existing one, include the computationId that was previously returned. \
+					The computation in the database is replaced with the one sent.""",
 			tags = {"REST - Computation Methods"},
 			requestBody = @RequestBody(
 					description = "Computation",
@@ -291,11 +294,12 @@ public final class ComputationResources extends OpenDcsResource
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Execute an Existing OpenDCS Computation",
-			description = "Endpoint takes in a computation name and a list of timeseries IDs to execute a computation. "
-					+ "Optionally takes in a start and end date for a time window to use for the computation. "
-					+ "For group computations, supply the tsid parameter to run against a specific input time series. "
-					+ "If tsid is omitted for a group computation, the computation is expanded and run against "
-					+ "every time series that can currently trigger it.",
+			description = """
+					Endpoint takes in a computation name and a list of timeseries IDs to execute a computation. \
+					Optionally takes in a start and end date for a time window to use for the computation. \
+					For group computations, supply the tsid parameter to run against a specific input time series. \
+					If tsid is omitted for a group computation, the computation is expanded and run against \
+					every time series that can currently trigger it.""",
 			tags = {"REST - Computation Methods"},
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Successfully initiated execution of computation",
@@ -317,10 +321,11 @@ public final class ComputationResources extends OpenDcsResource
 			@Parameter(required = true, description = "Parameter to specify the end of the time range to execute the computation on",
 					schema = @Schema(implementation = Instant.class, example = "2025-10-25T12:00:00Z"))
 			@QueryParam("end") String end,
-			@Parameter(description = "Time series key to use as the group computation input. "
-					+ "When provided the group computation is resolved against this specific time series. "
-					+ "When omitted for a group computation, the computation is expanded against every "
-					+ "time series that can currently trigger it.",
+			@Parameter(description = """
+					Time series key to use as the group computation input. \
+					When provided the group computation is resolved against this specific time series. \
+					When omitted for a group computation, the computation is expanded against every \
+					time series that can currently trigger it.""",
 					schema = @Schema(implementation = Long.class))
 			@QueryParam("tsid") Long tsId)
 			throws DbException, WebAppException

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
@@ -36,6 +36,7 @@ import decodes.tsdb.ConstraintException;
 import decodes.tsdb.DataCollection;
 import decodes.tsdb.DbCompParm;
 import decodes.tsdb.DbComputation;
+import decodes.tsdb.DbCompResolver;
 import decodes.tsdb.DbIoException;
 import decodes.tsdb.NoSuchObjectException;
 import decodes.tsdb.ProgressListener;
@@ -290,7 +291,8 @@ public final class ComputationResources extends OpenDcsResource
 	@Operation(
 			summary = "Execute an Existing OpenDCS Computation",
 			description = "Endpoint takes in a computation name and a list of timeseries IDs to execute a computation. "
-					+ "Optionally takes in a start and end date for a time window to use for the computation",
+					+ "Optionally takes in a start and end date for a time window to use for the computation. "
+					+ "For group computations, supply the tsid parameter to run against a specific input time series.",
 			tags = {"REST - Computation Methods"},
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Successfully initiated execution of computation",
@@ -311,7 +313,11 @@ public final class ComputationResources extends OpenDcsResource
 			@QueryParam("start") String start,
 			@Parameter(required = true, description = "Parameter to specify the end of the time range to execute the computation on",
 					schema = @Schema(implementation = Instant.class, example = "2025-10-25T12:00:00Z"))
-			@QueryParam("end") String end)
+			@QueryParam("end") String end,
+			@Parameter(description = "Time series key to use as the group computation input. "
+					+ "When provided the group computation is resolved against this specific time series.",
+					schema = @Schema(implementation = Long.class))
+			@QueryParam("tsid") Long tsId)
 			throws DbException, WebAppException
 	{
 		final String compStatus = "computation-status";
@@ -327,6 +333,13 @@ public final class ComputationResources extends OpenDcsResource
 		{
 			DbComputation comp = dai.getComputationById(DbKey.createDbKey(computationId));
 
+			if (tsId != null && comp.hasGroupInput())
+			{
+				TimeSeriesIdentifier inputTsid = tsDai.getTimeSeriesIdentifier(DbKey.createDbKey(tsId));
+				comp = DbCompResolver.makeConcrete(getLegacyTimeseriesDB(), tsDai, inputTsid, comp, true);
+			}
+
+			final DbComputation resolvedComp = comp;
 			String taskID = UUID.randomUUID().toString();
 
 			final Instant startTime = Instant.parse(start);
@@ -334,7 +347,7 @@ public final class ComputationResources extends OpenDcsResource
 			Date startDate = Date.from(startTime);
 			Date endDate = Date.from(endTime);
 
-			List<TimeSeriesIdentifier> outputList = processOutputTsIds(comp, tsDai, siteDai, computationId, taskID, sse, eventSink);
+			List<TimeSeriesIdentifier> outputList = processOutputTsIds(resolvedComp, tsDai, siteDai, computationId, taskID, sse, eventSink);
 
 			final var contextMap = MDC.getCopyOfContextMap();
 			CompletableFuture.runAsync(() ->
@@ -353,7 +366,7 @@ public final class ComputationResources extends OpenDcsResource
 					{
 						MDC.setContextMap(contextMap);
 					}
-					executeAndPublishResult(computationId, comp, startDate, endDate, sse, eventSink, compStatus, taskID);
+					executeAndPublishResult(computationId, resolvedComp, startDate, endDate, sse, eventSink, compStatus, taskID);
 				}
 				catch (RuntimeException ex)
 				{

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
@@ -396,7 +396,13 @@ public final class ComputationResources extends OpenDcsResource
 		}
 		catch(NoSuchObjectException ex)
 		{
-			throw new DatabaseItemNotFoundException(String.format("Computation with ID %s not found", computationId), ex);
+			// NoSuchObjectException is also thrown by the group-input resolution above (unknown
+			// tsid, or a parm that can't be resolved against it) -- prefer that specific message
+			// over a generic "computation not found" when one is available.
+			String message = ex.getMessage() != null
+					? ex.getMessage()
+					: String.format("Computation with ID %s not found", computationId);
+			throw new DatabaseItemNotFoundException(message, ex);
 		}
 		catch(DbIoException ex)
 		{

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
@@ -764,6 +764,56 @@ public final class TimeSeriesResources extends OpenDcsResource
 		return ret;
 	}
 
+	@GET
+	@Path("expandgroup")
+	@Produces(MediaType.APPLICATION_JSON)
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
+	@Operation(
+			summary = "Expand a time series group to its full list of member time series identifiers.",
+			description = "Returns the fully-expanded list of time series identifiers that belong to the "
+					+ "specified group, including members from sub-groups, attribute-based filters, "
+					+ "and include/exclude/intersect relationships.  \n\n"
+					+ "Example URL:  \n\n    http://localhost:8080/odcsapi/expandgroup?groupid=9\n\n",
+			responses = {
+					@ApiResponse(responseCode = "200", description = "Successfully expanded time series group",
+							content = @Content(mediaType = MediaType.APPLICATION_JSON,
+									array = @ArraySchema(schema = @Schema(implementation = ApiTimeSeriesIdentifier.class)))),
+					@ApiResponse(responseCode = "400", description = "Invalid or missing group ID"),
+					@ApiResponse(responseCode = "404", description = "Time series group not found"),
+					@ApiResponse(responseCode = "500", description = "Database error occurred")
+			},
+			tags = {"Time Series Methods - Groups"}
+	)
+	public Response expandGroup(@Parameter(description = "Group ID to expand", required = true,
+			schema = @Schema(implementation = Long.class), example = "9")
+		@QueryParam("groupid") Long groupId)
+			throws WebAppException, DbException
+	{
+		if (groupId == null)
+		{
+			throw new MissingParameterException("Missing required groupid parameter.");
+		}
+		try (TsGroupDAI dai = getLegacyTimeseriesDB().makeTsGroupDAO())
+		{
+			TsGroup group = dai.getTsGroupById(DbKey.createDbKey(groupId));
+			if (group == null)
+			{
+				throw new DatabaseItemNotFoundException("Time series group with ID=" + groupId + " not found");
+			}
+			ArrayList<TimeSeriesIdentifier> expanded = getLegacyTimeseriesDB().expandTsGroup(group);
+			List<ApiTimeSeriesIdentifier> result = new ArrayList<>();
+			for (TimeSeriesIdentifier tsid : expanded)
+			{
+				result.add(mapTsId(tsid));
+			}
+			return Response.ok().entity(result).build();
+		}
+		catch (DbIoException ex)
+		{
+			throw new DbException("Unable to expand time series group by ID", ex);
+		}
+	}
+
 	@POST
 	@Path("tsgroup")
 	@Consumes(MediaType.APPLICATION_JSON)

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
@@ -18,13 +18,17 @@ package org.opendcs.odcsapi.res;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
+import java.util.TreeSet;
 
 import decodes.cwms.CwmsTsId;
 import decodes.hdb.HdbTsId;
 import decodes.sql.DbKey;
 import decodes.tsdb.BadTimeSeriesException;
 import decodes.tsdb.CTimeSeries;
+import decodes.tsdb.DbComputation;
+import decodes.tsdb.DbCompParm;
 import decodes.tsdb.DbIoException;
 import decodes.tsdb.IntervalCodes;
 import decodes.tsdb.NoSuchObjectException;
@@ -53,6 +57,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import opendcs.dai.ComputationDAI;
 import opendcs.dai.IntervalDAI;
 import opendcs.dai.TimeSeriesDAI;
 import opendcs.dai.TsGroupDAI;
@@ -773,27 +778,38 @@ public final class TimeSeriesResources extends OpenDcsResource
 			description = "Returns the fully-expanded list of time series identifiers that belong to the "
 					+ "specified group, including members from sub-groups, attribute-based filters, "
 					+ "and include/exclude/intersect relationships.  \n\n"
+					+ "When computationid is also supplied, each expanded member is transformed against "
+					+ "that computation's first input parameter -- the same filtering the desktop client's "
+					+ "Run Computation dialog performs before offering a group's members for selection -- "
+					+ "so only members the computation can actually resolve an input time series for are "
+					+ "returned.  \n\n"
 					+ "Example URL:  \n\n    http://localhost:8080/odcsapi/expandgroup?groupid=9\n\n",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Successfully expanded time series group",
 							content = @Content(mediaType = MediaType.APPLICATION_JSON,
 									array = @ArraySchema(schema = @Schema(implementation = ApiTimeSeriesIdentifier.class)))),
 					@ApiResponse(responseCode = "400", description = "Invalid or missing group ID"),
-					@ApiResponse(responseCode = "404", description = "Time series group not found"),
+					@ApiResponse(responseCode = "404", description = "Time series group, or computation, not found"),
 					@ApiResponse(responseCode = "500", description = "Database error occurred")
 			},
 			tags = {"Time Series Methods - Groups"}
 	)
 	public Response expandGroup(@Parameter(description = "Group ID to expand", required = true,
 			schema = @Schema(implementation = Long.class), example = "9")
-		@QueryParam("groupid") Long groupId)
+		@QueryParam("groupid") Long groupId,
+			@Parameter(description = "Optional computation ID. When supplied, expanded members are "
+					+ "transformed against the computation's first input parameter and only the "
+					+ "members that resolve are returned.",
+					schema = @Schema(implementation = Long.class))
+		@QueryParam("computationid") Long computationId)
 			throws WebAppException, DbException
 	{
 		if (groupId == null)
 		{
 			throw new MissingParameterException("Missing required groupid parameter.");
 		}
-		try (TsGroupDAI dai = getLegacyTimeseriesDB().makeTsGroupDAO())
+		try (TsGroupDAI dai = getLegacyTimeseriesDB().makeTsGroupDAO();
+			TimeSeriesDAI tsDai = getLegacyTimeseriesDB().makeTimeSeriesDAO())
 		{
 			TsGroup group = dai.getTsGroupById(DbKey.createDbKey(groupId));
 			if (group == null)
@@ -801,8 +817,11 @@ public final class TimeSeriesResources extends OpenDcsResource
 				throw new DatabaseItemNotFoundException("Time series group with ID=" + groupId + " not found");
 			}
 			ArrayList<TimeSeriesIdentifier> expanded = getLegacyTimeseriesDB().expandTsGroup(group);
+			List<TimeSeriesIdentifier> candidates = computationId != null
+					? transformByFirstInput(expanded, computationId, tsDai)
+					: expanded;
 			List<ApiTimeSeriesIdentifier> result = new ArrayList<>();
-			for (TimeSeriesIdentifier tsid : expanded)
+			for (TimeSeriesIdentifier tsid : candidates)
 			{
 				result.add(mapTsId(tsid));
 			}
@@ -812,6 +831,59 @@ public final class TimeSeriesResources extends OpenDcsResource
 		{
 			throw new DbException("Unable to expand time series group by ID", ex);
 		}
+		catch (NoSuchObjectException ex)
+		{
+			throw new DatabaseItemNotFoundException(String.format("Computation with ID %s not found", computationId), ex);
+		}
+	}
+
+	/**
+	 * A group's raw expansion is typically broader than any single computation parameter needs
+	 * (it can span datatypes/intervals the parm doesn't use), so its members aren't all valid
+	 * run candidates as-is. Mirrors decodes.tsdb.comprungui.CompRunGuiFrame#buildComputationList:
+	 * transform each raw member through the computation's first input parameter, keeping only
+	 * the ones that resolve, deduplicated.
+	 */
+	private List<TimeSeriesIdentifier> transformByFirstInput(List<TimeSeriesIdentifier> expanded,
+			Long computationId, TimeSeriesDAI tsDai) throws DbIoException, NoSuchObjectException
+	{
+		DbCompParm firstInput = null;
+		try (ComputationDAI compDai = getLegacyTimeseriesDB().makeComputationDAO())
+		{
+			DbComputation comp = compDai.getComputationById(DbKey.createDbKey(computationId));
+			for (Iterator<DbCompParm> it = comp.getParms(); it.hasNext();)
+			{
+				DbCompParm parm = it.next();
+				if (parm.isInput())
+				{
+					firstInput = parm;
+					break;
+				}
+			}
+		}
+		if (firstInput == null)
+		{
+			return expanded;
+		}
+		TreeSet<TimeSeriesIdentifier> transformed = new TreeSet<>();
+		for (TimeSeriesIdentifier tsid : expanded)
+		{
+			try
+			{
+				TimeSeriesIdentifier candidate =
+						getLegacyTimeseriesDB().transformTsidByCompParm(tsDai, tsid, firstInput, false, false, "");
+				if (candidate != null)
+				{
+					transformed.add(candidate);
+				}
+			}
+			catch (NoSuchObjectException | BadTimeSeriesException ex)
+			{
+				// Member doesn't match the parm's site/datatype template; skip it, same as the
+				// desktop's Run Computation dialog does.
+			}
+		}
+		return new ArrayList<>(transformed);
 	}
 
 	@POST

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
@@ -96,19 +96,44 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "The tsrefs method returns a list of time series defined in the database.",
-			description = "You have the option to filter out inactive time series by passing 'active=true' argument.  \n"
-					+ "Examples:  \n\n    http://localhost:8080/odcsapi/tsrefs\n    "
-					+ "http://localhost:8080/odcsapi/tsrefs?active=true\n\n\n"
-					+ "This returns an array of Time Series Identifiers. The numeric Key of a time series identifier "
-					+ "may be used in subsequent calls to get the complete specification for the time series "
-					+ "(GET tsspec) or to retrieve time series data (GET tsdata). The format of the returned "
-					+ "data is as follows:  \n```\n[\n  {\n    \"uniqueString\": \"OKVI4.Stage.Inst.15Minutes.0.raw\","
-					+ "\n    \"key\": 1,\n    \"description\": null,\n    \"storageUnits\": \"ft\",\n    "
-					+ "\"active\": true\n  },\n  {\n    \"uniqueString\": \"OKVI4.Stage.Ave.1Day.1Day.CO\",\n    "
-					+ "\"key\": 2,\n    \"description\": null,\n    \"storageUnits\": \"ft\",\n    "
-					+ "\"active\": true\n  },\n  {\n    \"uniqueString\": \"OKVI4.Stage.Ave.1Day.1Day.CC\",\n    "
-					+ "\"key\": 4,\n    \"description\": null,\n    \"storageUnits\": \"ft\",\n    "
-					+ "\"active\": true\n  },\n. . .\n]\n```",
+			description = """
+					You have the option to filter out inactive time series by passing 'active=true' argument. \s
+					Examples: \s
+
+					    http://localhost:8080/odcsapi/tsrefs
+					    http://localhost:8080/odcsapi/tsrefs?active=true
+
+
+					This returns an array of Time Series Identifiers. The numeric Key of a time series identifier \
+					may be used in subsequent calls to get the complete specification for the time series \
+					(GET tsspec) or to retrieve time series data (GET tsdata). The format of the returned \
+					data is as follows: \s
+					```
+					[
+					  {
+					    "uniqueString": "OKVI4.Stage.Inst.15Minutes.0.raw",
+					    "key": 1,
+					    "description": null,
+					    "storageUnits": "ft",
+					    "active": true
+					  },
+					  {
+					    "uniqueString": "OKVI4.Stage.Ave.1Day.1Day.CO",
+					    "key": 2,
+					    "description": null,
+					    "storageUnits": "ft",
+					    "active": true
+					  },
+					  {
+					    "uniqueString": "OKVI4.Stage.Ave.1Day.1Day.CC",
+					    "key": 4,
+					    "description": null,
+					    "storageUnits": "ft",
+					    "active": true
+					  },
+					. . .
+					]
+					```""",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Success",
 							content = @Content(mediaType = MediaType.APPLICATION_JSON,
@@ -194,8 +219,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@Produces(MediaType.APPLICATION_JSON)
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
-			summary = "The tsspec method returns a complete specification for a time series "
-					+ "identified by the 'key' parameter.",
+			summary = "The tsspec method returns a complete specification for a time series identified by the 'key' parameter.",
 			description = "Example: \n\n    http://localhost:8080/odcsapi/tsspec?key=532",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Successfully retrieved time series specification",
@@ -306,22 +330,28 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "The tsdata method returns data for a time series over a specified time range.",
-			description = "The method takes 3 arguments:\n"
-					+ "* **tkey (required)** – the numeric key identifying the time series. "
-					+ "It is contained within a Time Series Identifier described above.\n"
-					+ "* **tstart** – Optionally specifies the start of the time range for retrieval. "
-					+ "If omitted, the oldest data in the database is returned. See below for time format.\n"
-					+ "* **tend** – Optionally specifies the end of the time range for retrieval. "
-					+ "If omitted, the newest data in the database is returned. See below for time format.  \n\n"
-					+ "The since and until arguments may have any of the following formats:\n"
-					+ "*\t**now-1day**\tThe word 'now' minus an increment times a unit. "
-					+ "Examples: now-1day, now-5hours, now-1week, etc.\n"
-					+ "*\t**now**\tThe current time that the web service call was made.\n"
-					+ "*\t**YYYY/DDD/HH:MM:SS**\tA complete Julian Year, Day-of-Year, and Time\n"
-					+ "*\t**YYYY/DDD/HH:MM**\tSeconds omitted means zero.\n"
-					+ "*\t**DDD/HH:MM:SS**\tAssume current year\n*\t**DDD/HH:MM**\t\n"
-					+ "*\t**HH:MM:SS**\tAssume current day\n*\t**HH:MM**  \n\n"
-					+ "Examples:  \n```http://localhost:8080/odcsapi/tsdata?key=12```",
+			description = """
+					The method takes 3 arguments:
+					* **tkey (required)** – the numeric key identifying the time series. \
+					It is contained within a Time Series Identifier described above.
+					* **tstart** – Optionally specifies the start of the time range for retrieval. \
+					If omitted, the oldest data in the database is returned. See below for time format.
+					* **tend** – Optionally specifies the end of the time range for retrieval. \
+					If omitted, the newest data in the database is returned. See below for time format. \s
+
+					The since and until arguments may have any of the following formats:
+					*\t**now-1day**\tThe word 'now' minus an increment times a unit. \
+					Examples: now-1day, now-5hours, now-1week, etc.
+					*\t**now**\tThe current time that the web service call was made.
+					*\t**YYYY/DDD/HH:MM:SS**\tA complete Julian Year, Day-of-Year, and Time
+					*\t**YYYY/DDD/HH:MM**\tSeconds omitted means zero.
+					*\t**DDD/HH:MM:SS**\tAssume current year
+					*\t**DDD/HH:MM**\t
+					*\t**HH:MM:SS**\tAssume current day
+					*\t**HH:MM** \s
+
+					Examples: \s
+					```http://localhost:8080/odcsapi/tsdata?key=12```""",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Successfully retrieved time series data",
 							content = @Content(mediaType = MediaType.APPLICATION_JSON,
@@ -396,17 +426,35 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@Path("intervals")
 	@Produces(MediaType.APPLICATION_JSON)
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
-	@Tag(name = "Time Series Methods - Interval Methods", description = "Time Intervals are stored in the database "
-			+ "for OpenTSDB. They are hardcoded for CWMS and HDB.")
+	@Tag(name = "Time Series Methods - Interval Methods", description = "Time Intervals are stored in the database for OpenTSDB. They are hardcoded for CWMS and HDB.")
 	@Operation(
 			summary = "Returns a list of time intervals defined in the database.",
-			description = "Example: \n\n    http://localhost:8080/odcsapi/intervals\n\n"
-					+ "An array of data structures representing all known time intervals will be returned as shown below.\n"
-					+ "```\n[\n  {\n    \"intervalId\": 1,\n    \"name\": \"irregular\",\n    \"calConstant\": \"minute\","
-					+ "\n    \"calMultilier\": 0\n  },\n  {\n    \"intervalId\": 2,\n    \"name\": \"2Minutes\","
-					+ "\n    \"calConstant\": \"minute\",\n    \"calMultilier\": 2\n  },\n. . .\n]\n```\n\n"
-					+ "For each interval the system stores a numeric ID, a name, a Java Calendar Constant "
-					+ "(one of second, minute, hour, day, week, month, year), and a multiplier for the constant.",
+			description = """
+					Example:
+
+					    http://localhost:8080/odcsapi/intervals
+
+					An array of data structures representing all known time intervals will be returned as shown below.
+					```
+					[
+					  {
+					    "intervalId": 1,
+					    "name": "irregular",
+					    "calConstant": "minute",
+					    "calMultilier": 0
+					  },
+					  {
+					    "intervalId": 2,
+					    "name": "2Minutes",
+					    "calConstant": "minute",
+					    "calMultilier": 2
+					  },
+					. . .
+					]
+					```
+
+					For each interval the system stores a numeric ID, a name, a Java Calendar Constant \
+					(one of second, minute, hour, day, week, month, year), and a multiplier for the constant.""",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Successfully retrieved intervals",
 							content = @Content(mediaType = MediaType.APPLICATION_JSON,
@@ -442,17 +490,30 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@Produces(MediaType.APPLICATION_JSON)
 	@Operation(
 			summary = "Create a new, or update an existing Time Interval",
-			description = "Example URL for POST:  \n\n    "
-					+ "http://localhost:8080/odcsapi/interval\n\n\n"
-					+ "The POST data should contain a single time interval record as described "
-					+ "above for the 'intervals' list.   \n\n"
-					+ "As with other POST methods, to create a new record, omit the numeric ID.  \n\n"
-					+ "To update an existing record, include the 'intervalId'.  \n\n"
-					+ "For example, to create a interval 'fortnight', the data could be:\n  "
-					+ "```\n  {\n    \"name\": \"fortnight\",\n    \"calConstant\": \"day\",\n    "
-					+ "\"calMultilier\": 14\n  }\n  ```\n\nThe returned data structure will be the "
-					+ "same as the data passed, except that if this is a new interval the "
-					+ "intervalId member will be added.",
+			description = """
+					Example URL for POST: \s
+
+					    http://localhost:8080/odcsapi/interval
+
+
+					The POST data should contain a single time interval record as described \
+					above for the 'intervals' list. \s
+
+					As with other POST methods, to create a new record, omit the numeric ID. \s
+
+					To update an existing record, include the 'intervalId'. \s
+
+					For example, to create a interval 'fortnight', the data could be:
+					  ```
+					  {
+					    "name": "fortnight",
+					    "calConstant": "day",
+					    "calMultilier": 14
+					  }
+					  ```
+
+					The returned data structure will be the same as the data passed, except that if this is a new interval the \
+					intervalId member will be added.""",
 			requestBody = @RequestBody(
 					description = "Engineering Unit Conversion",
 					required = true,
@@ -544,12 +605,18 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete an existing Time Interval record.",
-			description = "Example URL for DELETE:  \n\n    "
-					+ "http://localhost:8080/odcsapi/interval?intervalid=1459\n\n\n"
-					+ "This deletes the Time Interval with ID 1459.  \n\n"
-					+ "**Use care with this method**. The system needs to know about all of the 'interval' "
-					+ "and 'duration' specifiers used for time series IDs. \n\n"
-					+ "Deletion of intervals is currently unsupported!",
+			description = """
+					Example URL for DELETE: \s
+
+					    http://localhost:8080/odcsapi/interval?intervalid=1459
+
+
+					This deletes the Time Interval with ID 1459. \s
+
+					**Use care with this method**. The system needs to know about all of the 'interval' \
+					and 'duration' specifiers used for time series IDs.
+
+					Deletion of intervals is currently unsupported!""",
 			responses = {
 					@ApiResponse(responseCode = "204", description = "Successfully deleted the interval"),
 					@ApiResponse(responseCode = "400", description = "Invalid parameters"),
@@ -573,27 +640,58 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@Path("tsgrouprefs")
 	@Produces(MediaType.APPLICATION_JSON)
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
-	@Tag(name = "Time Series Methods - Groups", description = "Time Series Groups are used to define a "
-			+ "set of time series identifiers")
+	@Tag(name = "Time Series Methods - Groups", description = "Time Series Groups are used to define a set of time series identifiers")
 	@Operation(
 			summary = "Provide a list of all groups defined in the database.",
-			description = "Time Series Groups are used to define a set of time series identifiers. "
-					+ "Groups can contain:\n  \n*  Explicit list of time series identifiers  \n"
-					+ "*  A list of attributes to flexibly define a set of time series identifiers, "
-					+ "E.g. All time series at a particular with interval '30minutes'.  \n"
-					+ "*  A list of sub-groups that can be included, excluded, "
-					+ "or intersected with the group being defined.\n  \n"
-					+ "***\n  \nExample URL:  \n\n    http://localhost:8080/odcsapi/tsgrouprefs\n\n"
-					+ "The returned list has the following structure:\n  \n```\n  [\n    {\n      "
-					+ "\"groupId\": 8,\n      \"groupName\": \"topgroup\",\n      \"groupType\": \"basin\",\n      "
-					+ "\"description\": \"\"\n    },\n    {\n      \"groupId\": 7,\n      "
-					+ "\"groupName\": \"subgroup-x\",\n      \"groupType\": \"data type\",\n      "
-					+ "\"description\": \"testing for OPENDCS-15 issue\"\n    },\n    {\n      "
-					+ "\"groupId\": 2,\n      \"groupName\": \"regtest_017\",\n      "
-					+ "\"groupType\": \"data-type\",\n      \"description\": \"Group for regression test 017\"\n    },"
-					+ "\n    {\n      \"groupId\": 3,\n      \"groupName\": \"stageRate1Var\",\n      "
-					+ "\"groupType\": \"basin\",\n      \"description\": \"Collection of TS IDs with stage "
-					+ "to flow ratings\"\n    }\n  ]\n\n```\n\n  ",
+			description = """
+					Time Series Groups are used to define a set of time series identifiers. \
+					Groups can contain:
+					  \s
+					*  Explicit list of time series identifiers \s
+					*  A list of attributes to flexibly define a set of time series identifiers, \
+					E.g. All time series at a particular with interval '30minutes'. \s
+					*  A list of sub-groups that can be included, excluded, \
+					or intersected with the group being defined.
+					  \s
+					***
+					  \s
+					Example URL: \s
+
+					    http://localhost:8080/odcsapi/tsgrouprefs
+
+					The returned list has the following structure:
+					  \s
+					```
+					  [
+					    {
+					      "groupId": 8,
+					      "groupName": "topgroup",
+					      "groupType": "basin",
+					      "description": ""
+					    },
+					    {
+					      "groupId": 7,
+					      "groupName": "subgroup-x",
+					      "groupType": "data type",
+					      "description": "testing for OPENDCS-15 issue"
+					    },
+					    {
+					      "groupId": 2,
+					      "groupName": "regtest_017",
+					      "groupType": "data-type",
+					      "description": "Group for regression test 017"
+					    },
+					    {
+					      "groupId": 3,
+					      "groupName": "stageRate1Var",
+					      "groupType": "basin",
+					      "description": "Collection of TS IDs with stage to flow ratings"
+					    }
+					  ]
+
+					```
+
+					  """,
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Successfully retrieved time series group references",
 							content = @Content(mediaType = MediaType.APPLICATION_JSON,
@@ -643,50 +741,116 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Provide a complete definition of a single group.",
-			description = "Example URL:  \n\n    http://localhost:8080/odcsapi-0-7/tsgroup?groupid=9\n\n"
-					+ "The returned list has the following structure:  \n  \n```\n  {\n    \"groupId\": 9,\n    "
-					+ "\"groupName\": \"junk\",\n    \"groupType\": \"basin\",\n    \"description\": \"\",\n    "
-					+ "\"tsIds\": [\n      {\n        \"uniqueString\": \"OKVI4.Stage.Inst.15Minutes.0.raw\",\n        "
-					+ "\"key\": 1,\n        \"description\": null,\n        \"storageUnits\": \"ft\",\n        "
-					+ "\"active\": true\n      },\n      {\n        \"uniqueString\": \"OKVI4.Stage.Ave.1Day.1Day.CO\","
-					+ "\n        \"key\": 2,\n        \"description\": null,\n        \"storageUnits\": \"ft\",\n        "
-					+ "\"active\": true\n      }\n    ],\n    \"includeGroups\": [\n      {\n        \"groupId\": 1,"
-					+ "\n        \"groupName\": \"MROI4-ROWI4-HG\",\n        \"groupType\": \"basin\",\n        "
-					+ "\"description\": \"This is a group for the MROI4-ROWI4-HG Regression Test\"\n      }\n    ],"
-					+ "\n    \"excludeGroups\": [\n      {\n        \"groupId\": 2,\n        "
-					+ "\"groupName\": \"regtest_017\",\n        \"groupType\": \"data-type\",\n        "
-					+ "\"description\": \"Group for regression test 017\"\n      }\n    ],\n    "
-					+ "\"intersectGroups\": [\n      {\n        \"groupId\": 7,\n        "
-					+ "\"groupName\": \"subgroup-x\",\n        \"groupType\": \"data type\",\n        "
-					+ "\"description\": \"testing for OPENDCS-15 issue\"\n      }\n    ],\n    "
-					+ "\"groupAttrs\": [\n      \"BaseLocation=TESTSITE2\",\n      \"BaseParam=ELEV\",\n      "
-					+ "\"BaseVersion=DCP\",\n      \"Duration=0\",\n      \"Interval=1Hour\",\n      "
-					+ "\"ParamType=Inst\",\n      \"SubLocation=Spillway2-Gate1\",\n      \"SubParam=PZ1B\",\n      "
-					+ "\"SubVersion=Raw\",\n      \"Version=DCP-Raw\"\n    ],\n    \"groupSites\": [\n      "
-					+ "{\n        \"siteId\": 2,\n        \"sitenames\": {\n          "
-					+ "\"CWMS\": \"ROWI4\",\n          \"USGS\": \"05449500\"\n        },\n        "
-					+ "\"publicName\": \"IOWA RIVER NEAR ROWAN\",\n        "
-					+ "\"description\": \"IOWA RIVER NEAR ROWAN 4NW\"\n      }\n    ],\n    "
-					+ "\"groupDataTypes\": [\n      {\n        \"id\": 224,\n        "
-					+ "\"standard\": \"CWMS\",\n        \"code\": \"ELEV-PZ2A\",\n        "
-					+ "\"displayName\": \"CWMS:ELEV-PZ2A\"\n      }\n    ]\n  }\n\n```\n  \n"
-					+ "**Notes**:  \n*  **tsIds** is a list of explicit time series identifiers "
-					+ "that are considered part of the group.  \n*  **includedGroups** is a list of "
-					+ "subgroups to be included in this group.  \n*  **excludedGroups** is a list of subgroups. "
-					+ "The TSIDs in the subgroup will be excluded from this group.  \n"
-					+ "*  **intersectedGroups** is a list of subgroups to be intersected with this group. "
-					+ "Only TSIDs in both groups are considered part of this group.  \n"
-					+ "*  **groupSites** is a list of Site records. TSIDs in these Sites are "
-					+ "considered members of this group.  \n*  **groupDataTypes** is a list of fully-specified "
-					+ "data types (a.k.a. 'Param' in CWMS and OpenTSDB databases). TSIDs with a matching data "
-					+ "type will be included in the group.  \n*  **groupAttrs** is a list of attributes "
-					+ "that are used to define the group. These are presented in 'name=value' pairs where "
-					+ "the name is one of the following:  \n\n    *  **BaseLocation** – only the first "
-					+ "part of Site (Location) before first hyphen  \n    *  **SubLocation** – only trailing "
-					+ "part of Site after first hyphen.  \n    *  **BaseParam** – only first part of data "
-					+ "type (Param) before first hyphen  \n    *  **SubParam** – only trailing part of data "
-					+ "type (Param) after first hyphen\n    *  **ParamType**  \n    *  **Interval**\n    "
-					+ "*  **Duration**  \n    *  **Version**  \n    *  **BaseVersion**\n    *  **SubVersion**",
+			description = """
+					Example URL: \s
+
+					    http://localhost:8080/odcsapi-0-7/tsgroup?groupid=9
+
+					The returned list has the following structure: \s
+					  \s
+					```
+					  {
+					    "groupId": 9,
+					    "groupName": "junk",
+					    "groupType": "basin",
+					    "description": "",
+					    "tsIds": [
+					      {
+					        "uniqueString": "OKVI4.Stage.Inst.15Minutes.0.raw",
+					        "key": 1,
+					        "description": null,
+					        "storageUnits": "ft",
+					        "active": true
+					      },
+					      {
+					        "uniqueString": "OKVI4.Stage.Ave.1Day.1Day.CO",
+					        "key": 2,
+					        "description": null,
+					        "storageUnits": "ft",
+					        "active": true
+					      }
+					    ],
+					    "includeGroups": [
+					      {
+					        "groupId": 1,
+					        "groupName": "MROI4-ROWI4-HG",
+					        "groupType": "basin",
+					        "description": "This is a group for the MROI4-ROWI4-HG Regression Test"
+					      }
+					    ],
+					    "excludeGroups": [
+					      {
+					        "groupId": 2,
+					        "groupName": "regtest_017",
+					        "groupType": "data-type",
+					        "description": "Group for regression test 017"
+					      }
+					    ],
+					    "intersectGroups": [
+					      {
+					        "groupId": 7,
+					        "groupName": "subgroup-x",
+					        "groupType": "data type",
+					        "description": "testing for OPENDCS-15 issue"
+					      }
+					    ],
+					    "groupAttrs": [
+					      "BaseLocation=TESTSITE2",
+					      "BaseParam=ELEV",
+					      "BaseVersion=DCP",
+					      "Duration=0",
+					      "Interval=1Hour",
+					      "ParamType=Inst",
+					      "SubLocation=Spillway2-Gate1",
+					      "SubParam=PZ1B",
+					      "SubVersion=Raw",
+					      "Version=DCP-Raw"
+					    ],
+					    "groupSites": [
+					      {
+					        "siteId": 2,
+					        "sitenames": {
+					          "CWMS": "ROWI4",
+					          "USGS": "05449500"
+					        },
+					        "publicName": "IOWA RIVER NEAR ROWAN",
+					        "description": "IOWA RIVER NEAR ROWAN 4NW"
+					      }
+					    ],
+					    "groupDataTypes": [
+					      {
+					        "id": 224,
+					        "standard": "CWMS",
+					        "code": "ELEV-PZ2A",
+					        "displayName": "CWMS:ELEV-PZ2A"
+					      }
+					    ]
+					  }
+
+					```
+					  \s
+					**Notes**: \s
+					*  **tsIds** is a list of explicit time series identifiers that are considered part of the group. \s
+					*  **includedGroups** is a list of subgroups to be included in this group. \s
+					*  **excludedGroups** is a list of subgroups. The TSIDs in the subgroup will be excluded from this group. \s
+					*  **intersectedGroups** is a list of subgroups to be intersected with this group. \
+					Only TSIDs in both groups are considered part of this group. \s
+					*  **groupSites** is a list of Site records. TSIDs in these Sites are considered members of this group. \s
+					*  **groupDataTypes** is a list of fully-specified data types (a.k.a. 'Param' in CWMS and OpenTSDB databases). \
+					TSIDs with a matching data type will be included in the group. \s
+					*  **groupAttrs** is a list of attributes that are used to define the group. \
+					These are presented in 'name=value' pairs where the name is one of the following:
+
+					    *  **BaseLocation** – only the first part of Site (Location) before first hyphen \s
+					    *  **SubLocation** – only trailing part of Site after first hyphen. \s
+					    *  **BaseParam** – only first part of data type (Param) before first hyphen \s
+					    *  **SubParam** – only trailing part of data type (Param) after first hyphen
+					    *  **ParamType** \s
+					    *  **Interval**
+					    *  **Duration** \s
+					    *  **Version** \s
+					    *  **BaseVersion**
+					    *  **SubVersion**""",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Successfully retrieved time series group details",
 							content = @Content(mediaType = MediaType.APPLICATION_JSON,
@@ -775,15 +939,22 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Expand a time series group to its full list of member time series identifiers.",
-			description = "Returns the fully-expanded list of time series identifiers that belong to the "
-					+ "specified group, including members from sub-groups, attribute-based filters, "
-					+ "and include/exclude/intersect relationships.  \n\n"
-					+ "When computationid is also supplied, each expanded member is transformed against "
-					+ "that computation's first input parameter -- the same filtering the desktop client's "
-					+ "Run Computation dialog performs before offering a group's members for selection -- "
-					+ "so only members the computation can actually resolve an input time series for are "
-					+ "returned.  \n\n"
-					+ "Example URL:  \n\n    http://localhost:8080/odcsapi/expandgroup?groupid=9\n\n",
+			description = """
+					Returns the fully-expanded list of time series identifiers that belong to the \
+					specified group, including members from sub-groups, attribute-based filters, \
+					and include/exclude/intersect relationships. \s
+
+					When computationid is also supplied, each expanded member is transformed against \
+					that computation's first input parameter -- the same filtering the desktop client's \
+					Run Computation dialog performs before offering a group's members for selection -- \
+					so only members the computation can actually resolve an input time series for are \
+					returned. \s
+
+					Example URL: \s
+
+					    http://localhost:8080/odcsapi/expandgroup?groupid=9
+
+					""",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Successfully expanded time series group",
 							content = @Content(mediaType = MediaType.APPLICATION_JSON,
@@ -797,9 +968,10 @@ public final class TimeSeriesResources extends OpenDcsResource
 	public Response expandGroup(@Parameter(description = "Group ID to expand", required = true,
 			schema = @Schema(implementation = Long.class), example = "9")
 		@QueryParam("groupid") Long groupId,
-			@Parameter(description = "Optional computation ID. When supplied, expanded members are "
-					+ "transformed against the computation's first input parameter and only the "
-					+ "members that resolve are returned.",
+			@Parameter(description = """
+					Optional computation ID. When supplied, expanded members are \
+					transformed against the computation's first input parameter and only the \
+					members that resolve are returned.""",
 					schema = @Schema(implementation = Long.class))
 		@QueryParam("computationid") Long computationId)
 			throws WebAppException, DbException
@@ -893,9 +1065,12 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create a new, or update an existing time series group",
-			description = "Example URL for POST:  \n\n    "
-					+ "http://localhost:8080/odcsapi/tsgroup\n\n"
-					+ "The POST data is as described above for GET tsgroup",
+			description = """
+					Example URL for POST: \s
+
+					    http://localhost:8080/odcsapi/tsgroup
+
+					The POST data is as described above for GET tsgroup""",
 			requestBody = @RequestBody(
 					description = "Time Series Group",
 					required = true,
@@ -1026,9 +1201,12 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Time Series Group",
-			description = "Example URL for DELETE:  \n\n    "
-					+ "http://localhost:8080/odcsapi/delete\n\n"
-					+ "This example deletes the Time series group with ID 9.",
+			description = """
+					Example URL for DELETE: \s
+
+					    http://localhost:8080/odcsapi/delete
+
+					This example deletes the Time series group with ID 9.""",
 			responses = {
 					@ApiResponse(responseCode = "204", description = "Successfully deleted time series group"),
 					@ApiResponse(responseCode = "400", description = "Missing or invalid group ID"),

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/DTOMappers.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/DTOMappers.java
@@ -365,6 +365,11 @@ public final class DTOMappers
 		{
 			ref.setProcessId(DbKey.NullKey.getValue());
 		}
+		if (comp.getGroupId() != null && !DbKey.isNull(comp.getGroupId()))
+		{
+			ref.setGroupId(comp.getGroupId().getValue());
+			ref.setGroupName(comp.getGroupName());
+		}
 		return ref;
 	}
 

--- a/javascript/opendcs-web-ui-react/public/locales/de-DE/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/de-DE/computations.json
@@ -97,6 +97,13 @@
     "unknown_ts": "(unbekannt)",
     "fetching_data": "Berechnete Werte werden abgerufen...",
     "no_data": "In diesem Zeitfenster wurden keine Werte geschrieben.",
-    "fetch_warning": "Berechnete Werte konnten nicht abgerufen werden"
+    "fetch_warning": "Berechnete Werte konnten nicht abgerufen werden",
+    "group_select_label": "Eingabe-Zeitreihen auswählen",
+    "group_select_all": "Alle",
+    "group_select_none": "Keine",
+    "group_loading": "Gruppenmitglieder werden geladen...",
+    "group_load_error": "Gruppenmitglieder konnten nicht geladen werden",
+    "group_empty": "Keine Zeitreihen in dieser Gruppe gefunden.",
+    "group_running_for": "Wird ausgeführt für {{tsid}}"
   }
 }

--- a/javascript/opendcs-web-ui-react/public/locales/en-US/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/en-US/computations.json
@@ -97,6 +97,13 @@
     "unknown_ts": "(unknown)",
     "fetching_data": "Fetching computed values...",
     "no_data": "No values written in this time window.",
-    "fetch_warning": "Could not fetch computed values"
+    "fetch_warning": "Could not fetch computed values",
+    "group_select_label": "Select Input Time Series",
+    "group_select_all": "All",
+    "group_select_none": "None",
+    "group_loading": "Loading group members...",
+    "group_load_error": "Could not load group members",
+    "group_empty": "No time series found in this group.",
+    "group_running_for": "Running for {{tsid}}"
   }
 }

--- a/javascript/opendcs-web-ui-react/public/locales/es-ES/computations.json
+++ b/javascript/opendcs-web-ui-react/public/locales/es-ES/computations.json
@@ -97,6 +97,13 @@
     "unknown_ts": "(desconocido)",
     "fetching_data": "Obteniendo valores calculados...",
     "no_data": "No se escribieron valores en esta ventana de tiempo.",
-    "fetch_warning": "No se pudieron obtener los valores calculados"
+    "fetch_warning": "No se pudieron obtener los valores calculados",
+    "group_select_label": "Seleccionar series de tiempo de entrada",
+    "group_select_all": "Todas",
+    "group_select_none": "Ninguna",
+    "group_loading": "Cargando miembros del grupo...",
+    "group_load_error": "No se pudieron cargar los miembros del grupo",
+    "group_empty": "No se encontraron series de tiempo en este grupo.",
+    "group_running_for": "Ejecutando para {{tsid}}"
   }
 }

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computation.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computation.tsx
@@ -294,6 +294,23 @@ export const Computation: React.FC<ComputationProperties> = ({
     [dispatch],
   );
 
+  // The backend persists the computation/group link by groupId (a DB foreign key),
+  // so selecting a group by name must also resolve and store its groupId.
+  const groupChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const groupName = event.target.value;
+      const match = groupOptions.find((g) => g.groupName === groupName);
+      dispatch({
+        type: "save",
+        payload: {
+          groupName: groupName || undefined,
+          groupId: groupName ? match?.groupId : undefined,
+        },
+      });
+    },
+    [dispatch, groupOptions],
+  );
+
   const enabledChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       dispatch({ type: "save", payload: { enabled: event.target.checked } });
@@ -398,7 +415,7 @@ export const Computation: React.FC<ComputationProperties> = ({
                       id="applicationName"
                       name="applicationName"
                       disabled={!edit}
-                      defaultValue={localComputation.applicationName ?? ""}
+                      value={localComputation.applicationName ?? ""}
                       onChange={selectChange}
                     >
                       <option value="" />
@@ -419,8 +436,8 @@ export const Computation: React.FC<ComputationProperties> = ({
                       id="groupName"
                       name="groupName"
                       disabled={!edit}
-                      defaultValue={localComputation.groupName ?? ""}
-                      onChange={selectChange}
+                      value={localComputation.groupName ?? ""}
+                      onChange={groupChange}
                     >
                       <option value="" />
                       {groupOptions.map((g) => (

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computations.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/Computations.stories.tsx
@@ -6,6 +6,7 @@ import type {
   ApiAppRef,
   ApiComputation,
   ApiComputationRef,
+  ApiTimeSeriesIdentifier,
   ApiTsGroupRef,
 } from "opendcs-api";
 import { act } from "react";
@@ -30,6 +31,7 @@ type Story = StoryObj<typeof meta>;
 
 const mockComputations: ApiComputation[] = [
   {
+    // Computation 1: no group — used by existing non-group run stories
     computationId: 1,
     name: "DailyFlowAve",
     algorithmId: 10,
@@ -38,19 +40,18 @@ const mockComputations: ApiComputation[] = [
     applicationName: "compproc",
     enabled: true,
     comment: "Computes daily average flow.",
-    groupId: 5,
-    groupName: "Daily",
     props: { output_units: "cfs" },
     parmList: [],
   },
   {
+    // Computation 2: has groupId — used by group computation run stories
     computationId: 2,
     name: "DailyStageMax",
     algorithmId: 11,
     algorithmName: "MaxToDate",
     appId: 200,
     applicationName: "compproc",
-    enabled: false,
+    enabled: true,
     comment: "Computes daily max stage.",
     groupId: 5,
     groupName: "Daily",
@@ -623,5 +624,225 @@ export const RunComputationHttpError: Story = {
     await waitFor(() => expect(modal.queryByRole("alert")).toBeInTheDocument(), {
       timeout: 5000,
     });
+  },
+};
+
+// ── Group computation stories ─────────────────────────────────────────────────
+
+const mockGroupTsIds: ApiTimeSeriesIdentifier[] = [
+  {
+    uniqueString: "SITE_A.Flow.Inst.1Hour.0.compproc",
+    key: 101,
+    storageUnits: "cfs",
+    active: true,
+  },
+  {
+    uniqueString: "SITE_B.Flow.Inst.1Hour.0.compproc",
+    key: 102,
+    storageUnits: "cfs",
+    active: true,
+  },
+];
+
+const expandGroupHandler = http.get("/odcsapi/expandgroup", () =>
+  HttpResponse.json<ApiTimeSeriesIdentifier[]>(mockGroupTsIds),
+);
+
+const groupSseSuccessHandlers = [
+  http.get("/odcsapi/runcomputation", ({ request }) => {
+    const url = new URL(request.url);
+    const tsid = url.searchParams.get("tsid");
+    const tsStr =
+      tsid === "101"
+        ? "SITE_A.Flow.Inst.1Hour.0.compproc"
+        : "SITE_B.Flow.Inst.1Hour.0.compproc";
+    return new HttpResponse(
+      makeSseStream([
+        `event: computation-status\ndata: Running for ${tsStr}\n\n`,
+        `event: Results\ndata: ${JSON.stringify({
+          tsIds: [{ uniqueString: `${tsStr}.out`, key: Number(tsid) + 200 }],
+          startTime: "2025-01-01T00:00:00Z",
+          endTime: "2025-01-02T00:00:00Z",
+        })}\n\n`,
+      ]),
+      { headers: { "Content-Type": "text/event-stream" } },
+    );
+  }),
+];
+
+export const RunGroupComputationShowsSelector: Story = {
+  args: {},
+  parameters: {
+    msw: {
+      handlers: {
+        ...orgScopedHandlers,
+        expandGroup: expandGroupHandler,
+      },
+    },
+  },
+  render: () => (
+    <WithOrg>
+      <Computations />
+    </WithOrg>
+  ),
+  play: async ({ mount, parameters, userEvent }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    // Computation 2 has groupId: 5
+    const runBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:run.run_for", { id: 2 }),
+    });
+    await act(async () => userEvent.click(runBtn));
+
+    const dialog = await screen.findByRole("dialog", {}, { timeout: 5000 });
+    const modal = within(dialog);
+
+    // The group TS selector label should appear
+    await waitFor(
+      () =>
+        expect(
+          modal.queryByText(i18n.t("computations:run.group_select_label")),
+        ).toBeInTheDocument(),
+      { timeout: 5000 },
+    );
+
+    // Both TS IDs should be listed as checkboxes, all pre-checked
+    await waitFor(
+      () =>
+        expect(
+          modal.queryByRole("checkbox", { name: "SITE_A.Flow.Inst.1Hour.0.compproc" }),
+        ).toBeInTheDocument(),
+      { timeout: 5000 },
+    );
+    expect(
+      modal.queryByRole("checkbox", { name: "SITE_B.Flow.Inst.1Hour.0.compproc" }),
+    ).toBeInTheDocument();
+
+    // Both are checked by default
+    const checkboxA = modal.getByRole("checkbox", {
+      name: "SITE_A.Flow.Inst.1Hour.0.compproc",
+    });
+    const checkboxB = modal.getByRole("checkbox", {
+      name: "SITE_B.Flow.Inst.1Hour.0.compproc",
+    });
+    expect(checkboxA).toBeChecked();
+    expect(checkboxB).toBeChecked();
+
+    // Uncheck one; Run should still be enabled
+    await act(async () => userEvent.click(checkboxA));
+    expect(checkboxA).not.toBeChecked();
+    const runBtnModal = modal.getByRole("button", {
+      name: i18n.t("computations:run.run"),
+    });
+    expect(runBtnModal).not.toBeDisabled();
+
+    // Uncheck the last one; Run should become disabled
+    await act(async () => userEvent.click(checkboxB));
+    expect(runBtnModal).toBeDisabled();
+  },
+};
+
+export const RunGroupComputationSuccess: Story = {
+  args: {},
+  parameters: {
+    msw: {
+      handlers: {
+        ...orgScopedHandlers,
+        expandGroup: expandGroupHandler,
+        ...Object.fromEntries(groupSseSuccessHandlers.map((h, i) => [String(i), h])),
+        tsData: http.get("/odcsapi/tsdata", () =>
+          HttpResponse.json({ tsid: {}, values: [] }),
+        ),
+      },
+    },
+  },
+  render: () => (
+    <WithOrg>
+      <Computations />
+    </WithOrg>
+  ),
+  play: async ({ mount, parameters, userEvent }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    // Computation 2 has groupId: 5
+    const runBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:run.run_for", { id: 2 }),
+    });
+    await act(async () => userEvent.click(runBtn));
+
+    const dialog = await screen.findByRole("dialog", {}, { timeout: 5000 });
+    const modal = within(dialog);
+
+    // Wait for group members to load
+    await waitFor(
+      () =>
+        expect(
+          modal.queryByRole("checkbox", { name: "SITE_A.Flow.Inst.1Hour.0.compproc" }),
+        ).toBeInTheDocument(),
+      { timeout: 5000 },
+    );
+
+    // Run with both selected (default) — click Run
+    const executeBtn = await modal.findByRole("button", {
+      name: i18n.t("computations:run.run"),
+    });
+    await act(async () => userEvent.click(executeBtn));
+
+    // The first sequential log header appears in the log panel
+    await waitFor(
+      () =>
+        expect(
+          modal.queryByText(
+            `--- ${i18n.t("computations:run.group_running_for", { tsid: "SITE_A.Flow.Inst.1Hour.0.compproc" })} ---`,
+          ),
+        ).toBeInTheDocument(),
+      { timeout: 8000 },
+    );
+  },
+};
+
+export const RunGroupComputationGroupLoadError: Story = {
+  args: {},
+  parameters: {
+    msw: {
+      handlers: {
+        ...orgScopedHandlers,
+        expandGroup: http.get(
+          "/odcsapi/expandgroup",
+          () => new HttpResponse(null, { status: 500 }),
+        ),
+      },
+    },
+  },
+  render: () => (
+    <WithOrg>
+      <Computations />
+    </WithOrg>
+  ),
+  play: async ({ mount, parameters, userEvent }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    // Computation 2 has groupId: 5
+    const runBtn = await canvas.findByRole("button", {
+      name: i18n.t("computations:run.run_for", { id: 2 }),
+    });
+    await act(async () => userEvent.click(runBtn));
+
+    const dialog = await screen.findByRole("dialog", {}, { timeout: 5000 });
+    const modal = within(dialog);
+
+    // Error alert appears quickly (retry: 0 means no retries on the query)
+    await waitFor(() => expect(modal.queryByRole("alert")).toBeInTheDocument(), {
+      timeout: 5000,
+    });
+
+    // Run button is disabled because no TS IDs loaded
+    const executeBtn = modal.getByRole("button", {
+      name: i18n.t("computations:run.run"),
+    });
+    expect(executeBtn).toBeDisabled();
   },
 };

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/ComputationsTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/ComputationsTable.tsx
@@ -81,6 +81,7 @@ export const ComputationsTable: React.FC<ComputationsTableProperties> = ({
   const [runTarget, setRunTarget] = useState<{
     id: number;
     name: string | undefined;
+    groupId: number | undefined;
   } | null>(null);
   const tableRef = useRef<AppDataTableHandle<TableComputationRef>>(null);
   const draftsRef = useRef<Record<number, UiComputation>>({});
@@ -141,7 +142,11 @@ export const ComputationsTable: React.FC<ComputationsTableProperties> = ({
         aria: (row) => t("computations:run.run_for", { id: row.computationId }),
         onClick: ({ row }) => {
           if (row.computationId !== undefined) {
-            setRunTarget({ id: row.computationId, name: row.name });
+            setRunTarget({
+              id: row.computationId,
+              name: row.name,
+              groupId: row.groupId ?? undefined,
+            });
           }
         },
       },
@@ -257,6 +262,7 @@ export const ComputationsTable: React.FC<ComputationsTableProperties> = ({
         show={runTarget !== null}
         computationId={runTarget?.id}
         computationName={runTarget?.name}
+        groupId={runTarget?.groupId}
         onHide={() => setRunTarget(null)}
       />
       <AlgorithmSelectModal

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/RunComputationModal.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/RunComputationModal.tsx
@@ -125,6 +125,25 @@ const dispatchSseEvent = (
   return false;
 };
 
+/**
+ * Extract a short, human-readable message from a non-OK response. The API's
+ * error bodies are JSON `{ message }`, but a container/proxy-level failure
+ * (e.g. a Tomcat error page) can return raw HTML instead — fall back to the
+ * status text rather than dumping that markup into the UI.
+ */
+const readErrorMessage = async (response: Response): Promise<string> => {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      const body = (await response.json()) as { message?: string };
+      if (body.message) return body.message;
+    } catch {
+      // fall through to statusText below
+    }
+  }
+  return response.statusText || `status ${response.status}`;
+};
+
 /** Read a text/event-stream response body and call callbacks for each event. */
 const readSseStream = async (
   body: ReadableStream<Uint8Array>,
@@ -305,10 +324,17 @@ export const RunComputationModal: React.FC<Props> = ({
     isLoading: loadingGroup,
     error: groupQueryError,
   } = useQuery<ApiTimeSeriesIdentifier[]>({
-    queryKey: ["expandgroup", groupId, org],
+    queryKey: ["expandgroup", groupId, computationId, org],
     queryFn: async () => {
       const ctx = conf.baseServer.makeRequestContext("/expandgroup", HttpMethod.GET);
       ctx.setQueryParam("groupid", String(groupId));
+      // Filters the group's raw members down to ones that actually resolve against
+      // this computation's first input parm (datatype/interval can otherwise differ
+      // from what the group's site/datatype expansion alone implies) — mirrors the
+      // desktop client's Run Computation dialog.
+      if (computationId !== undefined) {
+        ctx.setQueryParam("computationid", String(computationId));
+      }
       const url = ctx.getUrl();
       const res = await fetch(url, {
         method: "GET",
@@ -381,8 +407,8 @@ export const RunComputationModal: React.FC<Props> = ({
         signal: abort.signal,
       });
       if (!response.ok) {
-        const text = await response.text().catch(() => response.statusText);
-        throw new Error(`HTTP ${response.status}: ${text}`);
+        const message = await readErrorMessage(response);
+        throw new Error(`HTTP ${response.status}: ${message}`);
       }
       if (!response.body) throw new Error("No response body");
       let parsedResults: CompResults | null = null;
@@ -665,7 +691,19 @@ export const RunComputationModal: React.FC<Props> = ({
           </div>
         )}
 
-        {status === "error" && errorMsg && <Alert variant="danger">{errorMsg}</Alert>}
+        {status === "error" && errorMsg && (
+          <Alert
+            variant="danger"
+            style={{
+              maxHeight: "16rem",
+              overflowY: "auto",
+              overflowWrap: "anywhere",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {errorMsg}
+          </Alert>
+        )}
 
         {status === "fetching" && (
           <div className="d-flex align-items-center gap-2 text-muted mb-3">

--- a/javascript/opendcs-web-ui-react/src/pages/computations/computations/RunComputationModal.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/computations/computations/RunComputationModal.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
   Alert,
   Button,
   Col,
   Form,
+  FormCheck,
   FormGroup,
   Modal,
   Row,
@@ -12,7 +14,12 @@ import {
 } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 import { PlayFill, StopFill } from "react-bootstrap-icons";
-import { HttpMethod, TimeSeriesMethodsApi, type ApiTimeSeriesData } from "opendcs-api";
+import {
+  HttpMethod,
+  TimeSeriesMethodsApi,
+  type ApiTimeSeriesData,
+  type ApiTimeSeriesIdentifier,
+} from "opendcs-api";
 import { useApi } from "../../../contexts/app/ApiContext";
 
 interface TsIdRef {
@@ -29,10 +36,17 @@ interface CompResults {
 
 type RunStatus = "idle" | "running" | "fetching" | "success" | "error";
 
+interface RunRun {
+  tsid: ApiTimeSeriesIdentifier;
+  results: CompResults | null;
+  tsData: ApiTimeSeriesData[];
+}
+
 interface Props {
   show: boolean;
   computationId: number | undefined;
   computationName: string | undefined;
+  groupId?: number;
   onHide: () => void;
 }
 
@@ -81,6 +95,7 @@ interface SseCallbacks {
 interface LogEntry {
   id: number;
   text: string;
+  header?: boolean;
 }
 
 const appendSsePart = (current: string, part: string): string =>
@@ -147,82 +162,123 @@ const readSseStream = async (
 };
 
 interface ResultsSectionProps {
-  results: CompResults;
-  tsData: ApiTimeSeriesData[];
-  times: Date[];
-  hasValues: boolean;
+  runs: RunRun[];
+  isGroup: boolean;
   status: RunStatus;
   t: (key: string) => string;
 }
 
 const ResultsSection: React.FC<ResultsSectionProps> = ({
-  results,
-  tsData,
-  times,
-  hasValues,
+  runs,
+  isGroup,
   status,
   t,
 }) => {
-  if (results.tsIds.length === 0) {
-    return <p className="text-muted mt-1">{t("computations:run.no_outputs")}</p>;
-  }
-  if (hasValues) {
-    return (
-      <div className="mt-2" style={{ maxHeight: "22rem", overflowY: "auto" }}>
-        <Table
-          size="sm"
-          bordered
-          hover
-          className="font-monospace mb-0"
-          style={{ fontSize: "0.8rem" }}
-        >
-          <thead className="table-dark sticky-top">
-            <tr>
-              <th>{t("translation:date_time")}</th>
-              {tsData.map((ts, i) => (
-                <th key={ts.tsid?.uniqueString ?? ts.tsid?.key}>
-                  {ts.tsid?.uniqueString ??
-                    results.tsIds[i]?.uniqueString ??
-                    t("computations:run.unknown_ts")}
-                  {ts.tsid?.storageUnits ? ` (${ts.tsid.storageUnits})` : ""}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {times.map((time) => (
-              <tr key={time.getTime()}>
-                <td className="text-nowrap">{time.toLocaleString()}</td>
-                {tsData.map((ts) => (
-                  <td key={ts.tsid?.uniqueString ?? ts.tsid?.key}>
-                    {lookupValue(ts, time)}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </Table>
-      </div>
-    );
-  }
-  if (status === "success") {
-    return (
-      <p className="text-muted mt-1 font-monospace" style={{ fontSize: "0.85rem" }}>
-        {results.tsIds
-          .map((id) => id.uniqueString ?? t("computations:run.unknown_ts"))
-          .join(", ")}
-        {" — "}
-        {t("computations:run.no_data")}
-      </p>
-    );
-  }
-  return null;
+  const sections = runs.filter((r) => r.results !== null);
+
+  if (sections.length === 0) return null;
+
+  return (
+    <>
+      {sections.map((run) => {
+        const label = run.tsid.uniqueString ?? t("computations:run.unknown_ts");
+        const times = pivotTimes(run.tsData);
+        const hasValues = run.tsData.some((ts) => (ts.values?.length ?? 0) > 0);
+
+        if (run.results!.tsIds.length === 0) {
+          return (
+            <p key={label} className="text-muted mt-1">
+              {isGroup ? (
+                <>
+                  <strong>{label}</strong>:{" "}
+                </>
+              ) : null}
+              {t("computations:run.no_outputs")}
+            </p>
+          );
+        }
+        if (hasValues) {
+          return (
+            <div key={label} className="mt-2">
+              {isGroup && (
+                <div
+                  className="fw-semibold mb-1 font-monospace"
+                  style={{ fontSize: "0.85rem" }}
+                >
+                  {label}
+                </div>
+              )}
+              <div style={{ maxHeight: "18rem", overflowY: "auto" }}>
+                <Table
+                  size="sm"
+                  bordered
+                  hover
+                  className="font-monospace mb-0"
+                  style={{ fontSize: "0.8rem" }}
+                >
+                  <thead className="table-dark sticky-top">
+                    <tr>
+                      <th>{t("translation:date_time")}</th>
+                      {run.tsData.map((ts, i) => (
+                        <th key={ts.tsid?.uniqueString ?? ts.tsid?.key}>
+                          {ts.tsid?.uniqueString ??
+                            run.results!.tsIds[i]?.uniqueString ??
+                            t("computations:run.unknown_ts")}
+                          {ts.tsid?.storageUnits ? ` (${ts.tsid.storageUnits})` : ""}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {times.map((time) => (
+                      <tr key={time.getTime()}>
+                        <td className="text-nowrap">{time.toLocaleString()}</td>
+                        {run.tsData.map((ts) => (
+                          <td key={ts.tsid?.uniqueString ?? ts.tsid?.key}>
+                            {lookupValue(ts, time)}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </div>
+            </div>
+          );
+        }
+        if (status === "success") {
+          return (
+            <p
+              key={label}
+              className="text-muted mt-1 font-monospace"
+              style={{ fontSize: "0.85rem" }}
+            >
+              {isGroup && (
+                <>
+                  <strong>{label}</strong>:{" "}
+                </>
+              )}
+              {run
+                .results!.tsIds.map(
+                  (id) => id.uniqueString ?? t("computations:run.unknown_ts"),
+                )
+                .join(", ")}
+              {" — "}
+              {t("computations:run.no_data")}
+            </p>
+          );
+        }
+        return null;
+      })}
+    </>
+  );
 };
 
 export const RunComputationModal: React.FC<Props> = ({
   show,
   computationId,
   computationName,
+  groupId,
   onHide,
 }) => {
   const { t } = useTranslation(["computations", "translation"]);
@@ -235,18 +291,167 @@ export const RunComputationModal: React.FC<Props> = ({
   const [endValue, setEndValue] = useState(defaultEnd);
   const [status, setStatus] = useState<RunStatus>("idle");
   const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [results, setResults] = useState<CompResults | null>(null);
-  const [tsData, setTsData] = useState<ApiTimeSeriesData[]>([]);
+  const [runs, setRuns] = useState<RunRun[]>([]);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const logsEndRef = useRef<HTMLDivElement>(null);
 
-  const appendLog = useCallback((msg: string) => {
+  const isGroup = groupId !== undefined;
+
+  // Fetch expanded group members via React Query (avoid useEffect+setState pattern).
+  // Use an "excluded keys" set so all entries are selected by default without any
+  // initialization effect — the user starts with everything checked and unchecks as desired.
+  const {
+    data: groupTsIds = [],
+    isLoading: loadingGroup,
+    error: groupQueryError,
+  } = useQuery<ApiTimeSeriesIdentifier[]>({
+    queryKey: ["expandgroup", groupId, org],
+    queryFn: async () => {
+      const ctx = conf.baseServer.makeRequestContext("/expandgroup", HttpMethod.GET);
+      ctx.setQueryParam("groupid", String(groupId));
+      const url = ctx.getUrl();
+      const res = await fetch(url, {
+        method: "GET",
+        credentials: "include",
+        headers: { Accept: "application/json", "X-ORGANIZATION-ID": org },
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.json() as Promise<ApiTimeSeriesIdentifier[]>;
+    },
+    enabled: show && !!groupId,
+    retry: 0,
+    staleTime: 0,
+  });
+
+  const groupError = groupQueryError ? (groupQueryError as Error).message : null;
+
+  // Track which keys the user has explicitly excluded; everything else is selected.
+  const [excludedKeys, setExcludedKeys] = useState<Set<number>>(new Set());
+
+  const selectedKeys = useMemo(
+    () =>
+      new Set(
+        groupTsIds
+          .map((ts) => ts.key)
+          .filter((k): k is number => k !== undefined && !excludedKeys.has(k)),
+      ),
+    [groupTsIds, excludedKeys],
+  );
+
+  const appendLog = useCallback((msg: string, header = false) => {
     const id = logCounterRef.current++;
-    setLogs((prev) => [...prev, { id, text: msg }]);
+    setLogs((prev) => [...prev, { id, text: msg, header }]);
     requestAnimationFrame(() => {
       logsEndRef.current?.scrollIntoView({ behavior: "smooth" });
     });
   }, []);
+
+  /** Fetch the computed output time series values after a successful run. */
+  const fetchTsData = useCallback(
+    async (results: CompResults): Promise<ApiTimeSeriesData[]> => {
+      const validIds = results.tsIds.filter((id) => id.key !== undefined && id.key > 0);
+      if (validIds.length === 0) return [];
+      setStatus("fetching");
+      try {
+        return await Promise.all(
+          validIds.map((id) =>
+            tsApi.getTimeSeriesData(org, id.key!, results.startTime, results.endTime),
+          ),
+        );
+      } catch (fetchErr) {
+        appendLog(
+          `${t("computations:run.fetch_warning")}: ${(fetchErr as Error).message}`,
+        );
+        return [];
+      }
+    },
+    [org, tsApi, appendLog, t],
+  );
+
+  /** Call the SSE runcomputation endpoint and return parsed results. */
+  const streamComputation = useCallback(
+    async (
+      url: string,
+      abort: AbortController,
+    ): Promise<{ results: CompResults | null; hadError: boolean }> => {
+      const response = await fetch(url, {
+        method: "GET",
+        credentials: "include",
+        headers: { Accept: "text/event-stream", "X-ORGANIZATION-ID": org },
+        signal: abort.signal,
+      });
+      if (!response.ok) {
+        const text = await response.text().catch(() => response.statusText);
+        throw new Error(`HTTP ${response.status}: ${text}`);
+      }
+      if (!response.body) throw new Error("No response body");
+      let parsedResults: CompResults | null = null;
+      const hadError = await readSseStream(response.body, {
+        onLog: appendLog,
+        onResults: (r) => {
+          parsedResults = r;
+        },
+        onError: (msg) => {
+          setStatus("error");
+          setErrorMsg(msg);
+        },
+      });
+      return { results: parsedResults, hadError };
+    },
+    [org, appendLog],
+  );
+
+  /** Run the computation for one input TS ID (or undefined for non-group). */
+  const runOne = useCallback(
+    async (
+      tsid: ApiTimeSeriesIdentifier | undefined,
+      startIso: string,
+      endIso: string,
+      abort: AbortController,
+    ): Promise<RunRun | null> => {
+      if (!computationId) return null;
+      const ctx = conf.baseServer.makeRequestContext("/runcomputation", HttpMethod.GET);
+      ctx.setQueryParam("computationid", String(computationId));
+      ctx.setQueryParam("start", startIso);
+      ctx.setQueryParam("end", endIso);
+      if (tsid?.key !== undefined) ctx.setQueryParam("tsid", String(tsid.key));
+      const { results, hadError } = await streamComputation(ctx.getUrl(), abort);
+      // null signals an SSE ERROR event — caller should not set success status
+      if (hadError) return null;
+      if (!results) return { tsid: tsid ?? {}, results, tsData: [] };
+      const tsData = await fetchTsData(results);
+      return { tsid: tsid ?? {}, results, tsData };
+    },
+    [computationId, conf, streamComputation, fetchTsData],
+  );
+
+  /** Sequential loop over selected group TS IDs. Returns true if an SSE ERROR was received. */
+  const runGroupSequential = useCallback(
+    async (
+      startIso: string,
+      endIso: string,
+      abort: AbortController,
+    ): Promise<boolean> => {
+      const toRun = groupTsIds.filter(
+        (ts) => ts.key !== undefined && selectedKeys.has(ts.key),
+      );
+      const accumulated: RunRun[] = [];
+      for (const tsid of toRun) {
+        if (abort.signal.aborted) break;
+        appendLog(
+          `--- ${t("computations:run.group_running_for", { tsid: tsid.uniqueString ?? tsid.key })} ---`,
+          true,
+        );
+        setStatus("running");
+        const result = await runOne(tsid, startIso, endIso, abort);
+        if (result === null) return true;
+        accumulated.push(result);
+        setRuns([...accumulated]);
+      }
+      return false;
+    },
+    [groupTsIds, selectedKeys, appendLog, t, runOne],
+  );
 
   const handleRun = useCallback(async () => {
     if (!computationId) return;
@@ -256,76 +461,25 @@ export const RunComputationModal: React.FC<Props> = ({
 
     setStatus("running");
     setLogs([]);
-    setResults(null);
-    setTsData([]);
+    setRuns([]);
     setErrorMsg(null);
 
     const abort = new AbortController();
     abortRef.current = abort;
 
-    const ctx = conf.baseServer.makeRequestContext("/runcomputation", HttpMethod.GET);
-    ctx.setQueryParam("computationid", String(computationId));
-    ctx.setQueryParam("start", startIso);
-    ctx.setQueryParam("end", endIso);
-    const url = ctx.getUrl();
-
-    let parsedResults: CompResults | null = null;
-
     try {
-      const response = await fetch(url, {
-        method: "GET",
-        credentials: "include",
-        headers: { Accept: "text/event-stream", "X-ORGANIZATION-ID": org },
-        signal: abort.signal,
-      });
-
-      if (!response.ok) {
-        const text = await response.text().catch(() => response.statusText);
-        throw new Error(`HTTP ${response.status}: ${text}`);
-      }
-      if (!response.body) throw new Error("No response body");
-
-      const hadError = await readSseStream(response.body, {
-        onLog: appendLog,
-        onResults: (r) => {
-          parsedResults = r;
-          setResults(r);
-        },
-        onError: (msg) => {
-          setStatus("error");
-          setErrorMsg(msg);
-        },
-      });
-
-      if (hadError) return;
-
-      if (parsedResults) {
-        const validIds = (parsedResults as CompResults).tsIds.filter(
-          (id) => id.key !== undefined && id.key > 0,
-        );
-        if (validIds.length > 0) {
-          setStatus("fetching");
-          try {
-            const fetched = await Promise.all(
-              validIds.map((id) =>
-                tsApi.getTimeSeriesData(
-                  org,
-                  id.key!,
-                  (parsedResults as CompResults).startTime,
-                  (parsedResults as CompResults).endTime,
-                ),
-              ),
-            );
-            setTsData(fetched);
-          } catch (fetchErr) {
-            appendLog(
-              `${t("computations:run.fetch_warning")}: ${(fetchErr as Error).message}`,
-            );
-          }
+      let hadSseError = false;
+      if (isGroup) {
+        hadSseError = await runGroupSequential(startIso, endIso, abort);
+      } else {
+        const result = await runOne(undefined, startIso, endIso, abort);
+        if (result === null) {
+          hadSseError = true;
+        } else {
+          setRuns([result]);
         }
       }
-
-      setStatus("success");
+      if (!abort.signal.aborted && !hadSseError) setStatus("success");
     } catch (err) {
       if ((err as Error).name === "AbortError") {
         appendLog(t("computations:run.aborted"));
@@ -338,7 +492,16 @@ export const RunComputationModal: React.FC<Props> = ({
     } finally {
       abortRef.current = null;
     }
-  }, [computationId, startValue, endValue, conf, org, appendLog, t, tsApi]);
+  }, [
+    computationId,
+    startValue,
+    endValue,
+    isGroup,
+    appendLog,
+    t,
+    runOne,
+    runGroupSequential,
+  ]);
 
   const handleStop = useCallback(() => {
     abortRef.current?.abort();
@@ -348,17 +511,45 @@ export const RunComputationModal: React.FC<Props> = ({
     abortRef.current?.abort();
     setStatus("idle");
     setLogs([]);
-    setResults(null);
-    setTsData([]);
+    setRuns([]);
     setErrorMsg(null);
     setStartValue(defaultStart());
     setEndValue(defaultEnd());
+    setExcludedKeys(new Set());
     onHide();
   }, [onHide]);
 
+  const toggleKey = useCallback((key: number) => {
+    setExcludedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setExcludedKeys(new Set());
+  }, []);
+
+  const selectNone = useCallback(() => {
+    setExcludedKeys(
+      new Set(
+        groupTsIds.map((ts) => ts.key).filter((k): k is number => k !== undefined),
+      ),
+    );
+  }, [groupTsIds]);
+
   const running = status === "running" || status === "fetching";
-  const times = useMemo(() => pivotTimes(tsData), [tsData]);
-  const hasValues = tsData.some((ts) => (ts.values?.length ?? 0) > 0);
+  const hasAnyResults = runs.length > 0;
+  const hasValues = runs.some((r) =>
+    r.tsData.some((ts) => (ts.values?.length ?? 0) > 0),
+  );
+  const canRun =
+    !!computationId &&
+    !!startValue &&
+    !!endValue &&
+    (!isGroup || selectedKeys.size > 0);
 
   return (
     <Modal show={show} onHide={handleHide} size={hasValues ? "xl" : "lg"}>
@@ -368,6 +559,66 @@ export const RunComputationModal: React.FC<Props> = ({
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
+        {/* Group input selection */}
+        {isGroup && (
+          <div className="mb-3">
+            <div className="d-flex align-items-center justify-content-between mb-1">
+              <Form.Label className="mb-0 fw-semibold">
+                {t("computations:run.group_select_label")}
+              </Form.Label>
+              {!loadingGroup && groupTsIds.length > 0 && (
+                <div className="d-flex gap-2">
+                  <Button variant="link" size="sm" className="p-0" onClick={selectAll}>
+                    {t("computations:run.group_select_all")}
+                  </Button>
+                  <Button variant="link" size="sm" className="p-0" onClick={selectNone}>
+                    {t("computations:run.group_select_none")}
+                  </Button>
+                </div>
+              )}
+            </div>
+            {loadingGroup && (
+              <div className="d-flex align-items-center gap-2 text-muted">
+                <Spinner size="sm" animation="border" />
+                <span>{t("computations:run.group_loading")}</span>
+              </div>
+            )}
+            {groupError && (
+              <Alert variant="warning">
+                {t("computations:run.group_load_error")}: {groupError}
+              </Alert>
+            )}
+            {!loadingGroup && groupTsIds.length === 0 && !groupError && (
+              <p className="text-muted mb-0" style={{ fontSize: "0.875rem" }}>
+                {t("computations:run.group_empty")}
+              </p>
+            )}
+            {!loadingGroup && groupTsIds.length > 0 && (
+              <div
+                className="border rounded p-2"
+                style={{ maxHeight: "10rem", overflowY: "auto" }}
+              >
+                {groupTsIds.map((ts) => {
+                  const key = ts.key ?? -1;
+                  return (
+                    <FormCheck
+                      key={key}
+                      id={`group-ts-${key}`}
+                      type="checkbox"
+                      label={ts.uniqueString ?? String(key)}
+                      checked={selectedKeys.has(key)}
+                      onChange={() => toggleKey(key)}
+                      disabled={running}
+                      className="font-monospace"
+                      style={{ fontSize: "0.85rem" }}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
         <Row className="mb-3 g-3">
           <Col sm={6}>
             <FormGroup>
@@ -403,7 +654,12 @@ export const RunComputationModal: React.FC<Props> = ({
             aria-live="polite"
           >
             {logs.map((entry) => (
-              <div key={entry.id}>{entry.text}</div>
+              <div
+                key={entry.id}
+                className={entry.header ? "text-warning fw-bold mt-1" : undefined}
+              >
+                {entry.text}
+              </div>
             ))}
             <div ref={logsEndRef} />
           </div>
@@ -418,17 +674,10 @@ export const RunComputationModal: React.FC<Props> = ({
           </div>
         )}
 
-        {results && (
+        {hasAnyResults && (
           <div className="mt-2">
             <strong>{t("computations:run.results_title")}</strong>
-            <ResultsSection
-              results={results}
-              tsData={tsData}
-              times={times}
-              hasValues={hasValues}
-              status={status}
-              t={t}
-            />
+            <ResultsSection runs={runs} isGroup={isGroup} status={status} t={t} />
           </div>
         )}
       </Modal.Body>
@@ -461,7 +710,7 @@ export const RunComputationModal: React.FC<Props> = ({
           <Button
             variant="success"
             onClick={handleRun}
-            disabled={!computationId || !startValue || !endValue}
+            disabled={!canRun}
             aria-label={t("computations:run.run")}
           >
             <PlayFill /> {t("computations:run.run")}


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

Could not select time series when running a group computation from the web UI. Let alone the group area saving properly. Unable to choose which inputs to execute the computation against. 

I believe this came from: the /computationrefs endpoint never included groupId or groupName in its response (DTOMappers.mapRef did not populate those fields). The Run button therefore always received undefined as the group ID, regardless of whether the computation had a group assigned.

## Solution

Describe your solution.

mapRef(DbComputation) now populates groupId and groupName on the returned ApiComputationRef when the computation has a group assigned). When no group is assigned the fields are left null, so the frontend correctly treats the computation as non-group.

## how you tested the change

* Assigned a TS group to an existing computation and saved it
* Confirmed the Run modal now shows the Time Series checklist
* Clicked Run on a computation with and without a group

Group computation run:
<img width="1713" height="1050" alt="image" src="https://github.com/user-attachments/assets/4557cc93-4a3e-4201-9ac4-d755935e692f" />

Single computation run:
<img width="1744" height="561" alt="image" src="https://github.com/user-attachments/assets/608fbb88-ea99-45a1-9286-35e350c6a248" />

## Where the following done:

- [x] Tests. Check all that apply:
   - [x] Unit tests created or modified that run during ant test.
   - [x] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [x] Test procedure descriptions for manual testing
- [x] Was relevant documentation updated?
- [x] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
