### PR TITLE
tests/Fix macOS Storybook tests (Routing/Platforms detail buttons)

### DIFF
--- a/javascript/opendcs-web-ui-react/src/pages/decodes/routing/RoutingsPage.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/decodes/routing/RoutingsPage.stories.tsx
@@ -442,6 +442,16 @@ export const AddPlatformViaModal: Story = {
       name: i18n.t("routing:edit_routing", { id: 8 }),
     });
     await act(async () => userEvent.click(editBtn));
+    // Wait for the detail's fade-in to finish before querying for buttons
+    // inside it — on slower CI machines the Suspense + DetailFade sequence
+    // can exceed Testing Library's 1 s findByRole timeout.
+    await waitFor(() => {
+      expect(
+        canvas.getByRole("button", {
+          name: i18n.t("routing:save_routing", { id: 8 }),
+        }),
+      ).toBeInTheDocument();
+    });
     const addBtn = await canvas.findByRole("button", {
       name: i18n.t("routing:add_platforms"),
     });
@@ -468,6 +478,16 @@ export const AddNetlistViaModal: Story = {
       name: i18n.t("routing:edit_routing", { id: 8 }),
     });
     await act(async () => userEvent.click(editBtn));
+    // Wait for the detail's fade-in to finish before querying for buttons
+    // inside it — on slower CI machines the Suspense + DetailFade sequence
+    // can exceed Testing Library's 1 s findByRole timeout.
+    await waitFor(() => {
+      expect(
+        canvas.getByRole("button", {
+          name: i18n.t("routing:save_routing", { id: 8 }),
+        }),
+      ).toBeInTheDocument();
+    });
     const addBtn = await canvas.findByRole("button", {
       name: i18n.t("routing:add_netlists"),
     });

--- a/javascript/opendcs-web-ui-react/src/pages/platforms/PlatformsPage.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/platforms/PlatformsPage.stories.tsx
@@ -212,6 +212,16 @@ export const EditSiteNavigatesToSites: Story = {
       name: i18n.t("platforms:edit_platform", { id: 1 }),
     });
     await act(async () => userEvent.click(editBtn));
+    // Wait for the detail's fade-in to finish before querying for buttons
+    // inside it — on slower CI machines the Suspense + DetailFade sequence
+    // can exceed Testing Library's 1 s findByRole timeout.
+    await waitFor(() => {
+      expect(
+        canvas.getByRole("button", {
+          name: i18n.t("platforms:save_platform", { id: 1 }),
+        }),
+      ).toBeInTheDocument();
+    });
     const editSiteBtn = await canvas.findByRole("button", {
       name: i18n.t("platforms:edit_site"),
     });


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

Three storybook interaction tests were sometimes failing on the macOS CI runner.
All three failed with `Unable to find role="button" and name "..."`.
Right after clicking a row's edit action, the table was still showing the
collapsed row instead of the expanded detail panel.


## Solution

Describe your solution.

The detail panel uses `DetailFade` to
animate from skeleton to real content. 

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

This was also used to amend two other stories (`EditMode`,
`RemovePlatformRow`) by waiting for the Save button after the edit click

* full suite passes (61 files, 301 tests)


## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
