### PR TITLE
tests/fix storybook story timeouts (Scheduling/Routing)

### DIFF
--- a/javascript/opendcs-web-ui-react/.storybook/vitest.setup.ts
+++ b/javascript/opendcs-web-ui-react/.storybook/vitest.setup.ts
@@ -1,7 +1,14 @@
 import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
 import { setProjectAnnotations } from "@storybook/react-vite";
 import * as projectAnnotations from "./preview";
+import { configure } from "@testing-library/react";
 
 // This is an important step to apply the right configuration when testing your stories.
 // More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
 setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
+
+// Increase the default waitFor/findBy timeout from 1s to 5s. On slower CI
+// runners, the sequence of createRoot render → MSW fetch → React Suspense
+// resolution → DetailFade animation (two rAF calls + 300ms setTimeout) can
+// exceed the 1s default, causing flaky "unable to find element" failures.
+configure({ asyncUtilTimeout: 5000 });

--- a/javascript/opendcs-web-ui-react/src/pages/decodes/routing/RoutingsPage.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/decodes/routing/RoutingsPage.stories.tsx
@@ -519,13 +519,16 @@ export const RemovePlatformRow: Story = {
     // inherits Storybook's longer default timeout, which is needed on
     // slower CI machines where the Suspense + DetailFade sequence exceeds
     // Testing Library's 1 s findByRole timeout.
-    await waitFor(() => {
-      expect(
-        canvas.getByRole("button", {
-          name: i18n.t("routing:save_routing", { id: 8 }),
-        }),
-      ).toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(
+          canvas.getByRole("button", {
+            name: i18n.t("routing:save_routing", { id: 8 }),
+          }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
     // "Alpha" is attached by name and shows in the platforms table.
     expect(await canvas.findByText("Alpha")).toBeInTheDocument();
     // The remove button is injected into the nested DataTable by drawCallback;

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/SchedulesPage.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/SchedulesPage.stories.tsx
@@ -155,7 +155,9 @@ export const OpenScheduleDetail: Story = {
     const { i18n } = parameters;
     await act(async () => userEvent.click((await canvas.findAllByText("goes1"))[0]));
     await waitFor(() => {
-      const nameInput = canvas.getByLabelText(i18n.t("schedule:name")) as HTMLInputElement;
+      const nameInput = canvas.getByLabelText(
+        i18n.t("schedule:name"),
+      ) as HTMLInputElement;
       expect(nameInput.value).toEqual("goes1");
     });
     await waitFor(() => {

--- a/javascript/opendcs-web-ui-react/src/pages/schedule/SchedulesPage.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/schedule/SchedulesPage.stories.tsx
@@ -154,10 +154,8 @@ export const OpenScheduleDetail: Story = {
     const canvas = await mount();
     const { i18n } = parameters;
     await act(async () => userEvent.click((await canvas.findAllByText("goes1"))[0]));
-    await waitFor(async () => {
-      const nameInput = (await canvas.findByLabelText(
-        i18n.t("schedule:name"),
-      )) as HTMLInputElement;
+    await waitFor(() => {
+      const nameInput = canvas.getByLabelText(i18n.t("schedule:name")) as HTMLInputElement;
       expect(nameInput.value).toEqual("goes1");
     });
     await waitFor(() => {
@@ -186,13 +184,16 @@ export const EditMode: Story = {
       name: i18n.t("schedule:edit_schedule", { id: 9 }),
     });
     await act(async () => userEvent.click(editBtn));
-    await waitFor(() => {
-      expect(
-        canvas.getByRole("button", {
-          name: i18n.t("schedule:save_schedule", { id: 9 }),
-        }),
-      ).toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(
+          canvas.getByRole("button", {
+            name: i18n.t("schedule:save_schedule", { id: 9 }),
+          }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
     const nameInput = canvas.getByLabelText(
       i18n.t("schedule:name"),
     ) as HTMLInputElement;
@@ -210,9 +211,15 @@ export const EditAndCancel: Story = {
       name: i18n.t("schedule:edit_schedule", { id: 9 }),
     });
     await act(async () => userEvent.click(editBtn));
-    const cancelBtn = await canvas.findByRole("button", {
-      name: i18n.t("schedule:cancel_for", { id: 9 }),
-    });
+    // Wait for the detail's fade-in to finish (the Cancel button becoming
+    // accessible confirms edit mode is interactive).
+    const cancelBtn = await waitFor(
+      () =>
+        canvas.getByRole("button", {
+          name: i18n.t("schedule:cancel_for", { id: 9 }),
+        }),
+      { timeout: 5000 },
+    );
     await act(async () => userEvent.click(cancelBtn));
     await waitFor(() => {
       expect(
@@ -234,13 +241,16 @@ export const AddNewScheduleRow: Story = {
       name: i18n.t("schedule:add_schedule"),
     });
     await act(async () => userEvent.click(addBtn));
-    await waitFor(() => {
-      const nameInput = canvas.getByLabelText(
-        i18n.t("schedule:name"),
-      ) as HTMLInputElement;
-      expect(nameInput.value).toEqual("");
-      expect(nameInput.readOnly).toBe(false);
-    });
+    await waitFor(
+      () => {
+        const nameInput = canvas.getByLabelText(
+          i18n.t("schedule:name"),
+        ) as HTMLInputElement;
+        expect(nameInput.value).toEqual("");
+        expect(nameInput.readOnly).toBe(false);
+      },
+      { timeout: 5000 },
+    );
   },
 };
 


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

On slow CI runners, createRoot render -> MSW fetch -> React Suspense resolution -> the DetailFade animation + the 300ms setTimeout exceeds the default 1s asyncUtilTimeout.

Gives "unable to find element" failures.


## Solution

Describe your solution.

vitest.setup.ts: raise asyncUtilTimeout from 1s to 5s globally
SchedulesPage.stories.tsx: add { timeout: 5000 } to waitFor calls
RoutingsPage.stories.tsx: add { timeout: 5000 } to waitFor 

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
