### PR TITLE
Fix/Editing Sensor Properties

### DIFF
--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ConfigResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ConfigResources.java
@@ -18,8 +18,10 @@ package org.opendcs.odcsapi.res;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Vector;
 
 import decodes.db.ConfigSensor;
@@ -345,7 +347,8 @@ public final class ConfigResources extends OpenDcsResource
 		}
 	}
 
-	static PlatformConfig map(ApiPlatformConfig config, DataTypeDao dataTypeDao, DataTransaction tx) throws OpenDcsDataException
+	static PlatformConfig map(ApiPlatformConfig config, DataTypeDao dataTypeDao, DataTransaction tx)
+			throws OpenDcsDataException, WebAppException
 	{
 		try
 		{
@@ -363,8 +366,14 @@ public final class ConfigResources extends OpenDcsResource
 
 			pc.configName = config.getName();
 			pc.decodesScripts = map(config.getScripts(), pc);
+			Set<Integer> seenSensorNumbers = new HashSet<>();
 			for (ApiConfigSensor sensor : config.getConfigSensors())
 			{
+				if (!seenSensorNumbers.add(sensor.getSensorNumber()))
+				{
+					throw new WebAppException(Response.Status.BAD_REQUEST.getStatusCode(),
+							"Duplicate sensor number: " + sensor.getSensorNumber());
+				}
 				ConfigSensor configSensor = new ConfigSensor(null, sensor.getSensorNumber());
 				configSensor.sensorName = sensor.getSensorName();
 				configSensor.platformConfig = pc;

--- a/javascript/opendcs-web-ui-react/public/locales/de-DE/configs.json
+++ b/javascript/opendcs-web-ui-react/public/locales/de-DE/configs.json
@@ -20,6 +20,7 @@
   "save_config": "Konfiguration mit ID {{id}} speichern",
   "cancel_for": "Bearbeitung der Konfiguration mit ID {{id}} abbrechen",
   "sensor_num": "Sensor-Nr.",
+  "duplicate_sensor_number": "Diese Sensornummer wird bereits von einem anderen Sensor in dieser Konfiguration verwendet.",
   "sensor_name": "Name",
   "data_types": "Datentyp(en)",
   "recording_mode": "Aufzeichnungsmodus",

--- a/javascript/opendcs-web-ui-react/public/locales/en-US/configs.json
+++ b/javascript/opendcs-web-ui-react/public/locales/en-US/configs.json
@@ -20,6 +20,7 @@
   "save_config": "Save config with id {{id}}",
   "cancel_for": "Cancel editing for config with id {{id}}",
   "sensor_num": "Sensor #",
+  "duplicate_sensor_number": "This sensor number is already used by another sensor in this config.",
   "sensor_name": "Name",
   "data_types": "Data Type(s)",
   "recording_mode": "Recording Mode",

--- a/javascript/opendcs-web-ui-react/public/locales/es-ES/configs.json
+++ b/javascript/opendcs-web-ui-react/public/locales/es-ES/configs.json
@@ -20,6 +20,7 @@
   "save_config": "Guardar configuración con ID {{id}}",
   "cancel_for": "Cancelar la edición de la configuración con ID {{id}}",
   "sensor_num": "Sensor n.º",
+  "duplicate_sensor_number": "Este número de sensor ya está en uso por otro sensor en esta configuración.",
   "sensor_name": "Nombre",
   "data_types": "Tipo(s) de dato",
   "recording_mode": "Modo de registro",

--- a/javascript/opendcs-web-ui-react/src/pages/decodes/configs/ConfigSensor.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/decodes/configs/ConfigSensor.stories.tsx
@@ -79,6 +79,42 @@ export const EditAndSave: Story = {
   },
 };
 
+// Entering a sensor number already used by a sibling sensor blocks the save
+// and shows an inline error instead of silently discarding the edit.
+export const DuplicateSensorNumberBlocksSave: Story = {
+  args: {
+    sensor: stage,
+    edit: true,
+    otherSensorNumbers: [2],
+    actions: { save: fn(), cancel: fn() },
+  },
+  play: async ({ mount, parameters, userEvent, args }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    const numberInput = (await waitFor(() => {
+      const el = canvas.getByLabelText(
+        i18n.t("configs:sensor_num"),
+      ) as HTMLInputElement;
+      expect(el).toBeVisible();
+      return el;
+    })) as HTMLInputElement;
+
+    await userEvent.clear(numberInput);
+    await userEvent.type(numberInput, "2");
+
+    const saveBtn = canvas.getByRole("button", {
+      name: i18n.t("configs:save_sensor", { id: 1 }),
+    });
+    await userEvent.click(saveBtn);
+
+    await waitFor(() =>
+      expect(canvas.getByText(i18n.t("configs:duplicate_sensor_number"))).toBeVisible(),
+    );
+    expect(args.actions!.save).not.toHaveBeenCalled();
+  },
+};
+
 // The data-types caption is "Data Types", proving the new caption override
 // on PropertiesTable. We assert "Properties" still appears for the other
 // table below — both tables coexist with distinct titles.

--- a/javascript/opendcs-web-ui-react/src/pages/decodes/configs/ConfigSensor.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/decodes/configs/ConfigSensor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useReducer } from "react";
+import { useCallback, useMemo, useReducer, useState } from "react";
 import { Button, Card, Col, Form, FormGroup, Placeholder, Row } from "react-bootstrap";
 import { Save, X } from "react-bootstrap-icons";
 import { useTranslation } from "react-i18next";
@@ -31,6 +31,8 @@ export type UiConfigSensor = Partial<ApiConfigSensor>;
 export interface ConfigSensorProperties {
   sensor: UiConfigSensor;
   edit?: boolean;
+  /** Sensor numbers already in use by sibling sensors in this config (excluding this one). */
+  otherSensorNumbers?: number[];
   actions?: SaveAction<ApiConfigSensor> & CancelAction<number>;
 }
 
@@ -147,10 +149,12 @@ const mapDataTypes = (dt: { [k: string]: string } | undefined): Property[] =>
 export const ConfigSensor: React.FC<ConfigSensorProperties> = ({
   sensor,
   edit = false,
+  otherSensorNumbers = [],
   actions = {},
 }) => {
   const [t] = useTranslation(["configs", "translation"]);
   const [local, dispatch] = useReducer(sensorReducer, sensor);
+  const [sensorNumberError, setSensorNumberError] = useState(false);
 
   const props = useMemo(() => mapProps(local.properties), [local.properties]);
   const dataTypes = useMemo(() => mapDataTypes(local.dataTypes), [local.dataTypes]);
@@ -185,6 +189,7 @@ export const ConfigSensor: React.FC<ConfigSensorProperties> = ({
 
   const numberChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
+    if (name === "sensorNumber") setSensorNumberError(false);
     dispatch({ type: "save", payload: { [name]: toNumberOrUndefined(value) } });
   }, []);
 
@@ -194,8 +199,15 @@ export const ConfigSensor: React.FC<ConfigSensorProperties> = ({
   }, []);
 
   const saveSensor = useCallback(() => {
+    if (
+      local.sensorNumber !== undefined &&
+      otherSensorNumbers.includes(local.sensorNumber)
+    ) {
+      setSensorNumberError(true);
+      return;
+    }
     actions.save?.(local as ApiConfigSensor);
-  }, [actions, local]);
+  }, [actions, local, otherSensorNumbers]);
 
   const cancel = useCallback(() => {
     if (sensor.sensorNumber !== undefined) actions.cancel?.(sensor.sensorNumber);
@@ -221,9 +233,13 @@ export const ConfigSensor: React.FC<ConfigSensorProperties> = ({
                     id="sensorNumber"
                     name="sensorNumber"
                     readOnly={!edit}
+                    isInvalid={sensorNumberError}
                     defaultValue={local.sensorNumber ?? ""}
                     onChange={numberChange}
                   />
+                  <Form.Control.Feedback type="invalid">
+                    {t("configs:duplicate_sensor_number")}
+                  </Form.Control.Feedback>
                 </Col>
               </FormGroup>
               <FormGroup as={Row} className="mb-3">

--- a/javascript/opendcs-web-ui-react/src/pages/decodes/configs/ConfigSensorsTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/decodes/configs/ConfigSensorsTable.tsx
@@ -118,6 +118,10 @@ export const ConfigSensorsTable: React.FC<ConfigSensorsTableProperties> = ({
         <ConfigSensor
           sensor={row}
           edit={mode !== "show"}
+          otherSensorNumbers={sensors
+            .filter((s) => s.sensorNumber !== row.sensorNumber)
+            .map((s) => s.sensorNumber)
+            .filter((n): n is number => n !== undefined)}
           actions={{
             save: (sensor) => {
               actions.save?.(sensor, row.sensorNumber);
@@ -138,7 +142,6 @@ export const ConfigSensorsTable: React.FC<ConfigSensorsTableProperties> = ({
             }
           : undefined
       }
-      onSave={(sensor) => actions.save?.(sensor)}
       caption={t("configs:config_sensors")}
       tableId="configSensorsTable"
       dataTableOptions={{ stateSave: false }}


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #2019 . 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Describe your solution.

Editing a sensor's properties and saving didn't stick so reopening the config showed the old values. You could set a sensor's number to match another sensor in the same config, and the save would silently fail to persist correctly instead of showing an error.

* Sensor save only updates the local state once. Before saving, it now checks the entered sensor number against its siblings' numbers. 
* map() tracks sensor numbers while building the config and throws a 400 Bad Request if two sensors in the payload share a number

## how you tested the change

[test_sensors1.zip](https://github.com/user-attachments/files/30103674/test_sensors1.zip)

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
