### PR TITLE
Fix leaked React roots in AppDataTable detail rows

### DIFF
--- a/javascript/opendcs-web-ui-react/src/components/data-table/AppDataTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/data-table/AppDataTable.tsx
@@ -17,7 +17,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { dtLangs } from "../../lang";
-import { useContextWrapper } from "../../util/ContextWrapper";
+import { unmountToDom, useContextWrapper } from "../../util/ContextWrapper";
 import { useTableProcessing } from "./useTableProcessing";
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -364,6 +364,8 @@ function syncChildRow<T>(
   if (state === undefined) {
     if (!isShown) return;
     row.child(false);
+    const closedNode = refs.childNodesRef.current[id];
+    if (closedNode) unmountToDom(closedNode);
     delete refs.childModeRef.current[id];
     delete refs.childNodesRef.current[id];
     return;
@@ -374,6 +376,10 @@ function syncChildRow<T>(
 
   if (isShown) row.child.hide();
   const cached = prevMode === state ? refs.childNodesRef.current[id] : undefined;
+  if (!cached) {
+    const replaced = refs.childNodesRef.current[id];
+    if (replaced) unmountToDom(replaced);
+  }
   const node = cached ?? buildDetailNode(rowData, state);
   refs.childNodesRef.current[id] = node;
   refs.childModeRef.current[id] = state;
@@ -474,6 +480,12 @@ export function AppDataTable<T, TId extends string | number, TSave = T>(
   // Child-row caches so in-progress edits survive redraws.
   const childModeRef = useRef<Record<string, RowMode>>({});
   const childNodesRef = useRef<Record<string, Node>>({});
+
+  useEffect(() => {
+    return () => {
+      Object.values(childNodesRef.current).forEach(unmountToDom);
+    };
+  }, []);
 
   // Synthetic ids for inline-edit new rows (row object → synthetic string).
   // WeakMap so GC can reclaim rows that leave `localItems`.

--- a/javascript/opendcs-web-ui-react/src/util/ContextWrapper.tsx
+++ b/javascript/opendcs-web-ui-react/src/util/ContextWrapper.tsx
@@ -1,11 +1,22 @@
 import { Suspense, use, useCallback, type ReactNode } from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, type Root } from "react-dom/client";
 import RefListContext from "../contexts/data/RefListContext";
 import { I18nextProvider, useTranslation } from "react-i18next";
 import { AuthContext } from "../contexts/app/AuthContext";
 import { ThemeContext } from "../contexts/app/ThemeContext";
 import { ApiContext } from "../contexts/app/ApiContext";
 import { QueryClientProvider, useQueryClient } from "@tanstack/react-query";
+
+const rootsByContainer = new WeakMap<Node, Root>();
+
+/** Unmount the React root created by `toDom` for `node`, if any. Safe to
+ *  call on nodes that were never a `toDom` container. */
+export function unmountToDom(node: Node): void {
+  const root = rootsByContainer.get(node);
+  if (!root) return;
+  rootsByContainer.delete(node);
+  root.unmount();
+}
 
 export interface Wrappers {
   /**
@@ -39,6 +50,7 @@ export function useContextWrapper(): Wrappers {
     (children: ReactNode): Node => {
       const container = document.createElement("div");
       const root = createRoot(container);
+      rootsByContainer.set(container, root);
       // The DataTables-rendered subtree gets a fresh React root, so contexts
       // from the parent tree don't flow in automatically. Re-wrap with the
       // same context values (and the same QueryClient) so any TanStack hooks


### PR DESCRIPTION
toDom() gives each row-detail render its own React root outside React's own tree, but nothing ever unmounted it when the row's mode changed.

## Problem Description



<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

* AppDataTable renders row-detail content via toDom(), creating a React root outside React's own tree. That root was never unmounted.
* Matches the CI flake on PickRoutingSpecViaModal.

## Solution

Describe your solution.

* ContextWrapper.tsx: track each toDom container's root in a WeakMap<Node, Root>, export unmountToDom(node).
* AppDataTable.tsx: call unmountToDom() when a cached detail node is changed.

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
