### PR TITLE
Lrgs Test Extension to reduce duplication.

### DIFF
--- a/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/extensions/lrgs/LrgsConfig.java
+++ b/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/extensions/lrgs/LrgsConfig.java
@@ -1,0 +1,18 @@
+package org.opendcs.fixtures.extensions.lrgs;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LrgsConfig
+{
+    /**
+     * Additional configuration properties for the LRGS
+     * separated by new lines
+     * @return
+     */
+    String value();
+}

--- a/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/extensions/lrgs/LrgsTestExtension.java
+++ b/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/extensions/lrgs/LrgsTestExtension.java
@@ -1,0 +1,54 @@
+package org.opendcs.fixtures.extensions.lrgs;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.opendcs.fixtures.lrgs.LrgsTestInstance;
+
+public final class LrgsTestExtension implements BeforeAllCallback, ParameterResolver
+{
+    private static final Namespace LRGS_INSTANCE = Namespace.create("lrgs", "instance");
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception
+    {
+        
+        var ns = context.getStore(LRGS_INSTANCE);
+        ns.computeIfAbsent(LrgsTestInstance.class, t ->
+            assertDoesNotThrow(() ->
+            {
+                File lrgsHome = Files.createTempDirectory("lrgshome").toFile();
+                lrgsHome.mkdirs();
+                var testClass = context.getRequiredTestClass();
+                var lrgsConfig = testClass.getAnnotation(LrgsConfig.class);
+                return new LrgsTestInstance(lrgsHome, lrgsConfig != null ? lrgsConfig.value() : null);
+            })
+        );
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException 
+    {
+        return LrgsTestInstance.class.equals(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public @Nullable Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException 
+    {
+        var ns = extensionContext.getStore(LRGS_INSTANCE);
+        return ns.get(parameterContext.getParameter().getType());
+    }
+
+    
+}

--- a/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/lrgs/LrgsTestInstance.java
+++ b/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/lrgs/LrgsTestInstance.java
@@ -32,10 +32,20 @@ public class LrgsTestInstance
 
     public LrgsTestInstance(File lrgsHome) throws Exception
     {
-        this(lrgsHome, null, null, TlsMode.NONE);
+        this(lrgsHome, null);
+    }
+
+    public LrgsTestInstance(File lrgsHome, String additionalConfig) throws Exception
+    {
+        this(lrgsHome, null, null, TlsMode.NONE, additionalConfig);
     }
 
     public LrgsTestInstance(File lrgsHome, File keyStore, String keyStorePassword, TlsMode tlsMode) throws Exception
+    {
+        this(lrgsHome, keyStore, keyStorePassword, tlsMode, null);
+    }
+
+    public LrgsTestInstance(File lrgsHome, File keyStore, String keyStorePassword, TlsMode tlsMode, String additionalConfig) throws Exception
     {
         if (!lrgsHome.canRead())
         {
@@ -65,6 +75,14 @@ public class LrgsTestInstance
                 fw.write("keyStoreFile="+fileName+System.lineSeparator());
                 fw.write("keyStorePassword="+keyStorePassword+System.lineSeparator());
             }
+
+            if (additionalConfig != null)
+            {
+                fw.write(System.lineSeparator());
+                fw.write(additionalConfig);
+                fw.write(System.lineSeparator());
+            }
+
             fw.flush();
         }
         new File(lrgsHome,"netlist").mkdirs();

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/ArchiveOperationsTestIT.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/ArchiveOperationsTestIT.java
@@ -16,6 +16,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.opendcs.fixtures.extensions.lrgs.LrgsConfig;
+import org.opendcs.fixtures.extensions.lrgs.LrgsTestExtension;
 import org.opendcs.fixtures.lrgs.LrgsTestInstance;
 
 import lrgs.apistatus.AttachedProcess;
@@ -32,25 +35,12 @@ import lrgs.common.SearchCriteria;
 import lrgs.ddsserver.MessageArchiveRetriever;
 import lrgs.lrgsmain.LrgsInputInterface;
 
+@ExtendWith(LrgsTestExtension.class)
+@LrgsConfig("noTimeout=true")
 public class ArchiveOperationsTestIT
 {
-
-    private static LrgsTestInstance lrgs = null;
-
-    @BeforeAll
-    public static void setup() throws Exception
-    {
-        System.out.println("Before");
-        assertDoesNotThrow(() ->
-        {
-            File lrgsHome = Files.createTempDirectory("lrgshome").toFile();
-            lrgsHome.mkdirs();
-            lrgs = new LrgsTestInstance(lrgsHome);
-        });
-    }
-
     @Test
-    public void test_save_and_read_back() throws Exception
+    public void test_save_and_read_back(LrgsTestInstance lrgs) throws Exception
     {
         // Store message
         assertNotNull(lrgs);


### PR DESCRIPTION
## Problem Description

Starting to setup more LRGS tests, duplication of LRGS setup code was imminent.

## Solution

Create LRGS test extension that handles initial setup and parameter resolving support.
Created a simple solution to LRGS configuration, will likely need to expand that to something more involved in the future.

Also suspect I may need to tweak the namespace to include the target class since the LrgsInstances should be independent by class. Don't really have a good test in mind that fits here to verify that though, will investigate in a separate PR I'm working on.

## how you tested the change

Existing LRGS tests.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
