### PR TITLE
RoutingScheduler forced exit.

### DIFF
--- a/java/opendcs/src/main/java/decodes/routing/RoutingScheduler.java
+++ b/java/opendcs/src/main/java/decodes/routing/RoutingScheduler.java
@@ -511,7 +511,21 @@ public class RoutingScheduler extends TsdbAppTemplate implements RoutingSchedule
 				});
 		}
 
-		routsched.execute(args);
+		// there may be a few non-daemon threads about that haven't been corrected yet
+		// So whether there is failure or not, forcibly exit the JVM so systems
+		// can detected and restart properly.
+		try
+		{
+			routsched.execute(args);
+			System.exit(0);
+		}
+		catch (Exception ex)
+		{
+			log.atError()
+			   .setCause(ex)
+			   .log("Fatal error during execution. Forcibly exiting JVM.");
+			System.exit(1);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
May fix #2117. 

In environment application is hosted in a lost "driver application". While the error detected is getting to the point where the JVM should be existing, the driver application is showing that it is still active.

## Solution

Wrap routsched.execute in a try catch so System.exit(1) and be called on error and System.exit(0) on normal termination.

## how you tested the change

Manually to verify new logging and error codes. Using `./gradlew runApp -Popendcs.app=routesched` behavior seems reasonable. Unfortunately I was not able to totally recreate the conditions. Will test change in USACE cloud environment and update if necessary.

Automated test not applicable, this is baseline JRE behavior.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
