### PR TITLE
Task/2110 additional dds server implementation

### DIFF
--- a/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/lrgs/LrgsTestInstance.java
+++ b/integrationtesting/fixtures/src/main/java/org/opendcs/fixtures/lrgs/LrgsTestInstance.java
@@ -127,6 +127,11 @@ public class LrgsTestInstance
         return archive;
     }
 
+    public LrgsMain getLrgsMain()
+    {
+        return lrgs;
+    }
+
     public int getDdsPort()
     {
         return lrgs.getDdsServer().getPort();

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/ArchiveOperationsTestIT.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/ArchiveOperationsTestIT.java
@@ -36,7 +36,7 @@ class ArchiveOperationsTestIT
     private static final String MSG_DATA = "Test String.";
 
     @BeforeAll
-    static void setup(LrgsTestInstance lrgs) throws Exception
+    static void setup(LrgsTestInstance lrgs)
     {
         // Store message
         assertNotNull(lrgs);

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/ArchiveOperationsTestIT.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/ArchiveOperationsTestIT.java
@@ -2,16 +2,11 @@ package org.opendcs.lrgs;
 
 import static org.opendcs.fixtures.assertions.Waiting.assertResultWithinTimeFrame;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/ArchiveOperationsTestIT.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/ArchiveOperationsTestIT.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -22,8 +23,6 @@ import org.opendcs.fixtures.extensions.lrgs.LrgsTestExtension;
 import org.opendcs.fixtures.lrgs.LrgsTestInstance;
 
 import lrgs.apistatus.AttachedProcess;
-import lrgs.archive.MsgFilter;
-import lrgs.archive.SearchHandle;
 import lrgs.archive.XmlMsgArchive;
 import lrgs.common.DcpAddress;
 import lrgs.common.DcpMsg;
@@ -37,16 +36,17 @@ import lrgs.lrgsmain.LrgsInputInterface;
 
 @ExtendWith(LrgsTestExtension.class)
 @LrgsConfig("noTimeout=true")
-public class ArchiveOperationsTestIT
+class ArchiveOperationsTestIT
 {
-    @Test
-    public void test_save_and_read_back(LrgsTestInstance lrgs) throws Exception
+    private static final String MSG_DATA = "Test String.";
+
+    @BeforeAll
+    static void setup(LrgsTestInstance lrgs) throws Exception
     {
         // Store message
         assertNotNull(lrgs);
         final var archive = (XmlMsgArchive)lrgs.getArchive();
-        final String msgData = "Test String.";
-        final DcpMsg msgIn = new DcpMsg(DcpMsgFlag.MSG_TYPE_OTHER, msgData.getBytes(Charset.forName("UTF8")),msgData.length(),0);
+        final DcpMsg msgIn = new DcpMsg(DcpMsgFlag.MSG_TYPE_OTHER, MSG_DATA.getBytes(StandardCharsets.UTF_8), MSG_DATA.length(),0);
         msgIn.setXmitTime(new Date());
         final DcpAddress addrIn = new DcpAddress("TEST");
         final LrgsInputInterface dataSource = lrgs.getLrgsInputs().get(0);
@@ -54,6 +54,12 @@ public class ArchiveOperationsTestIT
         assertDoesNotThrow(() -> archive.archiveMsg(msgIn, dataSource));
         assertEquals(1, archive.getTotalMessageCount());
         archive.checkpoint();
+    }
+
+    @Test
+    void test_read_specific_dcp(LrgsTestInstance lrgs) throws Exception
+    {
+        final var archive = (XmlMsgArchive)lrgs.getArchive();
         // Attempt to read back message.
         AttachedProcess ap = new AttachedProcess(1, "test", "test", "tester", 0, 0, 0, "running", (short)0);
         final MessageArchiveRetriever mar = new MessageArchiveRetriever(archive, ap);
@@ -83,7 +89,60 @@ public class ArchiveOperationsTestIT
                 final DcpMsg msgOut = dmi.getDcpMsg();
                 if (msgOut != null)
                 {
-                    return msgData.equals(msgOut.getDataStr());
+                    return MSG_DATA.equals(msgOut.getDataStr());
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            catch (EndOfArchiveException ex)
+            {
+                return false;
+            }
+        }, 15, TimeUnit.SECONDS, 5, TimeUnit.SECONDS,
+        "Saved message was not found in the allotted time frame.");
+    }
+
+    /**
+     * Created to verify some behavior with the Netty DdsServer. Even though the archive is valid,
+     * the {@link lrgs.ddsserver.MessageArchiveRetriever} doesn't always return any results immediately.
+     * @param lrgs
+     * @throws Exception
+     */
+    @Test
+    void test_read_all(LrgsTestInstance lrgs) throws Exception
+    {
+        final var archive = (XmlMsgArchive)lrgs.getArchive();
+        // Attempt to read back message.
+        AttachedProcess ap = new AttachedProcess(1, "test", "test", "tester", 0, 0, 0, "running", (short)0);
+        final MessageArchiveRetriever mar = new MessageArchiveRetriever(archive, ap);
+        SearchCriteria sc = new SearchCriteria();
+        sc.setLrgsSince("now - 1 day");
+        sc.setLrgsUntil("now");
+        mar.setDcpNameMapper(new DcpNameMapper()
+        {
+            @Override
+            public DcpAddress dcpNameToAddress(String name)
+            {
+                return new DcpAddress(name);
+            }
+        });
+        mar.setSearchCriteria(sc);
+        final DcpMsgIndex dmi = new DcpMsgIndex();
+        assertResultWithinTimeFrame(value ->
+        {
+            try
+            {
+                int idx = mar.getNextPassingIndex(dmi, System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1));
+                if (idx == -1)
+                {
+                    return false;
+                }
+                final DcpMsg msgOut = dmi.getDcpMsg();
+                if (msgOut != null)
+                {
+                    return MSG_DATA.equals(msgOut.getDataStr());
                 }
                 else
                 {

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
@@ -44,7 +44,7 @@ class NettyLrgsTest
             lrgs = new LrgsTestInstance(lrgsHome);
         });
 
-        ddsServer = new NettyDdsServer.Builder().build();
+        ddsServer = new NettyDdsServer.Builder().withLrgs(lrgs.getLrgsMain()).build();
         ddsServer.start().sync();
          
     }

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opendcs.fixtures.assertions.Waiting.assertResultWithinTimeFrame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opendcs.fixtures.lrgs.LrgsTestInstance;
 import org.opendcs.lrgs.dds.LddsCommandDecoder;
-import org.opendcs.lrgs.dds.LddsCommandHandler;
+import org.opendcs.lrgs.dds.LddsHelloHandler;
 import org.opendcs.lrgs.dds.LddsMessageDecoder;
 import org.opendcs.lrgs.dds.LddsMessageEncoder;
 
@@ -62,7 +62,7 @@ class NettyLrgsTest
                     new LddsMessageDecoder(),
                     new LddsCommandDecoder(),
                     new LddsMessageEncoder(),
-                    new LddsCommandHandler()
+                    new LddsHelloHandler()
             );
             }   
          })

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
@@ -16,6 +16,7 @@ import org.opendcs.lrgs.dds.LddsCommandDecoder;
 import org.opendcs.lrgs.dds.LddsHelloHandler;
 import org.opendcs.lrgs.dds.LddsMessageDecoder;
 import org.opendcs.lrgs.dds.LddsMessageEncoder;
+import org.opendcs.lrgs.dds.NettyDdsServer;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
@@ -30,10 +31,7 @@ import lrgs.ldds.LddsClient;
 class NettyLrgsTest
 {
     private static LrgsTestInstance lrgs = null;
-    private static EventLoopGroup boss = new NioEventLoopGroup();
-    private static EventLoopGroup worker = new NioEventLoopGroup();
-    private static ChannelFuture channel;
-    private static int port;
+    private static NettyDdsServer ddsServer = null;
 
     @BeforeAll
     static void setup() throws Exception
@@ -46,38 +44,15 @@ class NettyLrgsTest
             lrgs = new LrgsTestInstance(lrgsHome);
         });
 
-        // This should be part of a more formal "Updated Dds Server" class
-        // it is placed here for ease of initial setup and testing.
-    
-        ServerBootstrap b = new ServerBootstrap();
-        b.group(boss, worker)
-         .channel(NioServerSocketChannel.class)
-         .childHandler(new ChannelInitializer<SocketChannel>() 
-         {
-            @Override
-            protected void initChannel(SocketChannel ch) throws Exception
-            {
-                ch.pipeline()
-                    .addLast(
-                    new LddsMessageDecoder(),
-                    new LddsCommandDecoder(),
-                    new LddsMessageEncoder(),
-                    new LddsHelloHandler()
-            );
-            }   
-         })
-         .option(ChannelOption.SO_BACKLOG, 5)
-         .childOption(ChannelOption.SO_KEEPALIVE, true);
-
-         channel = b.bind(0).sync();
-         port = ((InetSocketAddress)channel.channel().localAddress()).getPort();
+        ddsServer = new NettyDdsServer.Builder().build();
+        ddsServer.start().sync();
          
     }
 
     @Test
     void test_netty_server() throws Exception
     {
-        LddsClient client = new LddsClient("127.0.0.1", port);
+        LddsClient client = new LddsClient("127.0.0.1", ddsServer.getBindPort());
         client.connect();
         client.sendHello("anonymous");
         var ret = client.getMsgBlockExt(0);

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
@@ -1,13 +1,11 @@
 package org.opendcs.lrgs;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opendcs.fixtures.assertions.Waiting.assertResultWithinTimeFrame;
 import java.io.File;
-import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.Date;
@@ -16,10 +14,10 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opendcs.fixtures.lrgs.LrgsTestInstance;
+import org.opendcs.lrgs.dds.NettyDdsServerBuilder;
 import org.opendcs.lrgs.dds.NettyDdsServer;
 
 import lrgs.archive.XmlMsgArchive;
-import lrgs.common.ArchiveException;
 import lrgs.common.DcpAddress;
 import lrgs.common.DcpMsg;
 import lrgs.common.DcpMsgFlag;
@@ -43,7 +41,7 @@ class NettyLrgsTest
             lrgs = new LrgsTestInstance(lrgsHome);
         });
 
-        ddsServer = new NettyDdsServer.Builder().withLrgs(lrgs.getLrgsMain()).build();
+        ddsServer = new NettyDdsServerBuilder().withLrgs(lrgs.getLrgsMain()).build();
         ddsServer.start().sync();
 
     }

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
@@ -7,26 +7,21 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.Date;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opendcs.fixtures.lrgs.LrgsTestInstance;
-import org.opendcs.lrgs.dds.LddsCommandDecoder;
-import org.opendcs.lrgs.dds.LddsHelloHandler;
-import org.opendcs.lrgs.dds.LddsMessageDecoder;
-import org.opendcs.lrgs.dds.LddsMessageEncoder;
 import org.opendcs.lrgs.dds.NettyDdsServer;
 
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
+import lrgs.archive.XmlMsgArchive;
+import lrgs.common.DcpAddress;
+import lrgs.common.DcpMsg;
+import lrgs.common.DcpMsgFlag;
 import lrgs.ldds.LddsClient;
+import lrgs.lrgsmain.LrgsInputInterface;
 
 class NettyLrgsTest
 {
@@ -52,10 +47,19 @@ class NettyLrgsTest
     @Test
     void test_netty_server() throws Exception
     {
+        final String msgData = "Test String.";
+        final DcpMsg msgIn = new DcpMsg(DcpMsgFlag.MSG_TYPE_OTHER, msgData.getBytes(Charset.forName("UTF8")),msgData.length(),0);
+        msgIn.setXmitTime(new Date());
+        final DcpAddress addrIn = new DcpAddress("TEST");
+        final LrgsInputInterface dataSource = lrgs.getLrgsInputs().get(0);
+        msgIn.setDcpAddress(addrIn);
+        lrgs.getArchive().archiveMsg(msgIn, dataSource);
+        ((XmlMsgArchive)lrgs.getArchive()).checkpoint();
+
         LddsClient client = new LddsClient("127.0.0.1", ddsServer.getBindPort());
         client.connect();
         client.sendHello("anonymous");
-        var ret = client.getMsgBlockExt(0);
+        var ret = client.getMsgBlockExt(500);
         assertNotNull(ret);
         assertEquals(1, ret.length);
         client.sendGoodbye();

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.net.InetSocketAddress;
@@ -55,9 +57,12 @@ class NettyLrgsTest
         msgIn.setDcpAddress(addrIn);
         lrgs.getArchive().archiveMsg(msgIn, dataSource);
         ((XmlMsgArchive)lrgs.getArchive()).checkpoint();
-
+        var sp = lrgs.getArchive().getStatusProvider();
+        assertNotNull(sp);
+        assertTrue(sp.isUsable());
         LddsClient client = new LddsClient("127.0.0.1", ddsServer.getBindPort());
         client.connect();
+        client.getSocket().setSoTimeout(0);
         client.sendHello("anonymous");
         var ret = client.getMsgBlockExt(500);
         assertNotNull(ret);

--- a/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
+++ b/integrationtesting/lrgs/src/test/java/org/opendcs/lrgs/NettyLrgsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opendcs.fixtures.assertions.Waiting.assertResultWithinTimeFrame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -12,6 +13,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -19,10 +21,12 @@ import org.opendcs.fixtures.lrgs.LrgsTestInstance;
 import org.opendcs.lrgs.dds.NettyDdsServer;
 
 import lrgs.archive.XmlMsgArchive;
+import lrgs.common.ArchiveException;
 import lrgs.common.DcpAddress;
 import lrgs.common.DcpMsg;
 import lrgs.common.DcpMsgFlag;
 import lrgs.ldds.LddsClient;
+import lrgs.ldds.ServerError;
 import lrgs.lrgsmain.LrgsInputInterface;
 
 class NettyLrgsTest
@@ -43,7 +47,7 @@ class NettyLrgsTest
 
         ddsServer = new NettyDdsServer.Builder().withLrgs(lrgs.getLrgsMain()).build();
         ddsServer.start().sync();
-         
+
     }
 
     @Test
@@ -64,9 +68,30 @@ class NettyLrgsTest
         client.connect();
         client.getSocket().setSoTimeout(0);
         client.sendHello("anonymous");
-        var ret = client.getMsgBlockExt(500);
-        assertNotNull(ret);
-        assertEquals(1, ret.length);
+        assertResultWithinTimeFrame(value ->
+        {
+            try
+            {
+                var ret = client.getMsgBlockExt(500);
+                if (ret == null)
+                {
+                    return false;
+                }
+                return ret.length >= 1;
+            }
+            catch (ServerError ex)
+            {
+                if (ex.getMessage().contains("End of Archive"))
+                {
+                    return false;
+                }
+                throw ex;
+            }
+        },
+        3, TimeUnit.MINUTES,
+        5, TimeUnit.SECONDS,
+        "No Data returned within reasonable time frame");
+
         client.sendGoodbye();
         client.disconnect();
         assertFalse(client.isConnected());

--- a/java/opendcs/src/main/java/lrgs/archive/DailyDomsatSeqMap.java
+++ b/java/opendcs/src/main/java/lrgs/archive/DailyDomsatSeqMap.java
@@ -17,6 +17,7 @@ package lrgs.archive;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import org.opendcs.lrgs.dao.MsgArchive;
 
@@ -146,7 +147,7 @@ public class DailyDomsatSeqMap
 	 * @return number of messages stored.
 	 */
 	public synchronized int getMsgsBySeqNum(long fromDomsatMsec,
-		long toDomsatMsec, int seqStart, int seqEnd, ArrayList<DcpMsg> msgs)
+		long toDomsatMsec, int seqStart, int seqEnd, List<DcpMsg> msgs)
 		throws ArchiveUnavailableException
 	{
 		// Search from 15 seconds before/after the approx time.

--- a/java/opendcs/src/main/java/lrgs/archive/XmlMsgArchive.java
+++ b/java/opendcs/src/main/java/lrgs/archive/XmlMsgArchive.java
@@ -22,7 +22,6 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;

--- a/java/opendcs/src/main/java/lrgs/archive/XmlMsgArchive.java
+++ b/java/opendcs/src/main/java/lrgs/archive/XmlMsgArchive.java
@@ -21,6 +21,7 @@ import java.text.SimpleDateFormat;
 import java.text.ParseException;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.ArrayList;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -183,6 +184,12 @@ public class XmlMsgArchive implements org.opendcs.lrgs.dao.MsgArchive
 		{
 			log.atWarn().log("cannot use LrgsStatusProvider of type {}", sp.getClass().getName());
 		}
+	}
+
+	@Override
+	public LrgsStatusProvider getStatusProvider()
+	{
+		return this.statusProvider;
 	}
 
 	/**
@@ -959,7 +966,7 @@ public class XmlMsgArchive implements org.opendcs.lrgs.dao.MsgArchive
 	 * @return number of messages stored.
 	 */
 	public int getMsgsBySeqNum(long fromDomsatTime, long untilDomsatTime,
-		int seqStart, int seqEnd, ArrayList<DcpMsg> msgs)
+		int seqStart, int seqEnd, List<DcpMsg> msgs)
 		throws ArchiveUnavailableException
 	{
 		int r = 0;

--- a/java/opendcs/src/main/java/lrgs/ldds/CmdAuthHello.java
+++ b/java/opendcs/src/main/java/lrgs/ldds/CmdAuthHello.java
@@ -480,4 +480,9 @@ public class CmdAuthHello extends LddsCommand
 
 	/** @return the code associated with this command. */
 	public char getCommandCode() { return LddsMessage.IdAuthHello; }
+
+	public int getDdsVersion()
+	{
+		return this.ddsVersion != null ? Integer.parseInt(this.ddsVersion) : -1;
+	}
 }

--- a/java/opendcs/src/main/java/lrgs/ldds/CmdHello.java
+++ b/java/opendcs/src/main/java/lrgs/ldds/CmdHello.java
@@ -190,4 +190,9 @@ public class CmdHello extends LddsCommand
 
 	/** @return the code associated with this command. */
 	public char getCommandCode() { return LddsMessage.IdHello; }
+
+	public int getDdsVersion()
+	{
+		return this.ddsVersion != null ? Integer.parseInt(this.ddsVersion) : -1;
+	}
 }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dao/MsgArchive.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dao/MsgArchive.java
@@ -47,4 +47,6 @@ public interface MsgArchive
      * @param statusProvider implementation of LrgsStatusProvider
      */
     void setStatusProvider(LrgsStatusProvider statusProvider);
+
+    LrgsStatusProvider getStatusProvider();
 }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/DdsSession.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/DdsSession.java
@@ -8,6 +8,20 @@ import org.opendcs.lrgs.dao.MsgArchive;
 import lrgs.common.DcpMsg;
 import lrgs.common.DcpMsgRetriever;
 
+/**
+ * Data objects that may be required during a given DdsSession. DdsUserPrincipal is stored separately.
+ * Additionally, items placed in here should make a best effort to disconnect from implementation assumptions.
+ *
+ * NOTE: seqNumMsgBuf* is clearly a failure in that regard and are currently left in for completeness of implementation.
+ * Such data is required, though likely better in a simple Map<String,Object> that is part of the session.
+ *
+ * DdsSession
+ * @param msgRetriever DcpMsgRetriever that is used to acquire messages.
+ * @param ddsVersion which version we are operating under
+ * @param archive MsgArchive for this LRGS instance.
+ * @param seqNumMsgBufIdx current index for retrieval by sequence number
+ * @param sequenceMessageBuf buffer of by sequence number messages
+ */
 public record DdsSession(DcpMsgRetriever msgRetriever, int ddsVersion, MsgArchive archive,
                          Integer seqNumMsgBufIdx, List<DcpMsg> sequenceMessageBuf)
 {

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/DdsSession.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/DdsSession.java
@@ -1,0 +1,8 @@
+package org.opendcs.lrgs.dds;
+
+import lrgs.common.DcpMsgRetriever;
+
+public record DdsSession(DcpMsgRetriever msgRetriever)
+{
+    
+}

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/DdsSession.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/DdsSession.java
@@ -1,8 +1,18 @@
 package org.opendcs.lrgs.dds;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opendcs.lrgs.dao.MsgArchive;
+
+import lrgs.common.DcpMsg;
 import lrgs.common.DcpMsgRetriever;
 
-public record DdsSession(DcpMsgRetriever msgRetriever)
+public record DdsSession(DcpMsgRetriever msgRetriever, int ddsVersion, MsgArchive archive,
+                         Integer seqNumMsgBufIdx, List<DcpMsg> sequenceMessageBuf)
 {
-    
+    public DdsSession(DcpMsgRetriever msgRetriever, int ddsVersion, MsgArchive archive)
+    {
+        this(msgRetriever, ddsVersion, archive, 0, new ArrayList<>());
+    }
 }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/DdsUserPrincipal.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/DdsUserPrincipal.java
@@ -1,30 +1,40 @@
+/*
+* Where Applicable, Copyright 2026 OpenDCS Consortium and/or its contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
 package org.opendcs.lrgs.dds;
 
 import java.security.Principal;
 
 /**
- * updated replacement of {@link lrgs.ldds.LddsUser that doesn't assume directories on disk.
+ * Updated replacement of {@link lrgs.ldds.LddsUser that doesn't assume directories on disk.
+ * Should likely be replaced by the rest-api Principal object; however that will require some additional
+ * restructuring.
  * DdsUserPrincipal
  */
 public class DdsUserPrincipal implements Principal
 {
     private final String username;
-    private final int version;
 
-    public DdsUserPrincipal(String username, int version)
+    public DdsUserPrincipal(String username)
     {
         this.username = username;
-        this.version = version;
     }
 
     @Override
     public String getName()
     {
         return username;
-    }
-
-    public int getDdsVersion()
-    {
-        return version;
     }
 }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/DdsUserPrincipal.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/DdsUserPrincipal.java
@@ -1,0 +1,30 @@
+package org.opendcs.lrgs.dds;
+
+import java.security.Principal;
+
+/**
+ * updated replacement of {@link lrgs.ldds.LddsUser that doesn't assume directories on disk.
+ * DdsUserPrincipal
+ */
+public class DdsUserPrincipal implements Principal
+{
+    private final String username;
+    private final int version;
+
+    public DdsUserPrincipal(String username, int version)
+    {
+        this.username = username;
+        this.version = version;
+    }
+
+    @Override
+    public String getName()
+    {
+        return username;
+    }
+
+    public int getDdsVersion()
+    {
+        return version;
+    }
+}

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsErrorHandler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsErrorHandler.java
@@ -1,0 +1,23 @@
+package org.opendcs.lrgs.dds;
+
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.slf4j.Logger;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * Catch all error handler the terminates the connection after logging the error.
+ * LddsErrorHandler
+ */
+public class LddsErrorHandler extends ChannelInboundHandlerAdapter
+{
+    private static final Logger log = OpenDcsLoggerFactory.getLogger();
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
+    {
+        log.atError().setCause(cause).log("Unable to process DDS Message");
+        ctx.close();
+    }
+}

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsErrorHandler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsErrorHandler.java
@@ -1,3 +1,18 @@
+/*
+* Where Applicable, Copyright 2026 OpenDCS Consortium and/or its contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
 package org.opendcs.lrgs.dds;
 
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
@@ -91,8 +91,10 @@ public class LddsHelloHandler extends ChannelInboundHandlerAdapter
             var ap = new AttachedProcess();
             ap.user = user.getName();
             var retriever = new MessageArchiveRetriever((XmlMsgArchive)lrgs.msgArchive, ap);
+            retriever.attachSource();
+            retriever.setDcpMsgSource(retriever);
             retriever.init();
-            var session = new DdsSession(retriever);
+            var session = new DdsSession(retriever, hello.getDdsVersion(), lrgs.msgArchive);
             ctx.channel().attr(DDS_SESSION).set(session);
 
             ctx.pipeline().addLast("dds14handler", new DdsProtocol14Handler());

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
@@ -81,7 +81,7 @@ public class LddsHelloHandler extends ChannelInboundHandlerAdapter
             var res = new LddsMessage(LddsMessage.IdHello, hello.getUserName() + " " + hello.getDdsVersion());
             user = new DdsUserPrincipal(hello.getUserName());
             ctx.channel().attr(DDS_USER).set(user);
-            
+
             var lrgs = ctx.channel().attr(NettyDdsServer.LRGS_INSTANCE).get();
             var ap = new AttachedProcess();
             ap.user = user.getName();

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
@@ -18,18 +18,22 @@ package org.opendcs.lrgs.dds;
 import java.io.ByteArrayOutputStream;
 import java.util.zip.GZIPOutputStream;
 
+import org.opendcs.lrgs.dds.dds14.DdsProtocol14Handler;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
 
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import lrgs.common.LrgsErrorCode;
 import lrgs.ldds.CmdGetMsgBlockExt;
 import lrgs.ldds.CmdGoodbye;
 import lrgs.ldds.CmdHello;
+import lrgs.ldds.DdsInternalException;
 import lrgs.ldds.DdsVersion;
 import lrgs.ldds.LddsCommand;
 import lrgs.ldds.LddsMessage;
+import lrgs.ldds.ServerError;
 
 /**
  *
@@ -47,7 +51,7 @@ import lrgs.ldds.LddsMessage;
  * taking an {@link lrgs.ldds.LddsCommand} and returning an appropriate {@link lrgs.ldds.LddsMessage} to send back
  * to the client.
  */
-public class LddsCommandHandler extends ChannelInboundHandlerAdapter
+public class LddsHelloHandler extends ChannelInboundHandlerAdapter
 {
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
 
@@ -71,7 +75,14 @@ public class LddsCommandHandler extends ChannelInboundHandlerAdapter
         if (msg instanceof CmdHello hello)
         {
             log.info("hello msg");
-            var res = new LddsMessage(LddsMessage.IdHello, hello.getUserName() + " " + DdsVersion.DdsVersionNum);
+            if (hello.getDdsVersion() != 14)
+            {
+                throw new ServerError("Only DDS Protcoll Version 14 is supported on this system.", LrgsErrorCode.DDDSFATAL, 0);
+            }
+            var res = new LddsMessage(LddsMessage.IdHello, hello.getUserName() + " " + hello.getDdsVersion());
+
+            ctx.pipeline().remove("hellohandler");
+            ctx.pipeline().addLast("dds14handler", new DdsProtocol14Handler());
             ctx.writeAndFlush(res);
         }
         else if (msg instanceof CmdGetMsgBlockExt)

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
@@ -59,7 +59,6 @@ public class LddsHelloHandler extends ChannelInboundHandlerAdapter
     {
         if (msg instanceof CmdHello hello)
         {
-            log.info("hello msg");
             if (hello.getDdsVersion() != 14)
             {
                 throw new ServerError("Only DDS Protcoll Version 14 is supported on this system.", LrgsErrorCode.DDDSFATAL, 0);
@@ -75,12 +74,5 @@ public class LddsHelloHandler extends ChannelInboundHandlerAdapter
             log.atInfo().log("did not receive an LddsCommand instance, was " + msg.getClass().getName());
             super.channelRead(ctx, msg);
         }
-    }
-
-    @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
-    {
-        log.atError().setCause(cause).log("Unable to process DDS Message");
-        ctx.close();
     }
 }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
@@ -15,15 +15,25 @@
 */
 package org.opendcs.lrgs.dds;
 
+import java.security.Principal;
+
 import org.opendcs.lrgs.dds.dds14.DdsProtocol14Handler;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
 
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.GenericFutureListener;
+import lrgs.apistatus.AttachedProcess;
+import lrgs.archive.XmlMsgArchive;
 import lrgs.common.LrgsErrorCode;
+import lrgs.ddsserver.MessageArchiveRetriever;
 import lrgs.ldds.CmdHello;
+import lrgs.ldds.DdsUser;
 import lrgs.ldds.LddsMessage;
+import lrgs.ldds.LddsUser;
 import lrgs.ldds.ServerError;
 
 /**
@@ -39,10 +49,14 @@ public class LddsHelloHandler extends ChannelInboundHandlerAdapter
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
 
     public static final String HANDLER_NAME = "helloHandler";
+    public static final AttributeKey<DdsUserPrincipal> DDS_USER = AttributeKey.valueOf("ddsUser");
+    public static final AttributeKey<DdsSession> DDS_SESSION = AttributeKey.valueOf("ddsSession");
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception
     {
+        ctx.channel().attr(DDS_USER).set(null);
+        ctx.channel().attr(DDS_SESSION).set(null);
         log.atInfo().log("Channel deactivated. Client disconnected");
     }
 
@@ -57,21 +71,35 @@ public class LddsHelloHandler extends ChannelInboundHandlerAdapter
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception
     {
-        if (msg instanceof CmdHello hello)
+        var user = ctx.channel().attr(DDS_USER).get();
+        if (msg instanceof CmdHello && user != null)
+        {
+            var res = new LddsMessage(LddsMessage.IdGoodbye, "hello already called.");
+            ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE);
+        }
+        else if (msg instanceof CmdHello hello)
         {
             if (hello.getDdsVersion() != 14)
             {
                 throw new ServerError("Only DDS Protcoll Version 14 is supported on this system.", LrgsErrorCode.DDDSFATAL, 0);
             }
             var res = new LddsMessage(LddsMessage.IdHello, hello.getUserName() + " " + hello.getDdsVersion());
+            user = new DdsUserPrincipal(hello.getUserName(), hello.getDdsVersion());
+            ctx.channel().attr(DDS_USER).set(user);
+            
+            var lrgs = ctx.channel().attr(NettyDdsServer.LRGS_INSTANCE).get();
+            var ap = new AttachedProcess();
+            ap.user = user.getName();
+            var retriever = new MessageArchiveRetriever((XmlMsgArchive)lrgs.msgArchive, ap);
+            retriever.init();
+            var session = new DdsSession(retriever);
+            ctx.channel().attr(DDS_SESSION).set(session);
 
-            ctx.pipeline().remove(HANDLER_NAME);
             ctx.pipeline().addLast("dds14handler", new DdsProtocol14Handler());
             ctx.writeAndFlush(res);
         }
         else
         {
-            log.atInfo().log("did not receive an LddsCommand instance, was " + msg.getClass().getName());
             super.channelRead(ctx, msg);
         }
     }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
@@ -15,12 +15,14 @@
 */
 package org.opendcs.lrgs.dds;
 
+import java.io.File;
 import java.security.Principal;
 
 import org.opendcs.lrgs.dds.dds14.DdsProtocol14Handler;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
 
+import ilex.util.EnvExpander;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -29,12 +31,14 @@ import io.netty.util.concurrent.GenericFutureListener;
 import lrgs.apistatus.AttachedProcess;
 import lrgs.archive.XmlMsgArchive;
 import lrgs.common.LrgsErrorCode;
+import lrgs.common.NetlistDcpNameMapper;
 import lrgs.ddsserver.MessageArchiveRetriever;
 import lrgs.ldds.CmdHello;
 import lrgs.ldds.DdsUser;
 import lrgs.ldds.LddsMessage;
 import lrgs.ldds.LddsUser;
 import lrgs.ldds.ServerError;
+import lrgs.lrgsmain.LrgsConfig;
 
 /**
  *
@@ -93,6 +97,9 @@ public class LddsHelloHandler extends ChannelInboundHandlerAdapter
             var retriever = new MessageArchiveRetriever((XmlMsgArchive)lrgs.msgArchive, ap);
             retriever.attachSource();
             retriever.setDcpMsgSource(retriever);
+            retriever.setDcpNameMapper(new NetlistDcpNameMapper(
+                new File(EnvExpander.expand(LrgsConfig.instance().ddsNetlistDir)),
+            null));
             retriever.init();
             var session = new DdsSession(retriever, hello.getDdsVersion(), lrgs.msgArchive);
             ctx.channel().attr(DDS_SESSION).set(session);

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
@@ -15,23 +15,14 @@
 */
 package org.opendcs.lrgs.dds;
 
-import java.io.ByteArrayOutputStream;
-import java.util.zip.GZIPOutputStream;
-
 import org.opendcs.lrgs.dds.dds14.DdsProtocol14Handler;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
 
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import lrgs.common.LrgsErrorCode;
-import lrgs.ldds.CmdGetMsgBlockExt;
-import lrgs.ldds.CmdGoodbye;
 import lrgs.ldds.CmdHello;
-import lrgs.ldds.DdsInternalException;
-import lrgs.ldds.DdsVersion;
-import lrgs.ldds.LddsCommand;
 import lrgs.ldds.LddsMessage;
 import lrgs.ldds.ServerError;
 
@@ -39,21 +30,15 @@ import lrgs.ldds.ServerError;
  *
  * LddsCommandHandler
  *
- * Given an {@link lrgs.ldds.LddsCommand instance} process the message appropriately.
+ * Given an {@link lrgs.ldds.LddsCommand instance} of {@link lrgs.ldds.CmdHello} or {@link lrgs.ldds.CmdAuthHello}
+ * process the message appropriately and setup the desired DdsServer version.
  *
- * NOTE: This is also where things like establishing session specific objects, like a MessageArchiveRetriever
- * or an implementation similar to {@link lrgs.ldds.LddsThread} (though far more generic) that wraps those instances.
- *
- * NOTE: DDS <b>is</b> a stateful protocol and that won't change so there are long running connections and state data
- * for that connection.
- *
- * As stated in {@see channelRead} below, this should be a light weight wrapper around some object dedicated to
- * taking an {@link lrgs.ldds.LddsCommand} and returning an appropriate {@link lrgs.ldds.LddsMessage} to send back
- * to the client.
  */
 public class LddsHelloHandler extends ChannelInboundHandlerAdapter
 {
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
+
+    public static final String HANDLER_NAME = "helloHandler";
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception
@@ -81,45 +66,9 @@ public class LddsHelloHandler extends ChannelInboundHandlerAdapter
             }
             var res = new LddsMessage(LddsMessage.IdHello, hello.getUserName() + " " + hello.getDdsVersion());
 
-            ctx.pipeline().remove("hellohandler");
+            ctx.pipeline().remove(HANDLER_NAME);
             ctx.pipeline().addLast("dds14handler", new DdsProtocol14Handler());
             ctx.writeAndFlush(res);
-        }
-        else if (msg instanceof CmdGetMsgBlockExt)
-        {
-            log.info("Get message block msg");
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            try (var gzip = new GZIPOutputStream(baos))
-            {
-                gzip.write("""
-                    <MsgBlock>
-                        <DcpMsg flags="0x0">
-                            <AsciiMsg>Header              Data</AsciiMsg>
-                            <CarrierStart>2026/131 00:00:00.000</CarrierStart>
-                            <CarrierStop>2026/131 00:00:10.000</CarrierStop>
-                            <DomsatTime>2026/131 00:00:00.000</DomsatTime>
-                            <DomsatSeq>0</DomsatSeq>
-                            <Baud>300</Baud>
-                        </DcpMsg>
-                    </MsgBlock>
-                """.getBytes());
-                gzip.finish();
-            }
-            var res = new LddsMessage(LddsMessage.IdDcpBlockExt, null);
-            res.MsgData = baos.toByteArray();
-            res.MsgLength = baos.size();
-            ctx.writeAndFlush(res);
-        }
-        else if (msg instanceof CmdGoodbye)
-        {
-            log.atInfo().log("User Sent Goodbye");
-            var res = new LddsMessage(LddsMessage.IdGoodbye, "");
-            ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE);
-        }
-        else if (msg instanceof LddsCommand cmd)
-        {
-            log.atInfo().log("Sending back response. Command was {}", cmd.cmdType());
-            ctx.writeAndFlush(cmd);
         }
         else
         {

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/LddsHelloHandler.java
@@ -16,8 +16,6 @@
 package org.opendcs.lrgs.dds;
 
 import java.io.File;
-import java.security.Principal;
-
 import org.opendcs.lrgs.dds.dds14.DdsProtocol14Handler;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
@@ -27,16 +25,13 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.AttributeKey;
-import io.netty.util.concurrent.GenericFutureListener;
 import lrgs.apistatus.AttachedProcess;
 import lrgs.archive.XmlMsgArchive;
 import lrgs.common.LrgsErrorCode;
 import lrgs.common.NetlistDcpNameMapper;
 import lrgs.ddsserver.MessageArchiveRetriever;
 import lrgs.ldds.CmdHello;
-import lrgs.ldds.DdsUser;
 import lrgs.ldds.LddsMessage;
-import lrgs.ldds.LddsUser;
 import lrgs.ldds.ServerError;
 import lrgs.lrgsmain.LrgsConfig;
 
@@ -65,12 +60,8 @@ public class LddsHelloHandler extends ChannelInboundHandlerAdapter
     }
 
     /**
-     * The command reponse implementation details here present as placeholders to verify the generic request/response
-     * handling with the original LddsClient works. The idea is not to implement the entire functionality here.
-     * Due the the tight integration with The BasicServerThread concept directly, it was not pratical
-     * to reuse the existing implementations. Next step is extracting the operations code from the LddsCommand
-     * implementations so that that logic can be reused where appropriate and creating new Dds IO operations
-     * classes that can then be used by both this handler and the original implementation.
+     * Handle the "hello" messages that this DdsServer will respond to and then setup the
+     * pipeline appropriately with the required data instances and additional/changed pipeline handlers.
      */
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception
@@ -88,7 +79,7 @@ public class LddsHelloHandler extends ChannelInboundHandlerAdapter
                 throw new ServerError("Only DDS Protcoll Version 14 is supported on this system.", LrgsErrorCode.DDDSFATAL, 0);
             }
             var res = new LddsMessage(LddsMessage.IdHello, hello.getUserName() + " " + hello.getDdsVersion());
-            user = new DdsUserPrincipal(hello.getUserName(), hello.getDdsVersion());
+            user = new DdsUserPrincipal(hello.getUserName());
             ctx.channel().attr(DDS_USER).set(user);
             
             var lrgs = ctx.channel().attr(NettyDdsServer.LRGS_INSTANCE).get();

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServer.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServer.java
@@ -1,0 +1,129 @@
+package org.opendcs.lrgs.dds;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.slf4j.Logger;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+public final class NettyDdsServer
+{
+    private static final Logger log = OpenDcsLoggerFactory.getLogger();
+
+    private final EventLoopGroup boss;
+    private final EventLoopGroup worker;
+    private ChannelFuture channel;
+    private final InetAddress bindAddress;
+    private final int bindPort;
+    private final ServerBootstrap boostrap;
+
+
+    private NettyDdsServer(EventLoopGroup boss, EventLoopGroup worker, ServerBootstrap bootstrap,
+                           InetAddress bindAddress, int bindPort)
+    {
+        this.boss = boss;
+        this.worker = worker;
+        this.bindAddress = bindAddress;
+        this.boostrap = bootstrap;
+        this.bindPort = bindPort;
+    }
+
+    public void start()
+    {
+        channel = boostrap.bind(bindAddress, bindPort);
+    }
+
+    public void stop()
+    {
+        try 
+        {
+            stop(false);
+        }
+        catch (InterruptedException ex)
+        {
+            log.
+        }
+    }
+
+    public void stop(boolean wait) throws InterruptedException
+    {
+        this.worker.shutdownGracefully();
+        this.boss.shutdownGracefully();        
+        if (wait)
+        {
+            channel.sync();
+        }
+    }
+    
+
+    public static class Builder
+    {
+        int port = 16003;
+        InetAddress bindAddr;
+
+        public Builder()
+        {
+            try
+            {
+                bindAddr = Inet4Address.getByAddress(new byte[]{0,0,0,0});
+            }
+            catch (UnknownHostException ex)
+            {
+                throw new RuntimeException("Unable to create address object for any host.", ex);
+            }
+        }
+
+        public Builder withPort(int port)
+        {
+            this.port = port;
+            return this;
+        }
+
+        public Builder bindTo(InetAddress bindAddress)
+        {
+            this.bindAddr = bindAddress;
+            return this;
+        }
+
+
+        public NettyDdsServer build()
+        {
+            EventLoopGroup boss = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+            EventLoopGroup worker = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(boss, worker)
+            .channel(NioServerSocketChannel.class)
+            .childHandler(new ChannelInitializer<SocketChannel>() 
+            {
+                @Override
+                protected void initChannel(SocketChannel ch) throws Exception
+                {
+                    ch.pipeline()
+                        .addLast(
+                        new LddsMessageDecoder(),
+                        new LddsCommandDecoder(),
+                        new LddsMessageEncoder(),
+                        new LddsHelloHandler()
+                );
+                }   
+            })
+            .option(ChannelOption.SO_BACKLOG, 5)
+            .childOption(ChannelOption.SO_KEEPALIVE, true);
+            
+            return new NettyDdsServer(boss, worker, b, bindAddr, port);
+        }
+    }
+}
+
+

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServer.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServer.java
@@ -16,7 +16,6 @@
 package org.opendcs.lrgs.dds;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Objects;
 
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
@@ -24,13 +23,7 @@ import org.slf4j.Logger;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.MultiThreadIoEventLoopGroup;
-import io.netty.channel.nio.NioIoHandler;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.AttributeKey;
 import lrgs.lrgsmain.LrgsMain;
 
@@ -48,7 +41,7 @@ public final class NettyDdsServer
     private final ServerBootstrap boostrap;
     private final LrgsMain lrgs;
 
-    private NettyDdsServer(EventLoopGroup boss, EventLoopGroup worker, ServerBootstrap bootstrap,
+    NettyDdsServer(EventLoopGroup boss, EventLoopGroup worker, ServerBootstrap bootstrap,
                            InetAddress bindAddress, int bindPort, LrgsMain lrgs)
     {
         this.boss = boss;
@@ -106,88 +99,5 @@ public final class NettyDdsServer
     public InetAddress getBindAddress()
     {
         return bindAddress;
-    }
-
-    /**
-     * Builder to assign or override various components of the LRGS server
-     * Builder
-     */
-    public static class Builder
-    {
-        int port = 16003;
-        InetAddress bindAddr;
-        LrgsMain lrgs = null;
-
-        public Builder()
-        {
-            try
-            {
-                bindAddr = InetAddress.getByAddress(new byte[]{0,0,0,0});
-            }
-            catch (UnknownHostException ex)
-            {
-                throw new RuntimeException("Unable to create address object for any host.", ex);
-            }
-        }
-
-        /**
-         * Port to bind this DdsServer to. Default is <code>16003</code>
-         * @param port
-         * @return
-         */
-        public Builder withPort(int port)
-        {
-            this.port = port;
-            return this;
-        }
-
-        /**
-         * Address to bind this DdsServer to. Default is <code>0.0.0.0</code>
-         * @param bindAddress
-         * @return
-         */
-        public Builder bindTo(InetAddress bindAddress)
-        {
-            this.bindAddr = bindAddress;
-            return this;
-        }
-
-        public Builder withLrgs(LrgsMain lrgs)
-        {
-            this.lrgs = lrgs;
-            return this;
-        }
-
-        /**
-         * Initialize DdsServer. Returned NettyDdsServer is ready to start when this returns, but has not been started.
-         * @return
-         */
-        public NettyDdsServer build()
-        {
-            EventLoopGroup boss = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
-            EventLoopGroup worker = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
-            ServerBootstrap b = new ServerBootstrap();
-            b.group(boss, worker)
-            .channel(NioServerSocketChannel.class)
-            .childAttr(LRGS_INSTANCE, lrgs)
-            .childHandler(new ChannelInitializer<SocketChannel>()
-            {
-                @Override
-                protected void initChannel(SocketChannel ch) throws Exception
-                {
-                    ch.pipeline()
-                        .addLast(
-                            new LddsMessageDecoder(),
-                            new LddsCommandDecoder(),
-                            new LddsMessageEncoder())
-                        .addLast(LddsHelloHandler.HANDLER_NAME, new LddsHelloHandler())
-                        .addLast(new LddsErrorHandler());
-                }
-            })
-            .option(ChannelOption.SO_BACKLOG, 5)
-            .childOption(ChannelOption.SO_KEEPALIVE, true);
-
-            return new NettyDdsServer(boss, worker, b, bindAddr, port, lrgs);
-        }
     }
 }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServer.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServer.java
@@ -3,6 +3,7 @@ package org.opendcs.lrgs.dds;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Objects;
 
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
@@ -16,10 +17,14 @@ import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.AttributeKey;
+import lrgs.lrgsmain.LrgsMain;
 
 public final class NettyDdsServer
 {
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
+
+    public static final AttributeKey<LrgsMain> LRGS_INSTANCE = AttributeKey.valueOf("lrgs");
 
     private final EventLoopGroup boss;
     private final EventLoopGroup worker;
@@ -27,16 +32,18 @@ public final class NettyDdsServer
     private final InetAddress bindAddress;
     private final int bindPort;
     private final ServerBootstrap boostrap;
+    private final LrgsMain lrgs;
 
 
     private NettyDdsServer(EventLoopGroup boss, EventLoopGroup worker, ServerBootstrap bootstrap,
-                           InetAddress bindAddress, int bindPort)
+                           InetAddress bindAddress, int bindPort, LrgsMain lrgs)
     {
         this.boss = boss;
         this.worker = worker;
         this.bindAddress = bindAddress;
         this.boostrap = bootstrap;
         this.bindPort = bindPort;
+        this.lrgs = Objects.requireNonNull(lrgs, ":rgs instance is required");
     }
 
     /**
@@ -98,6 +105,7 @@ public final class NettyDdsServer
     {
         int port = 16003;
         InetAddress bindAddr;
+        LrgsMain lrgs = null;
 
         public Builder()
         {
@@ -123,6 +131,12 @@ public final class NettyDdsServer
             return this;
         }
 
+        public Builder withLrgs(LrgsMain lrgs)
+        {
+            this.lrgs = lrgs;
+            return this;
+        }
+
         public NettyDdsServer build()
         {
             EventLoopGroup boss = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
@@ -130,6 +144,7 @@ public final class NettyDdsServer
             ServerBootstrap b = new ServerBootstrap();
             b.group(boss, worker)
             .channel(NioServerSocketChannel.class)
+            .childAttr(LRGS_INSTANCE, lrgs)
             .childHandler(new ChannelInitializer<SocketChannel>() 
             {
                 @Override
@@ -137,16 +152,17 @@ public final class NettyDdsServer
                 {
                     ch.pipeline()
                         .addLast(
-                        new LddsMessageDecoder(),
-                        new LddsCommandDecoder(),
-                        new LddsMessageEncoder())
-                        .addLast(LddsHelloHandler.HANDLER_NAME, new LddsHelloHandler());
+                            new LddsMessageDecoder(),
+                            new LddsCommandDecoder(),
+                            new LddsMessageEncoder())
+                        .addLast(LddsHelloHandler.HANDLER_NAME, new LddsHelloHandler())
+                        .addLast(new LddsErrorHandler());
                 }   
             })
             .option(ChannelOption.SO_BACKLOG, 5)
             .childOption(ChannelOption.SO_KEEPALIVE, true);
             
-            return new NettyDdsServer(boss, worker, b, bindAddr, port);
+            return new NettyDdsServer(boss, worker, b, bindAddr, port, lrgs);
         }
     }
 }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServer.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServer.java
@@ -39,11 +39,20 @@ public final class NettyDdsServer
         this.bindPort = bindPort;
     }
 
-    public void start()
+    /**
+     * Start listening on the given port. The Netty channel future is returned if the caller needs
+     * to wait for the startup to finish.
+     * @return Netty ChannelFuture for the server.
+     */
+    public ChannelFuture start()
     {
         channel = boostrap.bind(bindAddress, bindPort);
+        return channel;
     }
 
+    /**
+     * Shutdown the socket and stop listening. Returns immediately.
+     */
     public void stop()
     {
         try 
@@ -52,10 +61,15 @@ public final class NettyDdsServer
         }
         catch (InterruptedException ex)
         {
-            log.
+            log.atError().setCause(ex).log("Exception thrown, that shouldn't have been.");
         }
     }
 
+    /**
+     * Shutdown the socket and stop listening. Optionally waiting for the operation to finish.
+     * @param wait whether to wait until shutdown is complete.
+     * @throws InterruptedException if there are any issues waiting.
+     */
     public void stop(boolean wait) throws InterruptedException
     {
         this.worker.shutdownGracefully();
@@ -65,8 +79,21 @@ public final class NettyDdsServer
             channel.sync();
         }
     }
-    
 
+    public int getBindPort()
+    {
+        return this.bindPort;
+    }
+
+    public InetAddress getBindAddress()
+    {
+        return bindAddress;
+    }
+
+    /**
+     * Builder to assign or override various components of the LRGS server
+     * Builder
+     */
     public static class Builder
     {
         int port = 16003;
@@ -96,7 +123,6 @@ public final class NettyDdsServer
             return this;
         }
 
-
         public NettyDdsServer build()
         {
             EventLoopGroup boss = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
@@ -113,9 +139,8 @@ public final class NettyDdsServer
                         .addLast(
                         new LddsMessageDecoder(),
                         new LddsCommandDecoder(),
-                        new LddsMessageEncoder(),
-                        new LddsHelloHandler()
-                );
+                        new LddsMessageEncoder())
+                        .addLast(LddsHelloHandler.HANDLER_NAME, new LddsHelloHandler());
                 }   
             })
             .option(ChannelOption.SO_BACKLOG, 5)

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServer.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServer.java
@@ -1,6 +1,20 @@
+/*
+* Where Applicable, Copyright 2026 OpenDCS Consortium and/or its contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
 package org.opendcs.lrgs.dds;
 
-import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Objects;
@@ -34,7 +48,6 @@ public final class NettyDdsServer
     private final ServerBootstrap boostrap;
     private final LrgsMain lrgs;
 
-
     private NettyDdsServer(EventLoopGroup boss, EventLoopGroup worker, ServerBootstrap bootstrap,
                            InetAddress bindAddress, int bindPort, LrgsMain lrgs)
     {
@@ -50,48 +63,46 @@ public final class NettyDdsServer
      * Start listening on the given port. The Netty channel future is returned if the caller needs
      * to wait for the startup to finish.
      * @return Netty ChannelFuture for the server.
+     * @throws IllegalStateException if called after the server was previously shutdown.
      */
     public ChannelFuture start()
     {
+        if (worker.isShutdown() || worker.isShuttingDown() || worker.isTerminated() ||
+            boss.isShutdown() || boss.isShutdown() || boss.isTerminated())
+        {
+            throw new IllegalStateException("This instance is not usable, it has been previously shutdown.");
+        }
+        log.info("Starting DdsServer on {}:{}", bindAddress, bindPort);
         channel = boostrap.bind(bindAddress, bindPort);
         return channel;
     }
 
     /**
      * Shutdown the socket and stop listening. Returns immediately.
+     * If you wish to wait for shutdown call .sync() on the returned ChannelFuture.
+     * @return the ChannelFuture of this server;
      */
-    public void stop()
+    public ChannelFuture stop()
     {
-        try 
-        {
-            stop(false);
-        }
-        catch (InterruptedException ex)
-        {
-            log.atError().setCause(ex).log("Exception thrown, that shouldn't have been.");
-        }
+        log.info("Stoping DdsServer on {}:{}", bindAddress, bindPort);
+        this.worker.shutdownGracefully();
+        this.boss.shutdownGracefully();
+        return channel;
     }
 
     /**
-     * Shutdown the socket and stop listening. Optionally waiting for the operation to finish.
-     * @param wait whether to wait until shutdown is complete.
-     * @throws InterruptedException if there are any issues waiting.
+     * Retrieve port this DdsServer is bound to.
+     * @return
      */
-    public void stop(boolean wait) throws InterruptedException
-    {
-        this.worker.shutdownGracefully();
-        this.boss.shutdownGracefully();        
-        if (wait)
-        {
-            channel.sync();
-        }
-    }
-
     public int getBindPort()
     {
         return this.bindPort;
     }
 
+    /**
+     * Return Address this DdsServer is bound to.
+     * @return
+     */
     public InetAddress getBindAddress()
     {
         return bindAddress;
@@ -111,7 +122,7 @@ public final class NettyDdsServer
         {
             try
             {
-                bindAddr = Inet4Address.getByAddress(new byte[]{0,0,0,0});
+                bindAddr = InetAddress.getByAddress(new byte[]{0,0,0,0});
             }
             catch (UnknownHostException ex)
             {
@@ -119,12 +130,22 @@ public final class NettyDdsServer
             }
         }
 
+        /**
+         * Port to bind this DdsServer to. Default is <code>16003</code>
+         * @param port
+         * @return
+         */
         public Builder withPort(int port)
         {
             this.port = port;
             return this;
         }
 
+        /**
+         * Address to bind this DdsServer to. Default is <code>0.0.0.0</code>
+         * @param bindAddress
+         * @return
+         */
         public Builder bindTo(InetAddress bindAddress)
         {
             this.bindAddr = bindAddress;
@@ -137,6 +158,10 @@ public final class NettyDdsServer
             return this;
         }
 
+        /**
+         * Initialize DdsServer. Returned NettyDdsServer is ready to start when this returns, but has not been started.
+         * @return
+         */
         public NettyDdsServer build()
         {
             EventLoopGroup boss = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
@@ -145,7 +170,7 @@ public final class NettyDdsServer
             b.group(boss, worker)
             .channel(NioServerSocketChannel.class)
             .childAttr(LRGS_INSTANCE, lrgs)
-            .childHandler(new ChannelInitializer<SocketChannel>() 
+            .childHandler(new ChannelInitializer<SocketChannel>()
             {
                 @Override
                 protected void initChannel(SocketChannel ch) throws Exception
@@ -157,14 +182,12 @@ public final class NettyDdsServer
                             new LddsMessageEncoder())
                         .addLast(LddsHelloHandler.HANDLER_NAME, new LddsHelloHandler())
                         .addLast(new LddsErrorHandler());
-                }   
+                }
             })
             .option(ChannelOption.SO_BACKLOG, 5)
             .childOption(ChannelOption.SO_KEEPALIVE, true);
-            
+
             return new NettyDdsServer(boss, worker, b, bindAddr, port, lrgs);
         }
     }
 }
-
-

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServerBuilder.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/NettyDdsServerBuilder.java
@@ -1,0 +1,97 @@
+package org.opendcs.lrgs.dds;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import lrgs.lrgsmain.LrgsMain;
+
+/**
+ * Builder to assign or override various components of the LRGS server
+ * Builder
+ */
+public class NettyDdsServerBuilder
+{
+    int port = 16003;
+    InetAddress bindAddr;
+    LrgsMain lrgs = null;
+
+    public NettyDdsServerBuilder()
+    {
+        try
+        {
+            bindAddr = InetAddress.getByAddress(new byte[]{0,0,0,0});
+        }
+        catch (UnknownHostException ex)
+        {
+            throw new RuntimeException("Unable to create address object for any host.", ex);
+        }
+    }
+
+    /**
+     * Port to bind this DdsServer to. Default is <code>16003</code>
+     * @param port
+     * @return
+     */
+    public NettyDdsServerBuilder withPort(int port)
+    {
+        this.port = port;
+        return this;
+    }
+
+    /**
+     * Address to bind this DdsServer to. Default is <code>0.0.0.0</code>
+     * @param bindAddress
+     * @return
+     */
+    public NettyDdsServerBuilder bindTo(InetAddress bindAddress)
+    {
+        this.bindAddr = bindAddress;
+        return this;
+    }
+
+    public NettyDdsServerBuilder withLrgs(LrgsMain lrgs)
+    {
+        this.lrgs = lrgs;
+        return this;
+    }
+
+    /**
+     * Initialize DdsServer. Returned NettyDdsServer is ready to start when this returns, but has not been started.
+     * @return
+     */
+    public NettyDdsServer build()
+    {
+        EventLoopGroup boss = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+        EventLoopGroup worker = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(boss, worker)
+        .channel(NioServerSocketChannel.class)
+        .childAttr(NettyDdsServer.LRGS_INSTANCE, lrgs)
+        .childHandler(new ChannelInitializer<SocketChannel>()
+        {
+            @Override
+            protected void initChannel(SocketChannel ch) throws Exception
+            {
+                ch.pipeline()
+                    .addLast(
+                        new LddsMessageDecoder(),
+                        new LddsCommandDecoder(),
+                        new LddsMessageEncoder())
+                    .addLast(LddsHelloHandler.HANDLER_NAME, new LddsHelloHandler())
+                    .addLast(new LddsErrorHandler());
+            }
+        })
+        .option(ChannelOption.SO_BACKLOG, 5)
+        .childOption(ChannelOption.SO_KEEPALIVE, true);
+
+        return new NettyDdsServer(boss, worker, b, bindAddr, port, lrgs);
+    }
+}

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
@@ -73,11 +73,7 @@ public class DdsProtocol14Handler extends ChannelInboundHandlerAdapter
     {
         var res = new LddsMessage(LddsMessage.IdDcpBlockExt, cause.getMessage());
         var future = ctx.writeAndFlush(res);
-        if (cause instanceof ArchiveException aex && aex.getHangup() == false)
-        {
-            return;
-        }
-        else
+        if (!(cause instanceof ArchiveException aex) || aex.getHangup())
         {
             future.addListener(ChannelFutureListener.CLOSE);
         }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
@@ -1,8 +1,17 @@
 package org.opendcs.lrgs.dds.dds14;
 
+import java.io.ByteArrayOutputStream;
+import java.util.zip.GZIPOutputStream;
+
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import lrgs.common.LrgsErrorCode;
+import lrgs.ldds.CmdGetMsgBlockExt;
+import lrgs.ldds.CmdGoodbye;
 import lrgs.ldds.LddsCommand;
+import lrgs.ldds.LddsMessage;
+import lrgs.ldds.ServerError;
 
 /**
  * Handles clients using DdsProtocol 14
@@ -14,9 +23,39 @@ public class DdsProtocol14Handler extends ChannelInboundHandlerAdapter
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception
     {
-        if (msg instanceof LddsCommand cmd)
+        if (msg instanceof CmdGetMsgBlockExt)
         {
-            // TODO
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (var gzip = new GZIPOutputStream(baos))
+            {
+                gzip.write("""
+                    <MsgBlock>
+                        <DcpMsg flags="0x0">
+                            <AsciiMsg>Header              Data</AsciiMsg>
+                            <CarrierStart>2026/131 00:00:00.000</CarrierStart>
+                            <CarrierStop>2026/131 00:00:10.000</CarrierStop>
+                            <DomsatTime>2026/131 00:00:00.000</DomsatTime>
+                            <DomsatSeq>0</DomsatSeq>
+                            <Baud>300</Baud>
+                        </DcpMsg>
+                    </MsgBlock>
+                """.getBytes());
+                gzip.finish();
+            }
+            var res = new LddsMessage(LddsMessage.IdDcpBlockExt, null);
+            res.MsgData = baos.toByteArray();
+            res.MsgLength = baos.size();
+            ctx.writeAndFlush(res);
+        }
+        else if (msg instanceof CmdGoodbye)
+        {
+            var res = new LddsMessage(LddsMessage.IdGoodbye, "");
+            ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE);
+        }
+        else if (msg instanceof LddsCommand cmd)
+        {
+            throw new ServerError("Invalid command sent " + cmd.getCommandCode(),
+                                  LrgsErrorCode.DPARSEERROR, 0);
         }
         else
         {

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
@@ -1,7 +1,19 @@
+/*
+* Where Applicable, Copyright 2026 OpenDCS Consortium and/or its contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
 package org.opendcs.lrgs.dds.dds14;
-
-import java.io.ByteArrayOutputStream;
-import java.util.zip.GZIPOutputStream;
 
 import org.opendcs.lrgs.dds.LddsHelloHandler;
 
@@ -18,12 +30,15 @@ import lrgs.ldds.LddsMessage;
 import lrgs.ldds.ServerError;
 
 /**
- * Handles clients using DdsProtocol 14
+ * Handles clients using DdsProtocol 14.
+ *
+ * Currently only implements MsgBlockExt and GoodBye. GoodByte should probably just be it's own
+ * ChannelInboundHandlerAdapter.
  * DdsProtocol14Handler
  */
 public class DdsProtocol14Handler extends ChannelInboundHandlerAdapter
 {
-    
+
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception
     {

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
@@ -3,9 +3,12 @@ package org.opendcs.lrgs.dds.dds14;
 import java.io.ByteArrayOutputStream;
 import java.util.zip.GZIPOutputStream;
 
+import org.opendcs.lrgs.dds.LddsHelloHandler;
+
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.opentelemetry.api.trace.Span;
 import lrgs.common.LrgsErrorCode;
 import lrgs.ldds.CmdGetMsgBlockExt;
 import lrgs.ldds.CmdGoodbye;
@@ -23,43 +26,29 @@ public class DdsProtocol14Handler extends ChannelInboundHandlerAdapter
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception
     {
-        if (msg instanceof CmdGetMsgBlockExt)
+        var user = ctx.channel().attr(LddsHelloHandler.DDS_USER).get();
+        var session = ctx.channel().attr(LddsHelloHandler.DDS_SESSION).get();
+        try (var span = Span.current().setAttribute("ddsUser", user.getName()).makeCurrent())
         {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            try (var gzip = new GZIPOutputStream(baos))
+            if (msg instanceof CmdGetMsgBlockExt cmd)
             {
-                gzip.write("""
-                    <MsgBlock>
-                        <DcpMsg flags="0x0">
-                            <AsciiMsg>Header              Data</AsciiMsg>
-                            <CarrierStart>2026/131 00:00:00.000</CarrierStart>
-                            <CarrierStop>2026/131 00:00:10.000</CarrierStop>
-                            <DomsatTime>2026/131 00:00:00.000</DomsatTime>
-                            <DomsatSeq>0</DomsatSeq>
-                            <Baud>300</Baud>
-                        </DcpMsg>
-                    </MsgBlock>
-                """.getBytes());
-                gzip.finish();
+                var res = GetMsgBlockEx.process(cmd, session.msgRetriever(), user.getDdsVersion());
+                ctx.writeAndFlush(res);
             }
-            var res = new LddsMessage(LddsMessage.IdDcpBlockExt, null);
-            res.MsgData = baos.toByteArray();
-            res.MsgLength = baos.size();
-            ctx.writeAndFlush(res);
-        }
-        else if (msg instanceof CmdGoodbye)
-        {
-            var res = new LddsMessage(LddsMessage.IdGoodbye, "");
-            ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE);
-        }
-        else if (msg instanceof LddsCommand cmd)
-        {
-            throw new ServerError("Invalid command sent " + cmd.getCommandCode(),
-                                  LrgsErrorCode.DPARSEERROR, 0);
-        }
-        else
-        {
-            super.channelRead(ctx, msg);
+            else if (msg instanceof CmdGoodbye)
+            {
+                var res = new LddsMessage(LddsMessage.IdGoodbye, "");
+                ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE);
+            }
+            else if (msg instanceof LddsCommand cmd)
+            {
+                throw new ServerError("Invalid command sent " + cmd.getCommandCode(),
+                                    LrgsErrorCode.DPARSEERROR, 0);
+            }
+            else
+            {
+                super.channelRead(ctx, msg);
+            }
         }
     }
 }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
@@ -1,0 +1,26 @@
+package org.opendcs.lrgs.dds.dds14;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import lrgs.ldds.LddsCommand;
+
+/**
+ * Handles clients using DdsProtocol 14
+ * DdsProtocol14Handler
+ */
+public class DdsProtocol14Handler extends ChannelInboundHandlerAdapter
+{
+    
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception
+    {
+        if (msg instanceof LddsCommand cmd)
+        {
+            // TODO
+        }
+        else
+        {
+            super.channelRead(ctx, msg);
+        }
+    }
+}

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
@@ -9,6 +9,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.opentelemetry.api.trace.Span;
+import lrgs.common.ArchiveException;
 import lrgs.common.LrgsErrorCode;
 import lrgs.ldds.CmdGetMsgBlockExt;
 import lrgs.ldds.CmdGoodbye;
@@ -49,6 +50,21 @@ public class DdsProtocol14Handler extends ChannelInboundHandlerAdapter
             {
                 super.channelRead(ctx, msg);
             }
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
+    {
+        var res = new LddsMessage(LddsMessage.IdDcpBlockExt, cause.getMessage());
+        var future = ctx.writeAndFlush(res);
+        if (cause instanceof ArchiveException aex && aex.getHangup() == false)
+        {
+            return;
+        }
+        else
+        {
+            future.addListener(ChannelFutureListener.CLOSE);
         }
     }
 }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/DdsProtocol14Handler.java
@@ -33,7 +33,7 @@ public class DdsProtocol14Handler extends ChannelInboundHandlerAdapter
         {
             if (msg instanceof CmdGetMsgBlockExt cmd)
             {
-                var res = GetMsgBlockEx.process(cmd, session.msgRetriever(), user.getDdsVersion());
+                var res = GetMsgBlockEx.process(cmd, session);
                 ctx.writeAndFlush(res);
             }
             else if (msg instanceof CmdGoodbye)

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
@@ -1,9 +1,23 @@
+/*
+* Where Applicable, Copyright ? - 2026 OpenDCS Consortium and/or its contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
 package org.opendcs.lrgs.dds.dds14;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.zip.GZIPOutputStream;
@@ -19,18 +33,26 @@ import lrgs.common.ArchiveUnavailableException;
 import lrgs.common.DcpMsg;
 import lrgs.common.DcpMsgFlag;
 import lrgs.common.DcpMsgIndex;
-import lrgs.common.DcpMsgRetriever;
 import lrgs.common.EndOfArchiveException;
 import lrgs.common.LrgsErrorCode;
 import lrgs.common.NoSuchMessageException;
 import lrgs.common.SearchCriteria;
 import lrgs.common.SearchTimeoutException;
 import lrgs.common.UntilReachedException;
-import lrgs.ddsserver.DdsServer;
 import lrgs.ldds.CmdGetMsgBlockExt;
 import lrgs.ldds.ExtBlockXmlParser;
 import lrgs.ldds.LddsMessage;
 
+/**
+ * At the moment consider this a place holder. Intention is to move the
+ * LddsCommand logic out of the commands themselves. This intentionally dupplicates {@link lrgs.ldds.CmdGetMsgBlockExt}
+ * in order to start isolating the "session" components that would be required.
+ *
+ * After a few more command implementations and rearrangments of the Netty Channel Pipeline we should
+ * have a better sense of what should be where.
+ *
+ * GetMsgBlockEx
+ */
 public final class GetMsgBlockEx
 {
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
@@ -38,8 +60,9 @@ public final class GetMsgBlockEx
     private static final int MAX_SIZE = 20000;
     private static final int MAX_MSGS = 100;
 
-    public static final LddsMessage process(CmdGetMsgBlockExt cmd, DdsSession session) throws Exception
+    public static LddsMessage process(CmdGetMsgBlockExt cmd, DdsSession session) throws Exception
     {
+        log.info("Getting message " + session.toString());
         var msgRetriever = session.msgRetriever();
         var ddsVersion = session.ddsVersion();
         var seqNumMsgBuf = session.sequenceMessageBuf();
@@ -88,7 +111,7 @@ public final class GetMsgBlockEx
                 if (seqNumMsgBufIdx >= sz)
                 {
                     seqNumMsgBuf.clear();
-                    
+
                     // Modify searchcrit so it won't search seq nums again.
                     sc.seqStart = -1;
                     sc.seqEnd = -1;
@@ -192,7 +215,7 @@ public final class GetMsgBlockEx
             }
             return new LddsMessage(cmd.getCommandCode(), rs);
         }
-
+        log.info("returning data.");
         // end of while loop...
         LddsMessage lm = new LddsMessage(LddsMessage.IdDcpBlockExt, "");
         lm.MsgData = baos.toByteArray();

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
@@ -3,14 +3,17 @@ package org.opendcs.lrgs.dds.dds14;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.zip.GZIPOutputStream;
 
+import org.opendcs.lrgs.dds.DdsSession;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
 
 import ilex.xml.XmlOutputStream;
+import lrgs.archive.XmlMsgArchive;
 import lrgs.common.ArchiveException;
 import lrgs.common.ArchiveUnavailableException;
 import lrgs.common.DcpMsg;
@@ -23,6 +26,7 @@ import lrgs.common.NoSuchMessageException;
 import lrgs.common.SearchCriteria;
 import lrgs.common.SearchTimeoutException;
 import lrgs.common.UntilReachedException;
+import lrgs.ddsserver.DdsServer;
 import lrgs.ldds.CmdGetMsgBlockExt;
 import lrgs.ldds.ExtBlockXmlParser;
 import lrgs.ldds.LddsMessage;
@@ -34,8 +38,12 @@ public final class GetMsgBlockEx
     private static final int MAX_SIZE = 20000;
     private static final int MAX_MSGS = 100;
 
-    public static final LddsMessage process(CmdGetMsgBlockExt cmd, DcpMsgRetriever msgRetriever, int ddsVersion) throws Exception
+    public static final LddsMessage process(CmdGetMsgBlockExt cmd, DdsSession session) throws Exception
     {
+        var msgRetriever = session.msgRetriever();
+        var ddsVersion = session.ddsVersion();
+        var seqNumMsgBuf = session.sequenceMessageBuf();
+        var seqNumMsgBufIdx = session.seqNumMsgBufIdx();
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy/DDD HH:mm:ss.SSS");
 		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
 	    ExtBlockXmlParser myXmlParser = new ExtBlockXmlParser(DcpMsgFlag.SRC_DDS);;
@@ -44,31 +52,64 @@ public final class GetMsgBlockEx
         // Use XML_OS ( GZIP_OS ( BA_OS ) ) to build response body.
 		ByteArrayOutputStream baos = new ByteArrayOutputStream(MAX_SIZE+1000);
 
-
-		// Special Case - client is doing a DOMSAT Sequence Range Retrieval.
-		SearchCriteria sc = msgRetriever.getCrit();
-		Date since, until;
-		int numMessages = 0;
-		boolean didSeqSearch = false;
-		boolean bufDone = false;
-		String conName = "con(-1)";
-        if (sc.getLrgsSince() == null)
-        {
-            sc.setLrgsSince("now - 2 hours");
-        }
-		// Get message, every 5 seconds, check for stop message.
-		DcpMsgIndex idx = new DcpMsgIndex();
-		long start = System.currentTimeMillis();
-		long stopSearchMsec = start + 45000L;
-		int maxMsgs = MAX_MSGS;
-		if (sc.single)
-        {
-			maxMsgs = 1;
-        }
         try (GZIPOutputStream gzos = new GZIPOutputStream(baos))
         {
             XmlOutputStream xos = new XmlOutputStream(gzos, ExtBlockXmlParser.MsgBlockElem);
             xos.startElement(ExtBlockXmlParser.MsgBlockElem);
+
+            // Special Case - client is doing a DOMSAT Sequence Range Retrieval.
+            SearchCriteria sc = msgRetriever.getCrit();
+            Date since, until;
+            int numMessages = 0;
+            boolean didSeqSearch = false;
+            boolean bufDone = false;
+            String conName = "con(-1)";
+            if (sc != null && sc.seqStart >= 0 && sc.seqEnd >= 0
+            && (since = sc.evaluateLrgsSinceTime()) != null
+            && (until = sc.evaluateLrgsUntilTime()) != null)
+            {
+                didSeqSearch = true;
+
+                if (seqNumMsgBuf.isEmpty())
+                {
+                    var marc = (XmlMsgArchive)session.archive();
+                    int n = marc.getMsgsBySeqNum(since.getTime(),
+                        until.getTime(), sc.seqStart,
+                        sc.seqEnd, seqNumMsgBuf);
+                    seqNumMsgBufIdx = 0;
+                }
+                int sz = seqNumMsgBuf.size();
+                while(seqNumMsgBufIdx < sz && numMessages < MAX_MSGS)
+                {
+                    if (myXmlParser.addMsg(xos,
+                        seqNumMsgBuf.get(seqNumMsgBufIdx++), conName))
+                        numMessages++;
+                }
+                if (seqNumMsgBufIdx >= sz)
+                {
+                    seqNumMsgBuf.clear();
+                    
+                    // Modify searchcrit so it won't search seq nums again.
+                    sc.seqStart = -1;
+                    sc.seqEnd = -1;
+                }
+                if (numMessages >= MAX_MSGS)
+                    bufDone = true;
+            }
+            if (numMessages == 0)
+            {
+                didSeqSearch = false;
+            }
+            // Get message, every 5 seconds, check for stop message.
+            DcpMsgIndex idx = new DcpMsgIndex();
+            long start = System.currentTimeMillis();
+            long stopSearchMsec = start + 45000L;
+            int maxMsgs = MAX_MSGS;
+            if (sc.single)
+            {
+                maxMsgs = 1;
+            }
+
             while(!bufDone)
             {
                 try

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
@@ -17,6 +17,7 @@ package org.opendcs.lrgs.dds.dds14;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.rmi.ServerError;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
@@ -60,16 +61,22 @@ public final class GetMsgBlockEx
     private static final int MAX_SIZE = 20000;
     private static final int MAX_MSGS = 100;
 
-    public static LddsMessage process(CmdGetMsgBlockExt cmd, DdsSession session) throws Exception
+    private GetMsgBlockEx()
     {
-        log.info("Getting message " + session.toString());
+        /* utility class */
+    }
+
+    @SuppressWarnings({"java:S3776", "java:S138"}) // to be dealt with in future cleanup.
+    public static LddsMessage process(CmdGetMsgBlockExt cmd, DdsSession session) throws IOException
+    {
+        log.info("Getting message {}", session);
         var msgRetriever = session.msgRetriever();
         var ddsVersion = session.ddsVersion();
         var seqNumMsgBuf = session.sequenceMessageBuf();
         var seqNumMsgBufIdx = session.seqNumMsgBufIdx();
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy/DDD HH:mm:ss.SSS");
 		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-	    ExtBlockXmlParser myXmlParser = new ExtBlockXmlParser(DcpMsgFlag.SRC_DDS);;
+	    ExtBlockXmlParser myXmlParser = new ExtBlockXmlParser(DcpMsgFlag.SRC_DDS);
         myXmlParser.setDdsVersion(ddsVersion);
 
         // Use XML_OS ( GZIP_OS ( BA_OS ) ) to build response body.
@@ -82,7 +89,8 @@ public final class GetMsgBlockEx
 
             // Special Case - client is doing a DOMSAT Sequence Range Retrieval.
             SearchCriteria sc = msgRetriever.getCrit();
-            Date since, until;
+            Date since;
+            Date until;
             int numMessages = 0;
             boolean didSeqSearch = false;
             boolean bufDone = false;
@@ -96,7 +104,7 @@ public final class GetMsgBlockEx
                 if (seqNumMsgBuf.isEmpty())
                 {
                     var marc = (XmlMsgArchive)session.archive();
-                    int n = marc.getMsgsBySeqNum(since.getTime(),
+                    marc.getMsgsBySeqNum(since.getTime(),
                         until.getTime(), sc.seqStart,
                         sc.seqEnd, seqNumMsgBuf);
                     seqNumMsgBufIdx = 0;
@@ -105,7 +113,7 @@ public final class GetMsgBlockEx
                 while(seqNumMsgBufIdx < sz && numMessages < MAX_MSGS)
                 {
                     if (myXmlParser.addMsg(xos,
-                        seqNumMsgBuf.get(seqNumMsgBufIdx++), conName))
+                        seqNumMsgBuf.get(seqNumMsgBufIdx++), conName)) // NOSONAR
                         numMessages++;
                 }
                 if (seqNumMsgBufIdx >= sz)
@@ -133,9 +141,9 @@ public final class GetMsgBlockEx
                 maxMsgs = 1;
             }
 
-            while(!bufDone)
+            while(!bufDone) // NOSONAR
             {
-                try
+                try // NOSONAR
                 {
                     msgRetriever.getNextPassingIndex(idx, stopSearchMsec);
 
@@ -164,7 +172,6 @@ public final class GetMsgBlockEx
                 catch(NoSuchMessageException nsme)
                 {
                     log.atWarn().setCause(nsme).log("Bad message skipped. idx.Offset = {}", idx.getOffset());
-                    continue;
                 }
                 catch(UntilReachedException urex)
                 {

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
@@ -11,6 +11,7 @@ import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
 
 import ilex.xml.XmlOutputStream;
+import lrgs.common.ArchiveException;
 import lrgs.common.ArchiveUnavailableException;
 import lrgs.common.DcpMsg;
 import lrgs.common.DcpMsgFlag;
@@ -26,12 +27,12 @@ import lrgs.ldds.CmdGetMsgBlockExt;
 import lrgs.ldds.ExtBlockXmlParser;
 import lrgs.ldds.LddsMessage;
 
-public final class GetMsgBlockEx 
+public final class GetMsgBlockEx
 {
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
 
     private static final int MAX_SIZE = 20000;
-    private static final int MAX_MSGS = 100;    
+    private static final int MAX_MSGS = 100;
 
     public static final LddsMessage process(CmdGetMsgBlockExt cmd, DcpMsgRetriever msgRetriever, int ddsVersion) throws Exception
     {
@@ -42,9 +43,7 @@ public final class GetMsgBlockEx
 
         // Use XML_OS ( GZIP_OS ( BA_OS ) ) to build response body.
 		ByteArrayOutputStream baos = new ByteArrayOutputStream(MAX_SIZE+1000);
-		GZIPOutputStream gzos = new GZIPOutputStream(baos);
-		XmlOutputStream xos = new XmlOutputStream(gzos, ExtBlockXmlParser.MsgBlockElem);
-		xos.startElement(ExtBlockXmlParser.MsgBlockElem);
+
 
 		// Special Case - client is doing a DOMSAT Sequence Range Retrieval.
 		SearchCriteria sc = msgRetriever.getCrit();
@@ -53,7 +52,10 @@ public final class GetMsgBlockEx
 		boolean didSeqSearch = false;
 		boolean bufDone = false;
 		String conName = "con(-1)";
-
+        if (sc.getLrgsSince() == null)
+        {
+            sc.setLrgsSince("now - 2 hours");
+        }
 		// Get message, every 5 seconds, check for stop message.
 		DcpMsgIndex idx = new DcpMsgIndex();
 		long start = System.currentTimeMillis();
@@ -63,76 +65,93 @@ public final class GetMsgBlockEx
         {
 			maxMsgs = 1;
         }
+        try (GZIPOutputStream gzos = new GZIPOutputStream(baos))
+        {
+            XmlOutputStream xos = new XmlOutputStream(gzos, ExtBlockXmlParser.MsgBlockElem);
+            xos.startElement(ExtBlockXmlParser.MsgBlockElem);
+            while(!bufDone)
+            {
+                try
+                {
+                    msgRetriever.getNextPassingIndex(idx, stopSearchMsec);
 
-		while(!bufDone)
-		{
-			try
-			{
-				msgRetriever.getNextPassingIndex(idx, stopSearchMsec);
+                    // If we did a sequence search, then only accept messages
+                    // for the regular search that DO NOT have DOMSAT sequence nums.
+                    if (didSeqSearch
+                    && (idx.getFlagbits() & DcpMsgFlag.MSG_NO_SEQNUM) == 0)
+                        continue;
 
-				// If we did a sequence search, then only accept messages
-				// for the regular search that DO NOT have DOMSAT sequence nums.
-				if (didSeqSearch
-				 && (idx.getFlagbits() & DcpMsgFlag.MSG_NO_SEQNUM) == 0)
-					continue;
+                    DcpMsg msg = msgRetriever.readMsg(idx);
+                    if (msg.getData() == null)
+                        continue;
 
-				DcpMsg msg = msgRetriever.readMsg(idx);
-				if (msg.getData() == null)
-					continue;
+                    if (myXmlParser.addMsg(xos, msg, conName))
+                        numMessages++;
 
-				if (myXmlParser.addMsg(xos, msg, conName))
-					numMessages++;
+                    if (baos.size() >= MAX_SIZE         // byte size limit reached
+                    || numMessages >= maxMsgs)         // # msg limit reached
+                        bufDone = true;
+                }
+                catch(NoSuchMessageException nsme)
+                {
+                    log.atWarn().setCause(nsme).log("Bad message skipped. idx.Offset = {}", idx.getOffset());
+                    continue;
+                }
+                catch(UntilReachedException urex)
+                {
+                    if (numMessages == 0)
+                        throw urex;
+                    else // already have some data, drop down & return it.
+                        bufDone = true;
+                }
+                catch(EndOfArchiveException eoaex)
+                {
+                    if (numMessages == 0)
+                        // This means caught-up to end of storage.
+                        throw eoaex;
+                    else
+                        bufDone = true; // Just return what we have so far.
+                }
+                catch(SearchTimeoutException stex)
+                {
+                    log.atDebug()
+                        .setCause(stex)
+                        .log("DDS Connection aborting because of 45 second timeout");
 
-				if (baos.size() >= MAX_SIZE         // byte size limit reached
-				 || numMessages >= maxMsgs)         // # msg limit reached
-					bufDone = true;
-			}
-			catch(NoSuchMessageException nsme)
-			{
-				log.atWarn().setCause(nsme).log("Bad message skipped. idx.Offset = {}", idx.getOffset());
-				continue;
-			}
-			catch(UntilReachedException urex)
-			{
-				if (numMessages == 0)
-					throw urex;
-				else // already have some data, drop down & return it.
-					bufDone = true;
-			}
-			catch(EndOfArchiveException eoaex)
-			{
-				bufDone = true; // Just return what we have so far.
-			}
-			catch(SearchTimeoutException stex)
-			{				
-                log.atDebug()
-                    .setCause(stex)
-					   .log("DDS Connection aborting because of 45 second timeout");
+                    if (numMessages == 0)
+                        throw stex;     // Means 'try again'
+                    else
+                        bufDone = true; // return what we have so far.
+                }
+                catch(IOException ioex)
+                {
+                    throw new ArchiveUnavailableException(
+                        "Internal server error constructin MsgBlockExt response: "
+                        + ioex, LrgsErrorCode.DDDSINTERNAL, ioex);
+                }
+                // Allow ArchiveUnavailable to propegate.
+            }
 
-				if (numMessages == 0)
-					throw stex;     // Means 'try again'
-				else
-					bufDone = true; // return what we have so far.
-			}
-			catch(IOException ioex)
-			{
-				throw new ArchiveUnavailableException(
-					"Internal server error constructin MsgBlockExt response: "
-					+ ioex, LrgsErrorCode.DDDSINTERNAL, ioex);
-			}
-			// Allow ArchiveUnavailable to propegate.
-		}
+            xos.endElement(ExtBlockXmlParser.MsgBlockElem);
+            gzos.finish();
+        }
+        catch (ArchiveException ex)
+        {
+            String rs = "?" + ex.getErrorCode() + ",0," + ex.getMessage();
+            if (!(ex instanceof UntilReachedException))
+            {
+                log.atTrace()
+                   .setCause(ex)
+                   .log("ArchiveException on Response='{}'", rs);
+            }
+            return new LddsMessage(cmd.getCommandCode(), rs);
+        }
 
-		xos.endElement(ExtBlockXmlParser.MsgBlockElem);
-		gzos.finish();
-		try { gzos.close(); }
-		catch(Exception ex) {}
+        // end of while loop...
+        LddsMessage lm = new LddsMessage(LddsMessage.IdDcpBlockExt, "");
+        lm.MsgData = baos.toByteArray();
+        lm.MsgLength = lm.MsgData.length;
 
-		// end of while loop...
-		LddsMessage lm = new LddsMessage(LddsMessage.IdDcpBlockExt, "");
-		lm.MsgData = baos.toByteArray();
-		lm.MsgLength = lm.MsgData.length;
-		
         return lm;
     }
 }

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
@@ -1,0 +1,138 @@
+package org.opendcs.lrgs.dds.dds14;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.zip.GZIPOutputStream;
+
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
+import org.slf4j.Logger;
+
+import ilex.xml.XmlOutputStream;
+import lrgs.common.ArchiveUnavailableException;
+import lrgs.common.DcpMsg;
+import lrgs.common.DcpMsgFlag;
+import lrgs.common.DcpMsgIndex;
+import lrgs.common.DcpMsgRetriever;
+import lrgs.common.EndOfArchiveException;
+import lrgs.common.LrgsErrorCode;
+import lrgs.common.NoSuchMessageException;
+import lrgs.common.SearchCriteria;
+import lrgs.common.SearchTimeoutException;
+import lrgs.common.UntilReachedException;
+import lrgs.ldds.CmdGetMsgBlockExt;
+import lrgs.ldds.ExtBlockXmlParser;
+import lrgs.ldds.LddsMessage;
+
+public final class GetMsgBlockEx 
+{
+    private static final Logger log = OpenDcsLoggerFactory.getLogger();
+
+    private static final int MAX_SIZE = 20000;
+    private static final int MAX_MSGS = 100;    
+
+    public static final LddsMessage process(CmdGetMsgBlockExt cmd, DcpMsgRetriever msgRetriever, int ddsVersion) throws Exception
+    {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy/DDD HH:mm:ss.SSS");
+		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+	    ExtBlockXmlParser myXmlParser = new ExtBlockXmlParser(DcpMsgFlag.SRC_DDS);;
+        myXmlParser.setDdsVersion(ddsVersion);
+
+        // Use XML_OS ( GZIP_OS ( BA_OS ) ) to build response body.
+		ByteArrayOutputStream baos = new ByteArrayOutputStream(MAX_SIZE+1000);
+		GZIPOutputStream gzos = new GZIPOutputStream(baos);
+		XmlOutputStream xos = new XmlOutputStream(gzos, ExtBlockXmlParser.MsgBlockElem);
+		xos.startElement(ExtBlockXmlParser.MsgBlockElem);
+
+		// Special Case - client is doing a DOMSAT Sequence Range Retrieval.
+		SearchCriteria sc = msgRetriever.getCrit();
+		Date since, until;
+		int numMessages = 0;
+		boolean didSeqSearch = false;
+		boolean bufDone = false;
+		String conName = "con(-1)";
+
+		// Get message, every 5 seconds, check for stop message.
+		DcpMsgIndex idx = new DcpMsgIndex();
+		long start = System.currentTimeMillis();
+		long stopSearchMsec = start + 45000L;
+		int maxMsgs = MAX_MSGS;
+		if (sc.single)
+        {
+			maxMsgs = 1;
+        }
+
+		while(!bufDone)
+		{
+			try
+			{
+				msgRetriever.getNextPassingIndex(idx, stopSearchMsec);
+
+				// If we did a sequence search, then only accept messages
+				// for the regular search that DO NOT have DOMSAT sequence nums.
+				if (didSeqSearch
+				 && (idx.getFlagbits() & DcpMsgFlag.MSG_NO_SEQNUM) == 0)
+					continue;
+
+				DcpMsg msg = msgRetriever.readMsg(idx);
+				if (msg.getData() == null)
+					continue;
+
+				if (myXmlParser.addMsg(xos, msg, conName))
+					numMessages++;
+
+				if (baos.size() >= MAX_SIZE         // byte size limit reached
+				 || numMessages >= maxMsgs)         // # msg limit reached
+					bufDone = true;
+			}
+			catch(NoSuchMessageException nsme)
+			{
+				log.atWarn().setCause(nsme).log("Bad message skipped. idx.Offset = {}", idx.getOffset());
+				continue;
+			}
+			catch(UntilReachedException urex)
+			{
+				if (numMessages == 0)
+					throw urex;
+				else // already have some data, drop down & return it.
+					bufDone = true;
+			}
+			catch(EndOfArchiveException eoaex)
+			{
+				bufDone = true; // Just return what we have so far.
+			}
+			catch(SearchTimeoutException stex)
+			{				
+                log.atDebug()
+                    .setCause(stex)
+					   .log("DDS Connection aborting because of 45 second timeout");
+
+				if (numMessages == 0)
+					throw stex;     // Means 'try again'
+				else
+					bufDone = true; // return what we have so far.
+			}
+			catch(IOException ioex)
+			{
+				throw new ArchiveUnavailableException(
+					"Internal server error constructin MsgBlockExt response: "
+					+ ioex, LrgsErrorCode.DDDSINTERNAL, ioex);
+			}
+			// Allow ArchiveUnavailable to propegate.
+		}
+
+		xos.endElement(ExtBlockXmlParser.MsgBlockElem);
+		gzos.finish();
+		try { gzos.close(); }
+		catch(Exception ex) {}
+
+		// end of while loop...
+		LddsMessage lm = new LddsMessage(LddsMessage.IdDcpBlockExt, "");
+		lm.MsgData = baos.toByteArray();
+		lm.MsgLength = lm.MsgData.length;
+		
+        return lm;
+    }
+}

--- a/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
+++ b/java/opendcs/src/main/java/org/opendcs/lrgs/dds/dds14/GetMsgBlockEx.java
@@ -124,14 +124,19 @@ public final class GetMsgBlockEx
 
                     DcpMsg msg = msgRetriever.readMsg(idx);
                     if (msg.getData() == null)
+                    {
                         continue;
+                    }
 
                     if (myXmlParser.addMsg(xos, msg, conName))
+                    {
                         numMessages++;
-
-                    if (baos.size() >= MAX_SIZE         // byte size limit reached
-                    || numMessages >= maxMsgs)         // # msg limit reached
+                    }
+                    // byte size limit reached   # msg limit reached
+                    if (baos.size() >= MAX_SIZE || numMessages >= maxMsgs)
+                    {
                         bufDone = true;
+                    }
                 }
                 catch(NoSuchMessageException nsme)
                 {


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Partial for #2110. 

## Solution

- Reorg setup code for Netty based DdsServer
- Duplicate and rearrange code from CmdGetMsgBlockExt to allow future reuse.
- Create DdsSession and DdsUserPrincipal object to start isolating such data from implementation details
 - This is containing data that is currently member variables of LddsThread, intention is to have LddsThread *also* use the DdsSession object in the future (after sufficient testing)

Intentionally only implements one Get Message command to demonstrate changes and help show/reveal how we might organize.

Challenges in current design:
The specific command error handling is not as clean. I think the proper solution is still to use this style of mechanism but to have each command have it's own ChannelInboundHandler so that there can be a "happy path" and "specific exception path" as appropriate to each given system.

GetMsgBlockEx should likely implement a new "LddsCommand" interface that otherwise behaves in a similar way. Though I think the return should be some form or `Either` or multi return as several elements depend on things like "x results", though only the GetDcpMessages return anything and it appears to be for status updates; so should more likely be moved to standardized metrics collection.

NOTE: intention is to address the challenges above in future PRs, I'm going very slow on this to make sure various behavior and edge cases can be covered while better understanding how the current LRGS mechanisms work so that implementation and behavior can be improved over time.

## how you tested the change

- Additional integration tests.
- Server starts
- Client connects
- Attempts to retrieve data with default "get all" SearchCriteria.

## Where the following done:

- [x] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [x] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
