### PR TITLE
Initial work, first table altered.

### DIFF
--- a/java/opendcs/src/main/java/opendcs/opentsdb/OpenTsdb.java
+++ b/java/opendcs/src/main/java/opendcs/opentsdb/OpenTsdb.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 
+import org.opendcs.database.api.DatabaseEngine;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.slf4j.Logger;
 
@@ -160,7 +161,13 @@ public class OpenTsdb extends TimeSeriesDb
 	@Override
 	public void postConInit(Connection conn) throws SQLException
 	{
-		/* currently we don't need to do anything */
+		if (conn.getMetaData().getDatabaseProductName().contains(DatabaseEngine.POSTGRES.getProductString()))
+		{
+			try (var stmt = conn.prepareStatement("set opendcs.org_id=0"))
+			{
+				stmt.execute();
+			}
+		}
 	}
 
 	@Override

--- a/java/opendcs/src/main/java/org/opendcs/database/MigrationManager.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/MigrationManager.java
@@ -56,6 +56,7 @@ public final class MigrationManager
         flywayConfig = Flyway.configure()
                              .loggers("org.opendcs.database.logging.MigrationLogCreator")
                              .dataSource(ds)
+                             //.mixed(true)
                              .schemas(migrationProvider.schemas().toArray(new String[0]))
                              .createSchemas(migrationProvider.createSchemas())
                              .locations("db/"+implementation)

--- a/java/opendcs/src/main/java/org/opendcs/database/SimpleDataSource.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/SimpleDataSource.java
@@ -18,6 +18,7 @@ import javax.management.ObjectName;
 import javax.management.openmbean.OpenDataException;
 import javax.sql.DataSource;
 
+import org.opendcs.database.api.DatabaseEngine;
 import org.opendcs.jmx.ConnectionPoolMXBean;
 import org.opendcs.jmx.JmxUtils;
 import org.opendcs.jmx.WrappedConnectionMBean;
@@ -141,6 +142,7 @@ public class SimpleDataSource implements DataSource, ConnectionPoolMXBean
             },
             SqlSettings.TRACE_CONNECTIONS);
         requests.getAndIncrement();
+        init(wc);
         log.trace("connections requests/freed {}/{}", requests.get(),freed.get());
         connections.add(wc);
         // existing usages expect autocommit, Jdbi DatabaseWrapper will override when required.
@@ -163,10 +165,22 @@ public class SimpleDataSource implements DataSource, ConnectionPoolMXBean
             SqlSettings.TRACE_CONNECTIONS
         );
         requests.getAndIncrement();
+        init(wc);
         log.trace("connections requeste/freed {}/{}", requests.get(),freed.get());
         connections.add(wc);
         wc.setAutoCommit(true);
         return wc;
+    }
+
+    private void init(Connection conn) throws SQLException
+    {
+        if (conn.getMetaData().getDatabaseProductName().contains(DatabaseEngine.POSTGRES.getProductString()))
+		{
+			try (var stmt = conn.prepareStatement("set opendcs.org_id=0"))
+			{
+				stmt.execute();
+			}
+		}
     }
 
     @Override

--- a/schema/opendcs-schemas/src/main/resources/db/OpenDCS-Postgres/functions/R__organizations.sql
+++ b/schema/opendcs-schemas/src/main/resources/db/OpenDCS-Postgres/functions/R__organizations.sql
@@ -1,0 +1,5 @@
+create or replace function current_organization() returns bigint as $$
+begin
+    return nullif(current_setting('opendcs.org_id', true), '')::bigint;
+end;
+$$ language plpgsql stable;

--- a/schema/opendcs-schemas/src/main/resources/db/OpenDCS-Postgres/schema/V7.6__organizations.sql
+++ b/schema/opendcs-schemas/src/main/resources/db/OpenDCS-Postgres/schema/V7.6__organizations.sql
@@ -13,7 +13,7 @@ create table organization (
 
 
 insert into org_type(id, name, description) OVERRIDING SYSTEM VALUE
-    values(0, '<default>', 'Basic organization with not distinct attributes');
+    values(0, '<default>', 'Basic organization with no distinct attributes');
 insert into organization(id, name, org_type, parent_id) OVERRIDING SYSTEM VALUE
     values (0, 'Default', 0, null);
 

--- a/schema/opendcs-schemas/src/main/resources/db/OpenDCS-Postgres/schema/V7.6__organizations.sql
+++ b/schema/opendcs-schemas/src/main/resources/db/OpenDCS-Postgres/schema/V7.6__organizations.sql
@@ -36,11 +36,11 @@ begin
                 from information_schema.tables
                where table_schema = 'public'   -- These tables are "global"
                  and lower(table_name) not in ('org_type', 'opendcs_user', 'opendcs_user_password',
-                                               'opendcs_role', 'user_identity_provider', 'organization',
-                                               'flyway_schema_history', 'tsdb_database_version',
+                                               'opendcs_role', 'identity_provider', 'user_identity_provider',
+                                               'organization', 'flyway_schema_history', 'tsdb_database_version',
                                                'decodesdatabaseversion')) loop
-        -- execute format('alter table %I add column org_id bigint not null default current_organization()', r.table_name);
-        -- execute format('alter table %I enable row level security', r.table_name);
+        execute format('alter table %I add column org_id bigint not null default current_organization()', r.table_name);
+        execute format('alter table %I enable row level security', r.table_name);
         execute format('drop policy if exists org_read_isolation on %I', r.table_name);
         execute format('drop policy if exists org_insert_isolation on %I', r.table_name);
         execute format('drop policy if exists org_update_isolation on %I', r.table_name);
@@ -53,18 +53,18 @@ begin
                        r.table_name);
         execute format('create policy org_update_isolation on %I for insert with check (org_id = current_organization())',
                        r.table_name);
-        raise notice '%', r.table_name;
+        --raise notice '%', r.table_name;
     end loop; 
 end $$;
 
-raise notice 'The following will wait for indexes to be constructed. It is possible there could be some long waits.';
+--raise notice 'The following will wait for indexes to be constructed. It is possible there could be some long waits.';
 -- it would be nice to just loop through the data dictionary but given the various
 -- unique contraints that have been built over time it would be difficult to get right
 -- additonal instead of plain unique constraints, primary key constraints were (reasonably) used.
 -- While correct, it does make the sequence of events a bit more difficult.
 
-create unique index concurrently configsensor_pkey_idx on configsensor(org_id, configid, sensornumber);
-begin;
+create unique index /*concurrently*/ configsensor_pkey_idx on configsensor(org_id, configid, sensornumber);
+--begin;
 
 alter table configsensorproperty drop CONSTRAINT configsensorproperty_configid_sensornumber_fkey;
 alter table configsensordatatype drop constraint configsensordatatype_configid_sensornumber_fkey;
@@ -86,4 +86,4 @@ alter table configsensordatatype
     on delete restrict
 ;
 
-end;
+--end;

--- a/schema/opendcs-schemas/src/main/resources/db/OpenDCS-Postgres/schema/V7.6__organizations.sql
+++ b/schema/opendcs-schemas/src/main/resources/db/OpenDCS-Postgres/schema/V7.6__organizations.sql
@@ -1,0 +1,89 @@
+create table org_type (
+    id bigint generated always as identity (start with 1) primary key,
+    name varchar(64) not null unique,
+    description text not null
+);
+
+create table organization (
+    id bigint generated always as identity (start with 1) primary key,
+    name varchar(128) not null unique,
+    org_type bigint references org_type(id),
+    parent_id bigint references organization(id)
+);
+
+
+insert into org_type(id, name, description) OVERRIDING SYSTEM VALUE
+    values(0, '<default>', 'Basic organization with not distinct attributes');
+insert into organization(id, name, org_type, parent_id) OVERRIDING SYSTEM VALUE
+    values (0, 'Default', 0, null);
+
+-- Create the initial definition of the method. Full Implementation is in the 
+-- repeatable functions section.
+create function current_organization() returns bigint as $$
+begin
+    return 0;
+end;
+$$ language plpgsql stable;
+
+-- we don't need to set the org for below as the default implementation above always returns the default org.
+
+-- Loop through everything and add the colunmn and policies
+do $$
+declare
+ r record;
+begin
+    for r in (select *
+                from information_schema.tables
+               where table_schema = 'public'   -- These tables are "global"
+                 and lower(table_name) not in ('org_type', 'opendcs_user', 'opendcs_user_password',
+                                               'opendcs_role', 'user_identity_provider', 'organization',
+                                               'flyway_schema_history', 'tsdb_database_version',
+                                               'decodesdatabaseversion')) loop
+        -- execute format('alter table %I add column org_id bigint not null default current_organization()', r.table_name);
+        -- execute format('alter table %I enable row level security', r.table_name);
+        execute format('drop policy if exists org_read_isolation on %I', r.table_name);
+        execute format('drop policy if exists org_insert_isolation on %I', r.table_name);
+        execute format('drop policy if exists org_update_isolation on %I', r.table_name);
+        execute format('drop policy if exists org_delete_isolation on %I', r.table_name);
+        execute format('create policy org_read_isolation on %I for select using (org_id = 0 or org_id = current_organization())',
+                       r.table_name);
+        execute format('create policy org_delete_isolation on %I for delete using (org_id = current_organization())',
+                       r.table_name);
+        execute format('create policy org_insert_isolation on %I for insert with check (org_id = current_organization())',
+                       r.table_name);
+        execute format('create policy org_update_isolation on %I for insert with check (org_id = current_organization())',
+                       r.table_name);
+        raise notice '%', r.table_name;
+    end loop; 
+end $$;
+
+raise notice 'The following will wait for indexes to be constructed. It is possible there could be some long waits.';
+-- it would be nice to just loop through the data dictionary but given the various
+-- unique contraints that have been built over time it would be difficult to get right
+-- additonal instead of plain unique constraints, primary key constraints were (reasonably) used.
+-- While correct, it does make the sequence of events a bit more difficult.
+
+create unique index concurrently configsensor_pkey_idx on configsensor(org_id, configid, sensornumber);
+begin;
+
+alter table configsensorproperty drop CONSTRAINT configsensorproperty_configid_sensornumber_fkey;
+alter table configsensordatatype drop constraint configsensordatatype_configid_sensornumber_fkey;
+
+alter table configsensor drop constraint configsensor_pkey,
+    add constraint configsensor_pkey primary key using index configsensor_pkey_idx;
+
+alter table configsensorproperty
+	add foreign key (org_id, configid, sensornumber)
+	references configsensor (org_id, configid, sensornumber)
+    on update restrict
+    on delete restrict
+;
+
+alter table configsensordatatype
+	add foreign key (org_id, configid, sensornumber)
+	references configsensor (org_id, configid, sensornumber)
+    on update restrict
+    on delete restrict
+;
+
+end;


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #742. 

## Solution

Add org tables and appropriate columns.

After thinking about it for way to long, I've decide to use the postgres row level security and oracle vpd (cwms already does this) mechanisms.

Will be attempting to setup a form of "hierarchy", e.g. the default "org" loads the initial algorithms and the sub orgs can either just use it, or override.


NOTE: this is still *very* draft, opening for comment though.

## how you tested the change

At this time manually, existing integration tests will show if there are any issue with accessing the default org or setting up the "session"

Will then add tests of additional organizations.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
