### PR TITLE
Task/1882 complockdao

### DIFF
--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
@@ -58,9 +58,9 @@ class CompLockDaoTestIT extends AppTestBase
 
             var lockOneUpdate = lockDao.obtainLock(tx, appOne, 0, "bob");
             assertTrue(lockOneUpdate.isSuccess());
-            var firstLock = lockOne.getSuccess();
+            var firstLock = lockOne.success();
 
-            var updatedLock = lockOneUpdate.getSuccess();
+            var updatedLock = lockOneUpdate.success();
             assertNotEquals(firstLock.getHeartbeat(), updatedLock.getHeartbeat());
 
             var lockTwo = lockDao.obtainLock(tx, appTwo, 0, "bob");

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
@@ -54,7 +54,7 @@ class CompLockDaoTestIT extends AppTestBase
             var lockOneFail = lockDao.obtainLock(tx, appOne, 0, "alice");
             assertTrue(lockOneFail.isFailure());
             
-            Thread.sleep(000); // NOSONAR otherwise the dates will match.
+            Thread.sleep(1500); // NOSONAR otherwise the dates will match.
 
             var lockOneUpdate = lockDao.obtainLock(tx, appOne, 0, "bob");
             assertTrue(lockOneUpdate.isSuccess());

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
@@ -53,10 +53,13 @@ class CompLockDaoTestIT extends AppTestBase
             var lockOneFail = lockDao.obtainLock(tx, appOne, 0, "alice");
             assertTrue(lockOneFail.isFailure());
             
+            Thread.sleep(000); // NOSONAR otherwise the dates will match.
+
             var lockOneUpdate = lockDao.obtainLock(tx, appOne, 0, "bob");
             assertTrue(lockOneUpdate.isSuccess());
             var firstLock = lockOne.getSuccess();
-            var updatedLock = lockOne.getSuccess();
+
+            var updatedLock = lockOneUpdate.getSuccess();
             assertNotEquals(firstLock.getHeartbeat(), updatedLock.getHeartbeat());
 
             var lockTwo = lockDao.obtainLock(tx, appTwo, 0, "bob");

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
@@ -1,5 +1,6 @@
 package org.opendcs.dao;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -70,6 +71,10 @@ class CompLockDaoTestIT extends AppTestBase
 
             assertTrue(locks.stream()
                             .anyMatch(p -> p.getAppId() == appOne.getAppId() || p.getAppId() == appTwo.getAppId()));
+
+            lockDao.releaseLock(tx, updatedLock);
+
+            assertFalse(lockDao.getLock(tx, updatedLock.getAppId()).isPresent());
 
             tx.rollback();
         }

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
@@ -39,12 +39,12 @@ class CompLockDaoTestIT extends AppTestBase
             tmp.setAppName("app2");
             appTwo = appDao.save(tx, tmp);
         }
-    }    
-    
+    }
+
     @Test
     void test_lock_operations() throws Exception
     {
-        
+
         var lockDao = db.getDao(CompLockDao.class).orElseThrow();
 
         try (var tx = db.newTransaction())
@@ -53,7 +53,7 @@ class CompLockDaoTestIT extends AppTestBase
             assertTrue(lockOne.isSuccess());
             var lockOneFail = lockDao.obtainLock(tx, appOne, 0, "alice");
             assertTrue(lockOneFail.isFailure());
-            
+
             Thread.sleep(1500); // NOSONAR otherwise the dates will match.
 
             var lockOneUpdate = lockDao.obtainLock(tx, appOne, 0, "bob");

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/CompLockDaoTestIT.java
@@ -1,0 +1,74 @@
+package org.opendcs.dao;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opendcs.database.api.OpenDcsDatabase;
+import org.opendcs.database.dai.CompLockDao;
+import org.opendcs.database.dai.LoadingAppDao;
+import org.opendcs.fixtures.AppTestBase;
+import org.opendcs.fixtures.annotations.ConfiguredField;
+import org.opendcs.fixtures.annotations.EnableIfTsDb;
+
+import decodes.tsdb.CompAppInfo;
+
+@EnableIfTsDb
+class CompLockDaoTestIT extends AppTestBase
+{
+
+    private static CompAppInfo appOne;
+    private static CompAppInfo appTwo;
+
+    @ConfiguredField
+    static OpenDcsDatabase db;
+
+
+    @BeforeAll
+    static void setupApps() throws Exception
+    {
+        var appDao = db.getDao(LoadingAppDao.class).orElseThrow();
+        try (var tx = db.newTransaction())
+        {
+            var tmp = new CompAppInfo();
+            tmp.setAppName("app1");
+            appOne = appDao.save(tx, tmp);
+
+            tmp.setAppName("app2");
+            appTwo = appDao.save(tx, tmp);
+        }
+    }    
+    
+    @Test
+    void test_lock_operations() throws Exception
+    {
+        
+        var lockDao = db.getDao(CompLockDao.class).orElseThrow();
+
+        try (var tx = db.newTransaction())
+        {
+            var lockOne = lockDao.obtainLock(tx, appOne, 0, "bob");
+            assertTrue(lockOne.isSuccess());
+            var lockOneFail = lockDao.obtainLock(tx, appOne, 0, "alice");
+            assertTrue(lockOneFail.isFailure());
+            
+            var lockOneUpdate = lockDao.obtainLock(tx, appOne, 0, "bob");
+            assertTrue(lockOneUpdate.isSuccess());
+            var firstLock = lockOne.getSuccess();
+            var updatedLock = lockOne.getSuccess();
+            assertNotEquals(firstLock.getHeartbeat(), updatedLock.getHeartbeat());
+
+            var lockTwo = lockDao.obtainLock(tx, appTwo, 0, "bob");
+            assertTrue(lockTwo.isSuccess());
+
+            var locks = lockDao.getAll(tx, -1, -1);
+            assertTrue(locks.size() >= 2);
+
+            assertTrue(locks.stream()
+                            .anyMatch(p -> p.getAppId() == appOne.getAppId() || p.getAppId() == appTwo.getAppId()));
+
+            tx.rollback();
+        }
+    }
+}

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/AppResourcesIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/AppResourcesIT.java
@@ -31,6 +31,8 @@ import opendcs.dai.LoadingAppDAI;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opendcs.database.api.OpenDcsDataException;
+import org.opendcs.database.dai.CompLockDao;
 import org.opendcs.odcsapi.beans.ApiAppStatus;
 import org.opendcs.odcsapi.filters.W3CTraceFilter;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
@@ -331,7 +333,6 @@ final class AppResourcesIT extends BaseApiIT
 		assertNotNull(actual.get("appId"), "Application status was not returned.");
 		// ID not compared as we don't actually care what it is.
 		assertEquals(host, actual.get("hostname"));
-		assertEquals(expected.get("eventPort"), (Integer)actual.get("eventPort"));
 		assertEquals(expected.get("status"), (String)actual.get("status"));
 		assertEquals(expected.get("appName"), (String)actual.get("appName"));
 		assertEquals(expected.get("pid"), (Integer)actual.get("pid"));
@@ -357,23 +358,41 @@ final class AppResourcesIT extends BaseApiIT
 		;
 	}
 
-	TsdbCompLock getCompLock(CompAppInfo compAppInfo, int pid, String host) throws DatabaseException
+	TsdbCompLock getCompLock(CompAppInfo compAppInfo, int pid, String host) throws Exception
 	{
-		try (LoadingAppDAI dai = getTsdb().makeLoadingAppDAO())
+		try
 		{
-			return dai.obtainCompProcLock(compAppInfo, pid, host);
+			var db = getConfig().getOpenDcsDatabase();
+			var dao = db.getDao(CompLockDao.class).orElseThrow();
+			try (var tx = db.newTransaction())
+			{
+				var lock = dao.obtainLock(tx, compAppInfo, pid, host);
+				if (lock.isSuccess())
+				{
+					return lock.getSuccess();
+				}
+				else
+				{
+					throw lock.getFailure();
+				}
+			}
 		}
 		catch (Throwable thr)
 		{
-			throw new DatabaseException("Error getting comp lock", thr);
+			throw new OpenDcsDataException("Error getting comp lock", thr);
 		}
 	}
 
-	void releaseCompLock(TsdbCompLock compLock) throws DatabaseException
+	void releaseCompLock(TsdbCompLock compLock) throws Exception
 	{
-		try (LoadingAppDAI dai = getTsdb().makeLoadingAppDAO())
+		try
 		{
-			dai.releaseCompProcLock(compLock);
+		var db = getConfig().getOpenDcsDatabase();
+			var dao = db.getDao(CompLockDao.class).orElseThrow();
+			try (var tx = db.newTransaction())
+			{
+				dao.releaseLock(tx, compLock);
+			}
 		}
 		catch (Throwable thr)
 		{

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/AppResourcesIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/AppResourcesIT.java
@@ -27,7 +27,6 @@ import io.restassured.filter.log.LogDetail;
 import io.restassured.path.json.JsonPath;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import opendcs.dai.LoadingAppDAI;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -369,11 +368,11 @@ final class AppResourcesIT extends BaseApiIT
 				var lock = dao.obtainLock(tx, compAppInfo, pid, host);
 				if (lock.isSuccess())
 				{
-					return lock.getSuccess();
+					return lock.success();
 				}
 				else
 				{
-					throw lock.getFailure();
+					throw lock.failure();
 				}
 			}
 		}

--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/AppResourcesIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/odcsapi/res/it/AppResourcesIT.java
@@ -387,7 +387,7 @@ final class AppResourcesIT extends BaseApiIT
 	{
 		try
 		{
-		var db = getConfig().getOpenDcsDatabase();
+			var db = getConfig().getOpenDcsDatabase();
 			var dao = db.getDao(CompLockDao.class).orElseThrow();
 			try (var tx = db.newTransaction())
 			{

--- a/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/app_stat_expected.json
+++ b/integrationtesting/opendcs-tests/src/test/resources/org/opendcs/odcsapi/res/it/DEFAULT/app_stat_expected.json
@@ -5,6 +5,5 @@
   "hostname": "localhost",
   "pid": 8,
   "heartbeat": "2024-12-30T19:49:39.141Z",
-  "eventPort": 12345,
   "status": "Starting"
 }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
@@ -28,7 +28,7 @@ import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.CompLockDao;
 import org.opendcs.database.impl.opendcs.jdbi.logging.DetailSqlLogger;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.apps.CompLockMapper;
-import org.opendcs.utils.FailableResult;
+import org.opendcs.util.Result;
 import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
@@ -76,7 +76,7 @@ public final class CompLockDaoImpl implements CompLockDao
     }
 
     @Override
-    public FailableResult<TsdbCompLock,LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException
+    public Result<TsdbCompLock,LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException
     {
         var tlock = getLock(tx, lock.getAppId()).orElse(null);
         if (tlock != null)
@@ -84,7 +84,7 @@ public final class CompLockDaoImpl implements CompLockDao
             if (lock.getPID() != tlock.getPID()
                 || !lock.getHost().equalsIgnoreCase(tlock.getHost()))
             {
-                return FailableResult.failure(new LockBusyException(
+                return Result.failure(new LockBusyException(
                     "Lock for app ID " + lock.getAppId()
                     + " has been stolen by PID " + tlock.getPID()
                     + " on host '" + tlock.getHost() + "'"
@@ -92,11 +92,11 @@ public final class CompLockDaoImpl implements CompLockDao
                     + ", my host='" + lock.getHost() + "'"));
             }
             lock.setHeartbeat(new Date());
-            return FailableResult.success(saveLock(tx, lock));
+            return Result.success(saveLock(tx, lock));
         }
         else
         {
-            return FailableResult.failure(new LockBusyException("Lock for app ID " + lock.getAppId() + " has been deleted."));
+            return Result.failure(new LockBusyException("Lock for app ID " + lock.getAppId() + " has been deleted."));
         }
     }
 
@@ -137,7 +137,7 @@ public final class CompLockDaoImpl implements CompLockDao
     }
 
     @Override
-    public FailableResult<TsdbCompLock, LockBusyException> obtainLock(DataTransaction tx, CompAppInfo appInfo, int pid,
+    public Result<TsdbCompLock, LockBusyException> obtainLock(DataTransaction tx, CompAppInfo appInfo, int pid,
             String host) throws OpenDcsDataException
     {
         var lock = getLock(tx, appInfo.getAppId()).orElse(null);
@@ -155,12 +155,12 @@ public final class CompLockDaoImpl implements CompLockDao
                         "Cannot obtain lock for app ID " + appInfo.getAppId()
                         + ". Currently owned by PID " + lock.getPID()
                         + " on host '" + lock.getHost() + "'";
-                return FailableResult.failure( new LockBusyException(msg));
+                return Result.failure( new LockBusyException(msg));
             }
 
             releaseLock(tx, lock);
         }
-        return FailableResult.success(saveLock(tx,new TsdbCompLock(appInfo.getAppId(), pid, host, new Date(), "Starting")));        
+        return Result.success(saveLock(tx,new TsdbCompLock(appInfo.getAppId(), pid, host, new Date(), "Starting")));        
     }
     
 

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
@@ -23,14 +23,19 @@ import java.util.Optional;
 
 import org.jdbi.v3.core.Handle;
 import org.opendcs.database.api.DataTransaction;
+import org.opendcs.database.api.DatabaseEngine;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.CompLockDao;
+import org.opendcs.database.impl.opendcs.jdbi.logging.DetailSqlLogger;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.apps.CompLockMapper;
 import org.opendcs.utils.FailableResult;
+import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
 import org.openide.util.lookup.ServiceProvider;
+import org.slf4j.Logger;
 import org.stringtemplate.v4.ST;
+import org.stringtemplate.v4.STGroup;
 
 import decodes.sql.DbKey;
 import decodes.tsdb.CompAppInfo;
@@ -40,15 +45,23 @@ import decodes.tsdb.TsdbCompLock;
 @ServiceProvider(service = CompLockDao.class)
 public final class CompLockDaoImpl implements CompLockDao
 {
-    private static final ST SELECT = new ST("""
-        select lock.loading_application_id, la.loading_application_name, lock.pid, lock.hostname, 
-               lock.heartbeat, lock.cur_status
-          from cp_comp_proc_lock lock
-          left outer join hdb_loading_application la on ld.loading_application_id = lock.loading_application_id
-          <if(where)> <where> <endif>
-        order by lock.loading_application_id asc
-        <if(limit)> <limit> <endif>
-    """);
+    private static final Logger log = OpenDcsLoggerFactory.getLogger();
+    private static final String SELECT = "select";
+    private static final STGroup queries = new STGroup();
+
+    static
+    {
+        queries.defineTemplate(SELECT, "limit,where",
+            """
+                select lock.loading_application_id, la.loading_application_name, lock.pid, lock.hostname,
+                        lock.heartbeat, lock.cur_status
+                    from cp_comp_proc_lock lock
+                    left outer join hdb_loading_application la on la.loading_application_id = lock.loading_application_id
+                    <if(where)> <where> <endif>
+                order by lock.loading_application_id asc
+                <if(limit)> <limit> <endif>
+            """);
+    }
 
     private final CompLockMapper lockMapper = CompLockMapper.withPrefix(null);
 
@@ -94,7 +107,7 @@ public final class CompLockDaoImpl implements CompLockDao
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
-        try (var select = handle.createQuery(SELECT.add(LIMIT_CLAUSE, addLimitOffset(limit, offset)).render()))
+        try (var select = handle.createQuery(queries.getInstanceOf(SELECT).add(LIMIT_CLAUSE, addLimitOffset(limit, offset)).render()))
         {
             if (limit >= 0)
             {
@@ -113,8 +126,12 @@ public final class CompLockDaoImpl implements CompLockDao
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
-        try (var select = handle.createQuery(SELECT.add("where", "where lock.loading_application_id = :id").render()))
+        try (var select = handle.createQuery(
+                            queries.getInstanceOf(SELECT)
+                                  .add("where", " where lock.loading_application_id = :id ")
+                                  .render()))
         {
+            select.setSqlLogger(new DetailSqlLogger(log));
             return select.bind(GenericColumns.ID.column(), appId)
                          .map(lockMapper)
                          .findOne();
@@ -162,19 +179,22 @@ public final class CompLockDaoImpl implements CompLockDao
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        var ctx = tx.getContext();
+        var dbEngine = ctx.getDatabaseEngine();
         try (var merge = handle.createUpdate("""
                 merge into cp_comp_proc_lock lock
-                using (:loading_application_id loading_application_id, :pid pid, :hostname hostname,
+                using (select :loading_application_id loading_application_id, :pid pid, :hostname hostname,
                        :heartbeat heartbeat, :cur_status cur_status <dual>) input
                 on (lock.loading_application_id = input.loading_application_id)
                 when matched then
-                    update set pid = input.pid, hostname = input.hostname, heartbeat = input.heartbeat
+                    update set pid = input.pid, hostname = input.hostname, heartbeat = input.heartbeat,
                             cur_status = input.cur_status
                 when not matched then
                 insert(loading_application_id, pid, hostname, heartbeat, cur_status)
                 values(input.loading_application_id, input.pid, input.hostname, input.heartbeat, input.cur_status)
                 """))
         {
+            merge.define("dual", dbEngine == DatabaseEngine.ORACLE ? "from dual" : "");
             merge.bind(CompLockMapper.Columns.APP_ID.column(), lock.getAppId())
                   .bind(CompLockMapper.Columns.PID.column(), lock.getPID())
                   .bind(CompLockMapper.Columns.HOSTNAME.column(), lock.getHost())

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
@@ -14,6 +14,10 @@
  */
 package org.opendcs.database.impl.opendcs.dao;
 
+import static org.opendcs.utils.sql.SqlQueries.LIMIT_CLAUSE;
+import static org.opendcs.utils.sql.SqlQueries.addLimitOffset;
+
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,8 +38,6 @@ import decodes.tsdb.TsdbCompLock;
 
 public final class CompLockDaoImpl implements CompLockDao
 {
-    private final CompLockMapper lockMapper = CompLockMapper.withPrefix(null);
-
     private static final ST SELECT = new ST("""
         select loading_application_id, pid, hostname, heartbeat, cur_status
           from cp_comp_proc_lock
@@ -44,26 +46,62 @@ public final class CompLockDaoImpl implements CompLockDao
         <if(limit)> <limit> <endif>
     """);
 
+    private final CompLockMapper lockMapper = CompLockMapper.withPrefix(null);
+
     @Override
     public void releaseLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException
     {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'releaseLock'");
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        try (var delete = handle.createUpdate("delete from cp_comp_proc_lock where loading_application_id = :id"))
+        {
+            delete.bind(GenericColumns.ID.column(), lock.getAppId()).execute();
+        }
     }
 
     @Override
     public Optional<LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException
     {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'checkLock'");
+        var tlock = getLock(tx, lock.getAppId()).orElse(null);
+        if (tlock != null)
+        {
+            if (lock.getPID() != tlock.getPID()
+                || !lock.getHost().equalsIgnoreCase(tlock.getHost()))
+            {
+                return Optional.of(new LockBusyException(
+                    "Lock for app ID " + lock.getAppId()
+                    + " has been stolen by PID " + tlock.getPID()
+                    + " on host '" + tlock.getHost() + "'"
+                    + ", my PID=" + lock.getPID()
+                    + ", my host='" + lock.getHost() + "'"));
+            }
+            lock.setHeartbeat(new Date());
+            saveLock(tx, lock);
+        }
+        else
+        {
+            return Optional.of(new LockBusyException("Lock for app ID " + lock.getAppId() + " has been deleted."));
+        }
+        return Optional.empty();
     }
 
     @Override
     public List<TsdbCompLock> getAll(DataTransaction tx, int limit, int offset) throws OpenDcsDataException
     {
-    
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getAll'");
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        try (var select = handle.createQuery(SELECT.add(LIMIT_CLAUSE, addLimitOffset(limit, offset)).render()))
+        {
+            if (limit >= 0)
+            {
+                select.bind(LIMIT_CLAUSE, limit);
+            }
+            if (offset >= 0)
+            {
+                select.bind("offset", offset);
+            }
+            return select.map(lockMapper).list();
+        }
     }
 
     @Override
@@ -83,15 +121,64 @@ public final class CompLockDaoImpl implements CompLockDao
     public FailableResult<TsdbCompLock, LockBusyException> obtainLock(DataTransaction tx, CompAppInfo appInfo, int pid,
             String host) throws OpenDcsDataException
     {
-        var existing = getLock(tx, appInfo.getAppId());
-        if (existing.isPresent())
+        var lock = getLock(tx, appInfo.getAppId()).orElse(null);
+        if (lock != null)
         {
-            var lock = existing.get();
             if (lock.getPID() == pid)
             {
-                return 
+                var check = checkLock(tx, lock);
+                if (check.isEmpty())
+                {
+                    return FailableResult.success(lock);
+                }
+                else
+                {
+                    return FailableResult.failure(check.get());
+                }
             }
+            else if (!lock.isStale())
+            {
+                String msg =
+                        "Cannot obtain lock for app ID " + appInfo.getAppId()
+                        + ". Currently owned by PID " + lock.getPID()
+                        + " on host '" + lock.getHost() + "'";
+                return FailableResult.failure( new LockBusyException(msg));
+            }
+
+            releaseLock(tx, lock);
         }
+
+
+        
+        return FailableResult.success(saveLock(tx,new TsdbCompLock(appInfo.getAppId(), pid, host, new Date(), "Starting")));        
     }
     
+
+    private TsdbCompLock saveLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        try (var merge = handle.createUpdate("""
+                merge into cp_comp_proc_lock lock
+                using (:loading_application_id loading_application_id, :pid pid, :hostname hostname,
+                       :heartbeat heartbeat, :cur_status cur_status <dual>) input
+                on (lock.loading_application_id = input.loading_application_id)
+                when matched then
+                    update set pid = input.pid, hostname = input.hostname, heartbeat = input.heartbeat
+                            cur_status = input.cur_status
+                when not matched then
+                insert(loading_application_id, pid, hostname, heartbeat, cur_status)
+                values(input.loading_application_id, input.pid, input.hostname, input.heartbeat, input.cur_status)
+                """))
+        {
+            merge.bind(CompLockMapper.Columns.APP_ID.column(), lock.getAppId())
+                  .bind(CompLockMapper.Columns.PID.column(), lock.getPID())
+                  .bind(CompLockMapper.Columns.HOSTNAME.column(), lock.getHost())
+                  .bindByType(CompLockMapper.Columns.HEARTBEAT.column(), lock.getHeartbeat(), Date.class)
+                  .bind(CompLockMapper.Columns.STATUS.column(), lock.getStatus())
+                  .execute();
+            return getLock(tx, lock.getAppId())
+                    .orElseThrow(() -> new OpenDcsDataException("Unable to retrieve lock we just saved."));
+        }
+    }
 }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
@@ -145,7 +145,7 @@ public final class CompLockDaoImpl implements CompLockDao
         {
             // check for same application and host. With the introduction of the docker images
             // every instance generally would have the same PID, just a different hostname.
-            if (lock.getPID() == pid && lock.getHost().equals(host))
+            if (lock.getPID() == pid && lock.getHost().equalsIgnoreCase(host))
             {
                 return checkLock(tx, lock);
             }

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
@@ -113,7 +113,7 @@ public final class CompLockDaoImpl implements CompLockDao
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
-        try (var select = handle.createQuery(SELECT.add("where", " lock.loading_application_id = :id").render()))
+        try (var select = handle.createQuery(SELECT.add("where", "where lock.loading_application_id = :id").render()))
         {
             return select.bind(GenericColumns.ID.column(), appId)
                          .map(lockMapper)

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
@@ -77,7 +77,7 @@ public final class CompLockDaoImpl implements CompLockDao
     }
 
     @Override
-    public Optional<LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException
+    public FailableResult<TsdbCompLock,LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException
     {
         var tlock = getLock(tx, lock.getAppId()).orElse(null);
         if (tlock != null)
@@ -85,7 +85,7 @@ public final class CompLockDaoImpl implements CompLockDao
             if (lock.getPID() != tlock.getPID()
                 || !lock.getHost().equalsIgnoreCase(tlock.getHost()))
             {
-                return Optional.of(new LockBusyException(
+                return FailableResult.failure(new LockBusyException(
                     "Lock for app ID " + lock.getAppId()
                     + " has been stolen by PID " + tlock.getPID()
                     + " on host '" + tlock.getHost() + "'"
@@ -93,13 +93,12 @@ public final class CompLockDaoImpl implements CompLockDao
                     + ", my host='" + lock.getHost() + "'"));
             }
             lock.setHeartbeat(new Date());
-            saveLock(tx, lock);
+            return FailableResult.success(saveLock(tx, lock));
         }
         else
         {
-            return Optional.of(new LockBusyException("Lock for app ID " + lock.getAppId() + " has been deleted."));
+            return FailableResult.failure(new LockBusyException("Lock for app ID " + lock.getAppId() + " has been deleted."));
         }
-        return Optional.empty();
     }
 
     @Override
@@ -145,17 +144,11 @@ public final class CompLockDaoImpl implements CompLockDao
         var lock = getLock(tx, appInfo.getAppId()).orElse(null);
         if (lock != null)
         {
-            if (lock.getPID() == pid)
+            // check for same application and host. With the introduction of the docker images
+            // every instance generally would have the same PID, just a different hostname.
+            if (lock.getPID() == pid && lock.getHost().equals(host))
             {
-                var check = checkLock(tx, lock);
-                if (check.isEmpty())
-                {
-                    return FailableResult.success(lock);
-                }
-                else
-                {
-                    return FailableResult.failure(check.get());
-                }
+                return checkLock(tx, lock);
             }
             else if (!lock.isStale())
             {
@@ -168,9 +161,6 @@ public final class CompLockDaoImpl implements CompLockDao
 
             releaseLock(tx, lock);
         }
-
-
-        
         return FailableResult.success(saveLock(tx,new TsdbCompLock(appInfo.getAppId(), pid, host, new Date(), "Starting")));        
     }
     

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
@@ -26,14 +26,11 @@ import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.DatabaseEngine;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.dai.CompLockDao;
-import org.opendcs.database.impl.opendcs.jdbi.logging.DetailSqlLogger;
 import org.opendcs.database.impl.opendcs.jdbi.mapper.apps.CompLockMapper;
 import org.opendcs.util.Result;
-import org.opendcs.utils.logging.OpenDcsLoggerFactory;
 import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
 import org.openide.util.lookup.ServiceProvider;
-import org.slf4j.Logger;
 import org.stringtemplate.v4.STGroup;
 
 import decodes.sql.DbKey;
@@ -44,7 +41,6 @@ import decodes.tsdb.TsdbCompLock;
 @ServiceProvider(service = CompLockDao.class)
 public final class CompLockDaoImpl implements CompLockDao
 {
-    private static final Logger log = OpenDcsLoggerFactory.getLogger();
     private static final String SELECT = "select";
     private static final STGroup queries = new STGroup();
 
@@ -129,7 +125,6 @@ public final class CompLockDaoImpl implements CompLockDao
                                   .add("where", " where lk.loading_application_id = :id ")
                                   .render()))
         {
-            select.setSqlLogger(new DetailSqlLogger(log));
             return select.bind(GenericColumns.ID.column(), appId)
                          .map(lockMapper)
                          .findOne();

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
@@ -34,7 +34,6 @@ import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
 import org.openide.util.lookup.ServiceProvider;
 import org.slf4j.Logger;
-import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 
 import decodes.sql.DbKey;
@@ -53,12 +52,12 @@ public final class CompLockDaoImpl implements CompLockDao
     {
         queries.defineTemplate(SELECT, "limit,where",
             """
-                select lock.loading_application_id, la.loading_application_name, lock.pid, lock.hostname,
-                        lock.heartbeat, lock.cur_status
-                    from cp_comp_proc_lock lock
-                    left outer join hdb_loading_application la on la.loading_application_id = lock.loading_application_id
+                select lk.loading_application_id, la.loading_application_name, lk.pid, lk.hostname,
+                        lk.heartbeat, lk.cur_status
+                    from cp_comp_proc_lock lk
+                    left outer join hdb_loading_application la on la.loading_application_id = lk.loading_application_id
                     <if(where)> <where> <endif>
-                order by lock.loading_application_id asc
+                order by lk.loading_application_id asc
                 <if(limit)> <limit> <endif>
             """);
     }
@@ -127,7 +126,7 @@ public final class CompLockDaoImpl implements CompLockDao
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
         try (var select = handle.createQuery(
                             queries.getInstanceOf(SELECT)
-                                  .add("where", " where lock.loading_application_id = :id ")
+                                  .add("where", " where lk.loading_application_id = :id ")
                                   .render()))
         {
             select.setSqlLogger(new DetailSqlLogger(log));
@@ -172,10 +171,10 @@ public final class CompLockDaoImpl implements CompLockDao
         var ctx = tx.getContext();
         var dbEngine = ctx.getDatabaseEngine();
         try (var merge = handle.createUpdate("""
-                merge into cp_comp_proc_lock lock
+                merge into cp_comp_proc_lock lk
                 using (select :loading_application_id loading_application_id, :pid pid, :hostname hostname,
                        :heartbeat heartbeat, :cur_status cur_status <dual>) input
-                on (lock.loading_application_id = input.loading_application_id)
+                on (lk.loading_application_id = input.loading_application_id)
                 when matched then
                     update set pid = input.pid, hostname = input.hostname, heartbeat = input.heartbeat,
                             cur_status = input.cur_status

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2026 OpenDCS Consortium and its Contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.opendcs.database.impl.opendcs.dao;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.jdbi.v3.core.Handle;
+import org.opendcs.database.api.DataTransaction;
+import org.opendcs.database.api.OpenDcsDataException;
+import org.opendcs.database.dai.CompLockDao;
+import org.opendcs.database.impl.opendcs.jdbi.mapper.apps.CompLockMapper;
+import org.opendcs.utils.FailableResult;
+import org.opendcs.utils.sql.GenericColumns;
+import org.opendcs.utils.sql.SqlErrorMessages;
+import org.stringtemplate.v4.ST;
+
+import decodes.sql.DbKey;
+import decodes.tsdb.CompAppInfo;
+import decodes.tsdb.LockBusyException;
+import decodes.tsdb.TsdbCompLock;
+
+public final class CompLockDaoImpl implements CompLockDao
+{
+    private final CompLockMapper lockMapper = CompLockMapper.withPrefix(null);
+
+    private static final ST SELECT = new ST("""
+        select loading_application_id, pid, hostname, heartbeat, cur_status
+          from cp_comp_proc_lock
+          <if(where)> <where> <endif>
+        order by loading_application_id asc
+        <if(limit)> <limit> <endif>
+    """);
+
+    @Override
+    public void releaseLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException
+    {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'releaseLock'");
+    }
+
+    @Override
+    public Optional<LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException
+    {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'checkLock'");
+    }
+
+    @Override
+    public List<TsdbCompLock> getAll(DataTransaction tx, int limit, int offset) throws OpenDcsDataException
+    {
+    
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getAll'");
+    }
+
+    @Override
+    public Optional<TsdbCompLock> getLock(DataTransaction tx, DbKey appId) throws OpenDcsDataException
+    {
+        var handle = tx.connection(Handle.class)
+                       .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
+        try (var select = handle.createQuery(SELECT.add("where", " loading_application_id = :id").render()))
+        {
+            return select.bind(GenericColumns.ID.column(), appId)
+                         .map(lockMapper)
+                         .findOne();
+        }
+    }
+
+    @Override
+    public FailableResult<TsdbCompLock, LockBusyException> obtainLock(DataTransaction tx, CompAppInfo appInfo, int pid,
+            String host) throws OpenDcsDataException
+    {
+        var existing = getLock(tx, appInfo.getAppId());
+        if (existing.isPresent())
+        {
+            var lock = existing.get();
+            if (lock.getPID() == pid)
+            {
+                return 
+            }
+        }
+    }
+    
+}

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/CompLockDaoImpl.java
@@ -29,6 +29,7 @@ import org.opendcs.database.impl.opendcs.jdbi.mapper.apps.CompLockMapper;
 import org.opendcs.utils.FailableResult;
 import org.opendcs.utils.sql.GenericColumns;
 import org.opendcs.utils.sql.SqlErrorMessages;
+import org.openide.util.lookup.ServiceProvider;
 import org.stringtemplate.v4.ST;
 
 import decodes.sql.DbKey;
@@ -36,13 +37,16 @@ import decodes.tsdb.CompAppInfo;
 import decodes.tsdb.LockBusyException;
 import decodes.tsdb.TsdbCompLock;
 
+@ServiceProvider(service = CompLockDao.class)
 public final class CompLockDaoImpl implements CompLockDao
 {
     private static final ST SELECT = new ST("""
-        select loading_application_id, pid, hostname, heartbeat, cur_status
-          from cp_comp_proc_lock
+        select lock.loading_application_id, la.loading_application_name, lock.pid, lock.hostname, 
+               lock.heartbeat, lock.cur_status
+          from cp_comp_proc_lock lock
+          left outer join hdb_loading_application la on ld.loading_application_id = lock.loading_application_id
           <if(where)> <where> <endif>
-        order by loading_application_id asc
+        order by lock.loading_application_id asc
         <if(limit)> <limit> <endif>
     """);
 
@@ -109,7 +113,7 @@ public final class CompLockDaoImpl implements CompLockDao
     {
         var handle = tx.connection(Handle.class)
                        .orElseThrow(() -> new OpenDcsDataException(SqlErrorMessages.NO_JDBI_HANDLE));
-        try (var select = handle.createQuery(SELECT.add("where", " loading_application_id = :id").render()))
+        try (var select = handle.createQuery(SELECT.add("where", " lock.loading_application_id = :id").render()))
         {
             return select.bind(GenericColumns.ID.column(), appId)
                          .map(lockMapper)

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/apps/CompLockMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/apps/CompLockMapper.java
@@ -50,8 +50,10 @@ public class CompLockMapper extends PrefixRowMapper<TsdbCompLock, CompLockMapper
         var hostName = rs.getString(column(Columns.HOSTNAME));
         var heartBeat = dateMapper.map(rs, column(Columns.HEARTBEAT), ctx);
         var status = rs.getString(column(Columns.STATUS));
-
-        return new TsdbCompLock(appId, pid, hostName, heartBeat, status);
+        var name = rs.getString(column(Columns.APP_NAME));
+        var ret = new TsdbCompLock(appId, pid, hostName, heartBeat, status);
+        ret.setAppName(name);
+        return ret;
     }
 
 
@@ -63,6 +65,10 @@ public class CompLockMapper extends PrefixRowMapper<TsdbCompLock, CompLockMapper
     public enum Columns implements TableColumnDefinition
     {
         APP_ID("loading_application_id"),
+        // NOTE: the name is pulled from the joined loading_application_name table
+        // and not specifically on this time. Didn't make sense to pull in the whole
+        // LoadingAppDao, or table, just to get the name column
+        APP_NAME("loading_application_name"),
         PID("pid"),
         HOSTNAME("hostname"),
         HEARTBEAT("heartbeat"),

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/apps/CompLockMapper.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/jdbi/mapper/apps/CompLockMapper.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2026 OpenDCS Consortium and its Contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.opendcs.database.impl.opendcs.jdbi.mapper.apps;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Date;
+
+import org.jdbi.v3.core.statement.StatementContext;
+import org.opendcs.database.model.mappers.PrefixRowMapper;
+import org.opendcs.database.sql.TableColumnDefinition;
+import org.opendcs.utils.sql.SqlErrorMessages;
+
+import decodes.sql.DbKey;
+import decodes.tsdb.TsdbCompLock;
+
+public class CompLockMapper extends PrefixRowMapper<TsdbCompLock, CompLockMapper.Columns>
+{
+    protected CompLockMapper(String prefix)
+    {
+        super(prefix, "cp_comp_proc_lock", Columns.class);
+    }
+
+    @Override
+    public TsdbCompLock map(ResultSet rs, StatementContext ctx) throws SQLException
+    {
+        var keyMapper = ctx.findColumnMapperFor(DbKey.class)
+                           .orElseThrow(() -> new SQLException(SqlErrorMessages.DBKEY_MAPPER_NOT_FOUND));
+        var dateMapper = ctx.findColumnMapperFor(Date.class)
+                            .orElseThrow(() -> new SQLException(SqlErrorMessages.TIME_MAPPER_NOT_FOUND));
+        var appId = keyMapper.map(rs, column(Columns.APP_ID), ctx);
+        if (DbKey.isNull(appId) || rs.wasNull())
+        {
+            return null;
+        }
+
+        var pid = rs.getInt(column(Columns.PID));
+        var hostName = rs.getString(column(Columns.HOSTNAME));
+        var heartBeat = dateMapper.map(rs, column(Columns.HEARTBEAT), ctx);
+        var status = rs.getString(column(Columns.STATUS));
+
+        return new TsdbCompLock(appId, pid, hostName, heartBeat, status);
+    }
+
+
+    public static CompLockMapper withPrefix(String prefix)
+    {
+        return new CompLockMapper(prefix);
+    }
+    
+    public enum Columns implements TableColumnDefinition
+    {
+        APP_ID("loading_application_id"),
+        PID("pid"),
+        HOSTNAME("hostname"),
+        HEARTBEAT("heartbeat"),
+        STATUS("cur_status")
+        ;
+
+        private final String column;
+
+        Columns(String column)
+        {
+            this.column = column;
+        }
+
+        @Override
+        public String column()
+        {
+            return column;
+        }
+    }
+}

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/beans/ApiAppStatus.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/beans/ApiAppStatus.java
@@ -36,7 +36,8 @@ public final class ApiAppStatus
 	@Schema(description = "Last recorded heartbeat timestamp for the application.",
 			example = "2023-05-25T16:34:18.073Z[UTC]")
 	private Date heartbeat = null;
-	@Schema(description = "Port number used for event communication.", example = "8086")
+	@Schema(description = "Port number used for event communication. No longer used, field should either be null or not present.",
+			example = "8086")
 	private Integer eventPort = null;
 	@Schema(description = "Current status of the application. Default is 'Inactive'.", example = "Cmps: 0/0")
 	private String status = "Inactive";

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
@@ -15,13 +15,10 @@
 
 package org.opendcs.odcsapi.res;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import decodes.sql.DbKey;
 import decodes.tsdb.CompAppInfo;
-import decodes.tsdb.DbIoException;
-import decodes.tsdb.NoSuchObjectException;
 import decodes.tsdb.TsdbCompLock;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -41,7 +38,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import opendcs.dai.LoadingAppDAI;
 import org.opendcs.odcsapi.beans.ApiAppRef;
 import org.opendcs.odcsapi.beans.ApiAppStatus;
 import org.opendcs.odcsapi.beans.ApiLoadingApp;
@@ -52,6 +48,7 @@ import org.opendcs.odcsapi.errorhandling.MissingParameterException;
 import org.opendcs.odcsapi.errorhandling.WebAppException;
 import org.opendcs.odcsapi.util.ApiConstants;
 import org.opendcs.database.api.OpenDcsDataException;
+import org.opendcs.database.dai.CompLockDao;
 import org.opendcs.database.dai.LoadingAppDao;
 
 /**
@@ -446,28 +443,31 @@ public final class AppResources extends OpenDcsResource
 			},
 			tags = {"OpenDCS Process Monitor and Control (APP)"}
 	)
-	public Response getAppStat() throws DbException
+	public Response getAppStat() throws WebAppException
 	{
-		List<ApiAppStatus> ret = new ArrayList<>();
-		try (LoadingAppDAI dai = getLegacyDatabase().makeLoadingAppDAO())
+		var db = createDb();
+		var dao = db.getDao(CompLockDao.class).orElseThrow(); 
+		try (var tx = db.newTransaction())
 		{
-			for (TsdbCompLock lock : dai.getAllCompProcLocks())
-			{
-				if (!lock.isStale())
-				{
-					ret.add(map(dai, lock));
-				}
-			}
 			return Response.ok()
-					.entity(ret).build();
+					.entity(
+						tx.wrapErrors(() ->
+						{
+						return dao.getAll(tx, -1, -1)
+								.stream()
+								.filter(l -> l.isStale())
+								.map(l -> map(l))
+								.toList();
+						}))
+					.build();
 		}
-		catch (DbIoException ex)
+		catch (OpenDcsDataException ex)
 		{
-			throw new DbException("Unable to retrieve app status", ex);
+			throw new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Unable to retrieve comp locks.", ex);
 		}
 	}
 
-	static ApiAppStatus map(LoadingAppDAI dai, TsdbCompLock lock) throws DbIoException
+	static ApiAppStatus map(TsdbCompLock lock)
 	{
 		ApiAppStatus ret = new ApiAppStatus();
 		ret.setAppId(lock.getAppId().getValue());
@@ -476,21 +476,7 @@ public final class AppResources extends OpenDcsResource
 		ret.setPid((long) lock.getPID());
 		ret.setHeartbeat(lock.getHeartbeat());
 		ret.setStatus(lock.getStatus());
-		if (dai != null)
-		{
-			try {
-				ApiLoadingApp app = mapLoading(dai.getComputationApp(lock.getAppId()));
-				if (app.getProperties() != null && app.getProperties().getProperty("EventPort") != null)
-				{
-					ret.setEventPort(Integer.parseInt(app.getProperties().getProperty("EventPort")));
-				}
-				ret.setAppType(app.getAppType());
-			}
-			catch (DbIoException | NoSuchObjectException | NumberFormatException ex)
-			{
-				throw new DbIoException("Error mapping app status", ex);
-			}
-		}
+		// Event port is not longer supported, don't propgate the data in new systems.
 		return ret;
 	}
 

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
@@ -59,6 +59,7 @@ public final class AppResources extends OpenDcsResource
 {
 	private static final String NO_APP_FOUND = "No such app with ID: %s";
 	private static final WebAppException UNABLE_TO_GET_APP_DAO = new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "No Loading Application DAO available.");
+private static final WebAppException UNABLE_TO_GET_COMPLOC_DAO= new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "No Comp Lock DAO available.");
 
 	@GET
 	@Path("apprefs")
@@ -447,7 +448,7 @@ public final class AppResources extends OpenDcsResource
 	public Response getAppStat() throws WebAppException
 	{
 		var db = createDb();
-		var dao = db.getDao(CompLockDao.class).orElseThrow(); 
+		var dao = db.getDao(CompLockDao.class).orElseThrow(() -> UNABLE_TO_GET_COMPLOC_DAO); 
 		try (var tx = db.newTransaction())
 		{
 			return Response.ok()
@@ -476,7 +477,7 @@ public final class AppResources extends OpenDcsResource
 		ret.setPid((long) lock.getPID());
 		ret.setHeartbeat(lock.getHeartbeat());
 		ret.setStatus(lock.getStatus());
-		// Event port is not longer supported, don't propgate the data in new systems.
+		// Event port is not longer supported, don't propagate the data in new systems.
 		return ret;
 	}
 

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
@@ -242,6 +242,7 @@ public final class AppResources extends OpenDcsResource
 			responses = {
 					@ApiResponse(responseCode = "204", description = "Successfully deleted application"),
 					@ApiResponse(responseCode = "400", description = "Bad Request - Missing required appId parameter"),
+					@ApiResponse(responseCode = "409", description = "Unable to process request, Application is in use."),
 					@ApiResponse(responseCode = "404", description = "Not Found - No app found with the given ID"),
 					@ApiResponse(responseCode = "500", description = "Internal Server Error")
 			},
@@ -452,13 +453,12 @@ public final class AppResources extends OpenDcsResource
 			return Response.ok()
 					.entity(
 						tx.wrapErrors(() ->
-						{
-						return dao.getAll(tx, -1, -1)
+							dao.getAll(tx, -1, -1)
 								.stream()
-								.filter(l -> l.isStale())
+								.filter(l -> !l.isStale())
 								.map(l -> map(l))
-								.toList();
-						}))
+								.toList()
+						))
 					.build();
 		}
 		catch (OpenDcsDataException ex)

--- a/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
+++ b/java/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
@@ -58,8 +58,12 @@ import org.opendcs.database.dai.LoadingAppDao;
 public final class AppResources extends OpenDcsResource
 {
 	private static final String NO_APP_FOUND = "No such app with ID: %s";
-	private static final WebAppException UNABLE_TO_GET_APP_DAO = new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "No Loading Application DAO available.");
-private static final WebAppException UNABLE_TO_GET_COMPLOC_DAO= new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "No Comp Lock DAO available.");
+	private static final WebAppException UNABLE_TO_GET_APP_DAO =
+		new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+							"No Loading Application DAO available.");
+	private static final WebAppException UNABLE_TO_GET_COMPLOCK_DAO =
+		new WebAppException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+				 			"No Comp Lock DAO available.");
 
 	@GET
 	@Path("apprefs")
@@ -448,7 +452,7 @@ private static final WebAppException UNABLE_TO_GET_COMPLOC_DAO= new WebAppExcept
 	public Response getAppStat() throws WebAppException
 	{
 		var db = createDb();
-		var dao = db.getDao(CompLockDao.class).orElseThrow(() -> UNABLE_TO_GET_COMPLOC_DAO); 
+		var dao = db.getDao(CompLockDao.class).orElseThrow(() -> UNABLE_TO_GET_COMPLOCK_DAO); 
 		try (var tx = db.newTransaction())
 		{
 			return Response.ok()

--- a/java/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/AppResourcesTest.java
+++ b/java/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/AppResourcesTest.java
@@ -94,7 +94,7 @@ final class AppResourcesTest
 		TsdbCompLock compLock = new TsdbCompLock(appId, pid, host, heartbeat, status);
 		compLock.setAppName("Computation Application");
 
-		ApiAppStatus appStatus = map(null, compLock);
+		ApiAppStatus appStatus = map(compLock);
 
 		assertNotNull(appStatus);
 		assertEquals(compLock.getAppId().getValue(), appStatus.getAppId());

--- a/java/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/AppResourcesTest.java
+++ b/java/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/AppResourcesTest.java
@@ -84,7 +84,7 @@ final class AppResourcesTest
 	}
 
 	@Test
-	void testStatusMap() throws Exception
+	void testStatusMap()
 	{
 		DbKey appId = DbKey.createDbKey(151615L);
 		int pid = 12345;

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/CompLockDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/CompLockDao.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.OpenDcsDao;
 import org.opendcs.database.api.OpenDcsDataException;
-import org.opendcs.utils.FailableResult;
+import org.opendcs.util.Result;
 
 import decodes.sql.DbKey;
 import decodes.tsdb.CompAppInfo;
@@ -52,7 +52,7 @@ public interface CompLockDao extends OpenDcsDao
      * @return
      * @throws OpenDcsDataException
      */
-    FailableResult<TsdbCompLock,LockBusyException> obtainLock(DataTransaction tx, CompAppInfo appInfo, int pid, String host) throws OpenDcsDataException;
+    Result<TsdbCompLock,LockBusyException> obtainLock(DataTransaction tx, CompAppInfo appInfo, int pid, String host) throws OpenDcsDataException;
 
     /**
      * Release the given lock.
@@ -71,7 +71,7 @@ public interface CompLockDao extends OpenDcsDao
      * updated from the database regardless of weather or not the heartbeat or status was updated.
      * @throws OpenDcsDataException
      */
-    FailableResult<TsdbCompLock,LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException;
+    Result<TsdbCompLock,LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException;
 
     /**
      * Retrieve all current app locks.

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/CompLockDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/CompLockDao.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2026 OpenDCS Consortium and its Contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.opendcs.database.dai;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.opendcs.database.api.DataTransaction;
+import org.opendcs.database.api.OpenDcsDao;
+import org.opendcs.database.api.OpenDcsDataException;
+import org.opendcs.utils.FailableResult;
+
+import decodes.sql.DbKey;
+import decodes.tsdb.CompAppInfo;
+import decodes.tsdb.LockBusyException;
+import decodes.tsdb.TsdbCompLock;
+
+public interface CompLockDao extends OpenDcsDao
+{
+
+    /**
+     * Retrieve the current lock, if any, for the given app id.
+     * @param tx
+     * @param appId
+     * @return
+     * @throws OpenDcsDataException
+     */
+    Optional<TsdbCompLock> getLock(DataTransaction tx, DbKey appId) throws OpenDcsDataException;
+
+    /**
+     * Obtain a specific lock. If the lock already exists, and is not for the same pid and is not stale
+     * LockBusyException will be returned instead of the lock.
+     * 
+     * Otherwise the Lock is returned and know owned by that instance.
+     *
+     * @param tx
+     * @param appInfo
+     * @param pid
+     * @param host
+     * @return
+     * @throws OpenDcsDataException
+     */
+    FailableResult<TsdbCompLock,LockBusyException> obtainLock(DataTransaction tx, CompAppInfo appInfo, int pid, String host) throws OpenDcsDataException;
+
+    /**
+     * Release the given lock.
+     * @param tx
+     * @param lock
+     * @throws OpenDcsDataException
+     */
+    void releaseLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException;
+
+    /**
+     * Check if given Lock (App) is already set
+     * @param tx
+     * @param lock
+     * @return The LockBusyException, with details, if busy, otherwise empty.
+     * @throws OpenDcsDataException
+     */
+    Optional<LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException;
+
+    /**
+     * Retrieve all current app locks.
+     *
+     * @param tx
+     * @param limit
+     * @param offset
+     * @return
+     * @throws OpenDcsDataException
+     */
+    List<TsdbCompLock> getAll(DataTransaction tx, int limit, int offset) throws OpenDcsDataException;
+}

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/CompLockDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/CompLockDao.java
@@ -63,13 +63,15 @@ public interface CompLockDao extends OpenDcsDao
     void releaseLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException;
 
     /**
-     * Check if given Lock (App) is already set
+     * Check if given Lock (App) is already set. If so, update the heartbeat time and status.
+     *
      * @param tx
      * @param lock
-     * @return The LockBusyException, with details, if busy, otherwise empty.
+     * @return The updated Lock, or the reason the attempt at the lock failed. Returned lock is always
+     * updated from the database regardless of weather or not the heartbeat or status was updated.
      * @throws OpenDcsDataException
      */
-    Optional<LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException;
+    FailableResult<TsdbCompLock,LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException;
 
     /**
      * Retrieve all current app locks.

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/CompLockDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/CompLockDao.java
@@ -42,8 +42,8 @@ public interface CompLockDao extends OpenDcsDao
     /**
      * Obtain a specific lock. If the lock already exists, and is not for the same pid and is not stale
      * LockBusyException will be returned instead of the lock.
-     * 
-     * Otherwise the Lock is returned and know owned by that instance.
+     *
+     * Otherwise the Lock is returned and now owned by that instance.
      *
      * @param tx
      * @param appInfo

--- a/java/opendcs/src/main/java/org/opendcs/database/dai/CompLockDao.java
+++ b/java/opendcs/src/main/java/org/opendcs/database/dai/CompLockDao.java
@@ -68,7 +68,7 @@ public interface CompLockDao extends OpenDcsDao
      * @param tx
      * @param lock
      * @return The updated Lock, or the reason the attempt at the lock failed. Returned lock is always
-     * updated from the database regardless of weather or not the heartbeat or status was updated.
+     * updated from the database regardless of whether or not the heartbeat or status was updated.
      * @throws OpenDcsDataException
      */
     Result<TsdbCompLock,LockBusyException> checkLock(DataTransaction tx, TsdbCompLock lock) throws OpenDcsDataException;


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #1882. 

## Solution

Implement CompLock operations in stateless DAO.
Return `Result` over throwing an exception. Point of usage can throw the exception if needed.
NOTE: copy the implementation directly from the existing LoadingAppDao, could likely share the logic, but don't see the point as once the new one is used everywhere we'll just delete it.

## how you tested the change

Existing tests of REST API
New integration test.


## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
