### PR TITLE
Fix/Adding a decoding script crashes the script editor

### DIFF
--- a/javascript/opendcs-web-ui-react/src/pages/decodes/configs/DecodesScriptEditor.stories.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/decodes/configs/DecodesScriptEditor.stories.tsx
@@ -114,6 +114,39 @@ export const WithScriptInEdit: Story = {
   render: WithDecodedMessage,
 };
 
+/**
+ * The scripts table's "add" hands the editor a stub built from just a name, so
+ * every field the editor needs is missing. That used to leave formatStatements
+ * undefined and DataTables threw "Cannot read properties of undefined" on mount,
+ * taking the whole editor down.
+ */
+export const FromNameOnlyStub: Story = {
+  args: {
+    ...Default.args,
+    script: { name: "script_1" },
+  },
+  play: async ({ mount, parameters, canvasElement }) => {
+    const canvas = await mount();
+    const { i18n } = parameters;
+
+    // Renders at all (it used to throw during the mount effect) and starts with
+    // one statement row, since new rows can only be added from an existing row.
+    await expect(
+      await canvas.findByRole("textbox", {
+        name: i18n.t("decodes:script_editor.format_statements.label_input", {
+          sequence: 1,
+        }),
+      }),
+    ).toBeInTheDocument();
+
+    // The defaults still apply to the fields the stub didn't carry. Queried by
+    // id rather than accessible name so the assertion doesn't ride on a
+    // translation string.
+    const headerType = canvasElement.querySelector<HTMLSelectElement>("#headerType");
+    await expect(headerType).toHaveValue("other");
+  },
+};
+
 export const CreateFromEmpty: Story = {
   args: {
     ...Default.args,

--- a/javascript/opendcs-web-ui-react/src/pages/decodes/configs/DecodesScriptEditor.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/decodes/configs/DecodesScriptEditor.tsx
@@ -35,17 +35,24 @@ export const DecodesScriptEditor: React.FC<DecodesScriptEditorProperties> = ({
   const { t } = useTranslation(["decodes"]);
   const [localScript, dispatch] = useReducer(
     decodesScriptReducer,
-    script || {
-      // setup some sane defaults
-      dataOrder: ApiConfigScriptDataOrderEnum.U,
-      headerType: "other",
-      formatStatements: [{ sequenceNum: 1 }],
-      scriptSensors: sensors.map((cs) => {
-        return {
-          sensorNumber: cs.sensorNumber,
-          unitConverter: { algorithm: "none", fromAbbr: "raw", toAbbr: "raw" },
-        } as ApiConfigScriptSensor;
-      }),
+    script,
+    (incoming?: Partial<ApiConfigScript>): ApiConfigScript => {
+      const merged: ApiConfigScript = {
+        // setup some sane defaults
+        dataOrder: ApiConfigScriptDataOrderEnum.U,
+        headerType: "other",
+        scriptSensors: sensors.map((cs) => {
+          return {
+            sensorNumber: cs.sensorNumber,
+            unitConverter: { algorithm: "none", fromAbbr: "raw", toAbbr: "raw" },
+          } as ApiConfigScriptSensor;
+        }),
+        ...incoming,
+      };
+      if (!merged.formatStatements?.length) {
+        merged.formatStatements = [{ sequenceNum: 1 }];
+      }
+      return merged;
     },
   );
 
@@ -91,7 +98,7 @@ export const DecodesScriptEditor: React.FC<DecodesScriptEditorProperties> = ({
             </Card.Header>
             <Card.Body>
               <ClassicEditor
-                formatStatements={localScript.formatStatements!} // The default local script always includes an initial first row
+                formatStatements={localScript.formatStatements}
                 edit={edit}
                 onFormatStatementChange={statementChange}
               />

--- a/javascript/opendcs-web-ui-react/src/pages/decodes/configs/script/ClassicEditor.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/decodes/configs/script/ClassicEditor.tsx
@@ -23,7 +23,8 @@ hljs.registerLanguage("decodes", decodes);
 DataTable.use(DT);
 
 export interface ClassicFormatStatememntEditorProperties {
-  formatStatements: ApiScriptFormatStatement[];
+  /** Optional because callers build scripts incrementally; DataTables throws on undefined. */
+  formatStatements?: ApiScriptFormatStatement[];
   onFormatStatementChange?: (statements: ApiScriptFormatStatement[]) => void;
   edit?: boolean;
 }
@@ -37,7 +38,7 @@ const statementSorter = (a: ApiScriptFormatStatement, b: ApiScriptFormatStatemen
  */
 const ClassicFormatStatementEditor: React.FC<
   ClassicFormatStatememntEditorProperties
-> = ({ formatStatements, edit = false, onFormatStatementChange }) => {
+> = ({ formatStatements = [], edit = false, onFormatStatementChange }) => {
   const { toDom } = useContextWrapper();
   const { t, i18n } = useTranslation(["decodes"]);
   const table = useRef<DataTableRef>(null);


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

Not sure if this is an issue already but adding a decoding script takes down the script editor.  Every newly added script hits this, so a script can only be created if one already exists to copy from.

## Solution

Describe your solution.

ConfigScriptsTable builds a new script from a name and nothing else so the fix is that DecodesScriptEditor merges the incoming script over the defaults instead of choosing one or the other, so a partial script still gets dataOrder, headerType and scriptSensors. Guarantees at least one format statement. 

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

DecodesScriptEditor -> FromNameOnlyStub tries and reproduces it with a script stub carrying only a name and asserts. The editor renders a statement row and applies the defaults it was missing.
## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
