### PR TITLE
Configure Vite allowed hosts through the environment

### DIFF
--- a/javascript/opendcs-web-ui-react/README.md
+++ b/javascript/opendcs-web-ui-react/README.md
@@ -22,6 +22,26 @@ This will start an instance with "permanent" data. `--build` will be required if
 
 the vite.config.js current assumes localhost:7000, setup accordingly or improve the environment usage of the config.
 
+## Development server hosts
+
+Set `DEV_ALLOWED_HOSTS` in the environment that starts Vite to allow additional
+hostnames, such as a workspace hostname behind a reverse proxy. For a development
+Docker image, set:
+
+```dockerfile
+ENV DEV_ALLOWED_HOSTS=my-workspace.example.com
+```
+
+The value is a comma-separated list of hostnames without a scheme, port, or path.
+Whitespace and empty entries are ignored. A leading dot, such as `.example.com`,
+allows that domain and all its subdomains. Use only domains you control or trust.
+When unset or empty, Vite keeps its default host allowance.
+
+The variable is read from the process environment when Vite starts; setting it in
+`.env.local` alone does not configure the allowed hosts. Restart Vite after changing
+the value. It is not exposed to browser code and does not configure the production
+web server.
+
 ## Formatting
 
 `npm install` will setup a huksy pre-commit hook to run `lint-staged` on commit to ensure formatting remains consistent.

--- a/javascript/opendcs-web-ui-react/vite.config.ts
+++ b/javascript/opendcs-web-ui-react/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
     ],
   },
   server: {
+    allowedHosts: [".apps.hecdev.net"],
     fs: {
       // Allow serving files from one level up the project root
       allow: [

--- a/javascript/opendcs-web-ui-react/vite.config.ts
+++ b/javascript/opendcs-web-ui-react/vite.config.ts
@@ -31,7 +31,10 @@ export default defineConfig({
     ],
   },
   server: {
-    allowedHosts: [".apps.hecdev.net"],
+    allowedHosts: (process.env.DEV_ALLOWED_HOSTS ?? "")
+      .split(",")
+      .map((host) => host.trim())
+      .filter(Boolean),
     fs: {
       // Allow serving files from one level up the project root
       allow: [


### PR DESCRIPTION
## Summary
Configure Vite development-server allowed hosts through the `DEV_ALLOWED_HOSTS` process environment variable instead of a hardcoded organizational domain. Docker images or workspace environments can supply a comma-separated list of hostnames; whitespace and empty entries are ignored, and an unset or empty value preserves Vite defaults.

Document the Dockerfile setting, domain suffix matching, and restart behavior in the UI README. The variable is not exposed to browser code and does not configure the production web server.

## Validation
- Passed six environment-value cases using the allowedHosts expression extracted from the changed config with Vite 7.3.6 in an isolated server fixture: unset, empty, whitespace-only, exact host, multiple hosts, and domain suffix.
- Live HTTP checks confirmed configured hosts and localhost are accepted and unrelated hosts are rejected.
- Prettier checks passed for both changed files; `git diff --check` passed.
- Full application build and Docker-image integration were not run.
