### PR TITLE
Fix/inconsistent page loads

### DIFF
--- a/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsPlatformDaoTestIT.java
+++ b/integrationtesting/opendcs-tests/src/test/java/org/opendcs/dao/opendcs/OpenDcsPlatformDaoTestIT.java
@@ -6,6 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.database.dai.DecodesConfigDao;
@@ -20,6 +26,8 @@ import decodes.db.Platform;
 import decodes.db.PlatformSensor;
 import decodes.db.SiteName;
 import decodes.db.TransportMedium;
+import decodes.sql.DbKey;
+import decodes.util.DecodesSettings;
 
 @EnableIfTsDb({"OpenDCS-Postgres", "OpenDCS-Oracle", "CWMS-Oracle"})
 @DecodesConfigurationRequired({
@@ -127,5 +135,55 @@ class OpenDcsPlatformDaoTestIT extends AppTestBase
             assertNotNull(platforms.get(0).getSite());
             assertTrue(platforms.get(0).platformSensors.isEmpty());
         }
+    }
+
+    /**
+     * The site names joined onto each platform used to come back in whatever order the
+     * database happened to produce. Site#getPreferredName() - and the web UI - fall back to
+     * the <em>first</em> name when the preferred type isn't defined, so an unordered join made
+     * the displayed platform name flip between name types from one page load to the next
+     * (issue #2052). Verify the order is stable and preference-first instead.
+     */
+    @Test
+    void test_site_names_ordered_consistently() throws Exception
+    {
+        var dao = db.getDao(PlatformDao.class).orElseThrow();
+
+        try (var tx = db.newTransaction())
+        {
+            var first = namesOfPlatformsWithSites(dao.getAll(tx, -1, -1, false));
+            var second = namesOfPlatformsWithSites(dao.getAll(tx, -1, -1, false));
+            assertFalse(first.isEmpty(), "No platform with a site was returned.");
+            assertEquals(first, second, "Site name order changed between identical queries.");
+
+            var preferred = DecodesSettings.instance().siteNameTypePreference;
+            first.forEach((platformId, nameTypes) ->
+                    assertTrue(!nameTypes.contains(preferred) || preferred.equalsIgnoreCase(nameTypes.get(0)),
+                            () -> String.format("Platform %s has a %s name but it wasn't first: %s",
+                                    platformId, preferred, nameTypes)));
+        }
+    }
+
+    /** Platform id -> the site's name types, in the order the query returned them. */
+    private static Map<DbKey, List<String>> namesOfPlatformsWithSites(List<Platform> platforms)
+    {
+        Map<DbKey, List<String>> byPlatform = new LinkedHashMap<>();
+        for (Platform p : platforms)
+        {
+            if (p.getSite() == null)
+            {
+                continue;
+            }
+            List<String> nameTypes = new ArrayList<>();
+            for (Iterator<SiteName> it = p.getSite().getNames(); it.hasNext(); )
+            {
+                nameTypes.add(it.next().getNameType());
+            }
+            if (!nameTypes.isEmpty())
+            {
+                byPlatform.put(p.getId(), nameTypes);
+            }
+        }
+        return byPlatform;
     }
 }

--- a/java/cwms-implementation/src/main/resources/org/opendcs/database/impl/cwms/dao/CwmsPlatformDaoImpl.sql.stg
+++ b/java/cwms-implementation/src/main/resources/org/opendcs/database/impl/cwms/dao/CwmsPlatformDaoImpl.sql.stg
@@ -51,7 +51,11 @@ with platforms(id, agency, isproduction, description, lastmodifytime, configid, 
     <if(platform_sensor_join)><platform_sensor_join><endif>
     <if(platform_sensor_props_join)><platform_sensor_props_join><endif>
 
-    order by p.mediumtype <collate> asc, p.mediumid <collate> asc, p.platformdesignator <collate> asc
+    order by p.mediumtype <collate> asc, p.mediumid <collate> asc, p.platformdesignator <collate> asc<if(site_name_columns)>,
+        case
+            when lower(sn.nametype) = lower(:preferredType) then 0
+            else 1
+        end, sn.nametype <collate> asc, sn.sitename <collate> asc<endif>
 >>
 
 platformMerge(dual) ::= <<

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/PlatformDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/PlatformDaoImpl.java
@@ -22,6 +22,7 @@ import org.opendcs.database.api.DataTransaction;
 import org.opendcs.database.api.DatabaseEngine;
 import org.opendcs.database.api.OpenDcsDataException;
 import org.opendcs.database.api.OpenDcsDataRuntimeException;
+import org.opendcs.database.api.TransactionContext;
 import org.opendcs.database.dai.DecodesConfigDao;
 import org.opendcs.database.dai.EquipmentModelDao;
 import org.opendcs.database.dai.PlatformDao;
@@ -53,6 +54,7 @@ import decodes.db.Site;
 import decodes.db.TransportMedium;
 import decodes.sql.DbKey;
 import decodes.sql.KeyGenerator;
+import decodes.util.DecodesSettings;
 
 
 @ServiceProviders({
@@ -65,6 +67,8 @@ public class PlatformDaoImpl implements PlatformDao
     private static final Logger log = OpenDcsLoggerFactory.getLogger();
 
     private static final String SELECT = "select";
+    private static final String PREFERRED_TYPE = "preferredType";
+    private static final String DEFAULT_PREFERRED_TYPE = "CWMS";
     private static final String MERGE = "platformMerge";
     private static final String DELETE_PLATFORM = "deletePlatform";
     private static final String DELETE_PROPERTIES = "deleteProperties";
@@ -156,6 +160,7 @@ public class PlatformDaoImpl implements PlatformDao
         try (var select = handle.createQuery(setDefines(selectTemplate, dbEngine, allData)))
         {
             registerMappers(select, allData);
+            bindPreferredType(select, ctx, allData);
             return select.bind(PlatformMapper.Columns.ID.column(), id)
                          .reduceRows(new PlatformReducer(allData.platformMapper, allData.siteReducer(),
                                                          allData.platformSensorReducer()))
@@ -213,6 +218,7 @@ public class PlatformDaoImpl implements PlatformDao
         {
             registerMappers(select, allData);
 
+            bindPreferredType(select, ctx, allData);
             return select.bind("mediumtype", mediumType)
                          .bind("mediumid", mediumId)
                          .reduceRows(new PlatformReducer(allData.platformMapper, allData.siteReducer(),
@@ -257,6 +263,26 @@ public class PlatformDaoImpl implements PlatformDao
             ;
         }
         return select;
+    }
+
+    /**
+     * The site name rows joined onto each platform have no inherent order, so without an explicit
+     * sort the database is free to hand them back differently from one execution to the next. Both
+     * {@link decodes.db.Site#getPreferredName()} and the web UI fall back to the <em>first</em> name
+     * when the preferred type isn't defined for a site, so an unordered join makes the displayed
+     * platform name flip between name types. Mirrors {@code OpenDcsSiteDaoImpl}, which sorts the
+     * preferred type first and then by name type.
+     */
+    private static void bindPreferredType(Query select, TransactionContext ctx, Mappers mappers)
+    {
+        // Mirrors the template's <if(site_name_columns)> guard on the order-by clause. JDBI
+        // rejects a binding the statement never references, so the two must stay in step.
+        if (mappers.siteMapper() != null)
+        {
+            select.bind(PREFERRED_TYPE, ctx.getSettings(DecodesSettings.class)
+                                           .map(ds -> ds.siteNameTypePreference)
+                                           .orElse(DEFAULT_PREFERRED_TYPE));
+        }
     }
 
     private static String setDefines(ST select, DatabaseEngine dbEngine, Mappers mappers)
@@ -490,6 +516,7 @@ public class PlatformDaoImpl implements PlatformDao
         try (var select = handle.createQuery(setDefines(selectTemplate, dbEngine, mappers)))
         {
             registerMappers(select, mappers);
+            bindPreferredType(select, ctx, mappers);
             if (mediumType != null && !mediumType.isBlank())
             {
                 select.bind("mediumtype", mediumType);

--- a/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/PlatformDaoImpl.java
+++ b/java/opendcs-implementation/src/main/java/org/opendcs/database/impl/opendcs/dao/PlatformDaoImpl.java
@@ -275,8 +275,9 @@ public class PlatformDaoImpl implements PlatformDao
      */
     private static void bindPreferredType(Query select, TransactionContext ctx, Mappers mappers)
     {
-        // Mirrors the template's <if(site_name_columns)> guard on the order-by clause. JDBI
-        // rejects a binding the statement never references, so the two must stay in step.
+        // Mirrors the <if(site_name_columns)> guard on the order-by clause in both this DAO's
+        // template and CwmsPlatformDaoImpl.sql.stg. JDBI rejects a binding the statement never
+        // references, so every select template used with this DAO must declare :preferredType.
         if (mappers.siteMapper() != null)
         {
             select.bind(PREFERRED_TYPE, ctx.getSettings(DecodesSettings.class)

--- a/java/opendcs-implementation/src/main/resources/org/opendcs/database/impl/opendcs/dao/PlatformDaoImpl.sql.stg
+++ b/java/opendcs-implementation/src/main/resources/org/opendcs/database/impl/opendcs/dao/PlatformDaoImpl.sql.stg
@@ -33,7 +33,11 @@ with platforms(id, agency, isproduction, description, lastmodifytime, configid, 
     <if(platform_sensor_join)><platform_sensor_join><endif>
     <if(platform_sensor_props_join)><platform_sensor_props_join><endif>
 
-    order by p.mediumtype <collate> asc, p.mediumid <collate> asc, p.platformdesignator <collate> asc
+    order by p.mediumtype <collate> asc, p.mediumid <collate> asc, p.platformdesignator <collate> asc<if(site_name_columns)>,
+        case
+            when lower(sn.nametype) = lower(:preferredType) then 0
+            else 1
+        end, sn.nametype <collate> asc, sn.sitename <collate> asc<endif>
 >>
 
 platformMerge(dual) ::= <<

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsSqlDatabaseIO.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsSqlDatabaseIO.java
@@ -59,8 +59,8 @@ public class CwmsSqlDatabaseIO extends SqlDatabaseIO
 		this.dbOfficeId = settings.CwmsOfficeId;
         writeDateFmt = new SimpleDateFormat(
 			"'to_date'(''dd-MMM-yyyy HH:mm:ss''',' '''DD-MON-YYYY HH24:MI:SS''')");
-		DecodesSettings.instance().sqlTimeZone = "GMT";
-        writeDateFmt.setTimeZone(TimeZone.getTimeZone(DecodesSettings.instance().sqlTimeZone));
+		settings.sqlTimeZone = "GMT";
+        writeDateFmt.setTimeZone(TimeZone.getTimeZone(settings.sqlTimeZone));
 
 		/* 
 		 * Oracle does not require a COMMIT after each block of nested SELECTs.

--- a/java/opendcs/src/main/java/decodes/cwms/CwmsSqlDatabaseIO.java
+++ b/java/opendcs/src/main/java/decodes/cwms/CwmsSqlDatabaseIO.java
@@ -59,8 +59,8 @@ public class CwmsSqlDatabaseIO extends SqlDatabaseIO
 		this.dbOfficeId = settings.CwmsOfficeId;
         writeDateFmt = new SimpleDateFormat(
 			"'to_date'(''dd-MMM-yyyy HH:mm:ss''',' '''DD-MON-YYYY HH24:MI:SS''')");
-		settings.sqlTimeZone = "GMT";
-        writeDateFmt.setTimeZone(TimeZone.getTimeZone(settings.sqlTimeZone));
+		DecodesSettings.instance().sqlTimeZone = "GMT";
+        writeDateFmt.setTimeZone(TimeZone.getTimeZone(DecodesSettings.instance().sqlTimeZone));
 
 		/* 
 		 * Oracle does not require a COMMIT after each block of nested SELECTs.

--- a/javascript/opendcs-web-ui-react/src/components/data-table/AppDataTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/components/data-table/AppDataTable.tsx
@@ -326,33 +326,39 @@ type DtRowApi = {
 
 /** Build the DataTables `render` function for a column, accounting for the
  *  mode-aware edit swap. Returns `undefined` if the column needs no custom
- *  render. */
+ *  render.
+ *
+ *  The returned closure looks its column up through `columnsRef` on every call
+ *  rather than capturing it. DataTables keeps the render functions it was given
+ *  at init, so a captured `col` would freeze the markup a cell was first built
+ *  with - including the degraded markup an `edit.render` emits while its
+ *  reference data is still loading (issue #2052). Reading through the ref means
+ *  a redraw picks up whatever the caller has rebuilt `columns` into. */
 function makeColumnRender<T>(
-  col: ColumnDef<T>,
+  index: number,
+  columnsRef: { readonly current: ColumnDef<T>[] },
   hasInlineEdit: boolean,
   idOf: (row: T) => string,
   rowStateRef: { readonly current: Record<string, RowMode> },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): ((data: any, type: string, row: T, meta: any) => any) | undefined {
-  const baseRender = col.render;
-  const editRender = col.edit?.render;
-  const needsWrapper = Boolean(baseRender || (hasInlineEdit && editRender));
+  const initial = columnsRef.current[index];
+  const needsWrapper = Boolean(
+    initial.render || (hasInlineEdit && initial.edit?.render),
+  );
   if (!needsWrapper) return undefined;
-  const fallback = (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data: any,
-    type: string,
-    row: T,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    meta: any,
-  ) => (baseRender ? baseRender(data, type, row, meta) : (data ?? ""));
   return (data, type, row, meta) => {
-    if (type !== "display") return fallback(data, type, row, meta);
+    const col = columnsRef.current[index] ?? initial;
+    const baseRender = col.render;
+    const fallback = () =>
+      baseRender ? baseRender(data, type, row, meta) : (data ?? "");
+    if (type !== "display") return fallback();
+    const editRender = col.edit?.render;
     if (hasInlineEdit && editRender) {
       const mode = rowStateRef.current[idOf(row)];
       if (mode === "edit" || mode === "new") return editRender(row, idOf(row));
     }
-    return fallback(data, type, row, meta);
+    return fallback();
   };
 }
 
@@ -817,15 +823,22 @@ export function AppDataTable<T, TId extends string | number, TSave = T>(
 
   const hasInlineEdit = Boolean(inlineEdit);
 
+  // Stable ref so the render closures handed to DataTables at init always see
+  // the caller's latest column definitions. Assigned during render rather than
+  // in an effect because the `dtColumns` memo below reads it synchronously.
+  const columnsRef = useRef(columns);
+  // eslint-disable-next-line react-hooks/refs
+  columnsRef.current = columns;
+
   // --- DataTable column definitions (+ optional Actions column) ------------
   // When inlineEdit is enabled, wrap each column's render to swap to the
   // `edit.render` output when the row is in "edit" / "new" mode.
   const dtColumns = useMemo(() => {
-    // makeColumnRender stores rowStateRef in the returned render closure,
-    // which DataTables invokes later during its own cell rendering, not
-    // synchronously here.
+    // makeColumnRender stores rowStateRef / columnsRef in the returned render
+    // closure, which DataTables invokes later during its own cell rendering,
+    // not synchronously here.
     // eslint-disable-next-line react-hooks/refs
-    const cols = columns.map((c) => ({
+    const cols = columns.map((c, i) => ({
       data: c.data,
       defaultContent: c.defaultContent ?? "",
       className: c.className,
@@ -833,7 +846,7 @@ export function AppDataTable<T, TId extends string | number, TSave = T>(
       orderable: c.orderable,
       searchable: c.searchable,
       type: c.type,
-      render: makeColumnRender(c, hasInlineEdit, idOf, rowStateRef),
+      render: makeColumnRender(i, columnsRef, hasInlineEdit, idOf, rowStateRef),
     }));
     if (hasActionsCol) {
       cols.push({
@@ -1096,6 +1109,29 @@ export function AppDataTable<T, TId extends string | number, TSave = T>(
     }
     dt.draw(false);
   }, [rowState, hasInlineEdit]);
+
+  // --- Re-render open edit cells when the column definitions change ---------
+  // `edit.render` produces a one-shot HTML string, so a cell built while its
+  // reference data was still loading keeps the degraded markup it was given
+  // (a text box instead of a dropdown, a dropdown missing most of its
+  // options). Callers rebuild `columns` when that data arrives; invalidate and
+  // redraw so open rows pick the new markup up instead of staying stale until
+  // the user cancels and re-opens the row (issue #2052). Read-only tables are
+  // excluded, since they have no edit markup to refresh.
+  const columnsInitRef = useRef(false);
+  useEffect(() => {
+    if (!hasInlineEdit) return;
+    if (!columnsInitRef.current) {
+      columnsInitRef.current = true;
+      return; // first draw already used the current columns
+    }
+    const dt = table.current?.dt();
+    if (!dt) return;
+    (dt as unknown as { rows: () => { invalidate: () => unknown } })
+      .rows()
+      .invalidate();
+    dt.draw(false);
+  }, [dtColumns, hasInlineEdit]);
 
   // --- Confirmation dialog for `confirm`-flagged row actions ----------------
   const handleConfirmAccept = useCallback(() => {

--- a/javascript/opendcs-web-ui-react/src/pages/decodes/presentations/PresentationElementsTable.tsx
+++ b/javascript/opendcs-web-ui-react/src/pages/decodes/presentations/PresentationElementsTable.tsx
@@ -34,7 +34,7 @@ export const PresentationElementsTable: React.FC<
 > = ({ elements, edit = false, onSave, onRemove }) => {
   const [t] = useTranslation(["presentations", "translation"]);
   const { isSuccess: unitsReady } = useUnitListQuery();
-  const { data: dataTypes = [] } = useDataTypeListQuery();
+  const { data: dataTypes = [], isSuccess: dataTypesReady } = useDataTypeListQuery();
   const queryClient = useQueryClient();
 
   const dataTypeStandards = useMemo(() => {
@@ -57,26 +57,42 @@ export const PresentationElementsTable: React.FC<
         type: "string",
         defaultContent: "",
         edit: {
+          // Until the data type list resolves, `dataTypeStandards` holds only the
+          // standards already used by the rows on screen - often just one. Offering
+          // that as a complete dropdown hides the real choices, so fall back to a
+          // free-text box (as the units column does) rather than a truncated select.
           render: (row, rowId) =>
-            renderToString(
-              <Form.Select
-                name="dataTypeStd"
-                defaultValue={row.dataTypeStd ?? ""}
-                aria-label={t("presentations:elements.dataTypeStd_input", {
-                  name: elementDisplayName(row, rowId),
-                })}
-              >
-                <option value="" />
-                {dataTypeStandards.map((std) => (
-                  <option key={std} value={std}>
-                    {std}
-                  </option>
-                ))}
-              </Form.Select>,
-            ),
+            dataTypesReady
+              ? renderToString(
+                  <Form.Select
+                    name="dataTypeStd"
+                    defaultValue={row.dataTypeStd ?? ""}
+                    aria-label={t("presentations:elements.dataTypeStd_input", {
+                      name: elementDisplayName(row, rowId),
+                    })}
+                  >
+                    <option value="" />
+                    {dataTypeStandards.map((std) => (
+                      <option key={std} value={std}>
+                        {std}
+                      </option>
+                    ))}
+                  </Form.Select>,
+                )
+              : renderToString(
+                  <Form.Control
+                    type="text"
+                    name="dataTypeStd"
+                    defaultValue={row.dataTypeStd ?? ""}
+                    aria-label={t("presentations:elements.dataTypeStd_input", {
+                      name: elementDisplayName(row, rowId),
+                    })}
+                  />,
+                ),
           read: (cell) =>
-            cell.querySelector<HTMLSelectElement>('select[name="dataTypeStd"]')
-              ?.value ?? "",
+            cell.querySelector<HTMLSelectElement | HTMLInputElement>(
+              'select[name="dataTypeStd"], input[name="dataTypeStd"]',
+            )?.value ?? "",
         },
       },
       {
@@ -215,7 +231,7 @@ export const PresentationElementsTable: React.FC<
         },
       },
     ],
-    [t, dataTypeStandards, unitsReady, queryClient],
+    [t, dataTypeStandards, dataTypesReady, unitsReady, queryClient],
   );
 
   return (

--- a/javascript/opendcs-web-ui-react/src/queries/cachePolicy.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/cachePolicy.ts
@@ -1,0 +1,17 @@
+/**
+ * Cache policy for reference data - units, data types, intervals, ref lists,
+ * orgs. These are small, effectively static per org, and feed the dropdowns
+ * that every editor renders.
+ *
+ * `gcTime` must be at least as long as `staleTime`: it is measured from the
+ * moment the last observer unmounts, so a shorter `gcTime` silently evicts data
+ * the query still considers fresh. With the QueryClient default of 5 minutes,
+ * navigating away from a page for longer than that dropped these lists, and the
+ * consumers that fall back when the data is missing (UnitSelect renders a plain
+ * text box, the data-type-standard select renders a short option list) came back
+ * degraded on the next visit - see issue #2052.
+ */
+export const REFERENCE_DATA_CACHE = {
+  staleTime: 60 * 60_000,
+  gcTime: 60 * 60_000,
+} as const;

--- a/javascript/opendcs-web-ui-react/src/queries/dataTypes.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/dataTypes.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { RESTDataTypeMethodsApi, type ApiDataType } from "opendcs-api";
 import { useApi } from "../contexts/app/ApiContext";
 import { dataTypeKeys } from "./keys";
+import { REFERENCE_DATA_CACHE } from "./cachePolicy";
 
 const useDataTypesApi = () => {
   const api = useApi();
@@ -15,6 +16,6 @@ export const useDataTypeListQuery = () => {
   return useQuery<ApiDataType[]>({
     queryKey: dataTypeKeys.list(org),
     queryFn: () => dataTypesApi.getDataTypeList(org),
-    staleTime: 60 * 60_000,
+    ...REFERENCE_DATA_CACHE,
   });
 };

--- a/javascript/opendcs-web-ui-react/src/queries/intervals.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/intervals.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { TimeSeriesMethodsIntervalMethodsApi, type ApiInterval } from "opendcs-api";
 import { useApi } from "../contexts/app/ApiContext";
 import { intervalKeys } from "./keys";
+import { REFERENCE_DATA_CACHE } from "./cachePolicy";
 
 const useIntervalsApi = () => {
   const api = useApi();
@@ -19,6 +20,6 @@ export const useIntervalsQuery = () => {
   return useQuery<ApiInterval[]>({
     queryKey: intervalKeys.list(org),
     queryFn: () => intervalApi.getIntervals(org),
-    staleTime: 60 * 60_000,
+    ...REFERENCE_DATA_CACHE,
   });
 };

--- a/javascript/opendcs-web-ui-react/src/queries/orgs.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/orgs.ts
@@ -6,6 +6,7 @@ import {
 } from "opendcs-api";
 import { useApi } from "../contexts/app/ApiContext";
 import { orgKeys } from "./keys";
+import { REFERENCE_DATA_CACHE } from "./cachePolicy";
 
 // The org list is global (passes "" as the org header) — it's the input to
 // the org switcher itself, so it must not be scoped by current org.
@@ -21,6 +22,6 @@ export const useOrganizationsQuery = () => {
       const res = await authApi.getOrganizationsWithHttpInfo("");
       return res.data as ApiOrganization[];
     },
-    staleTime: 60 * 60_000,
+    ...REFERENCE_DATA_CACHE,
   });
 };

--- a/javascript/opendcs-web-ui-react/src/queries/refLists.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/refLists.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { RESTReferenceListsApi, type ApiRefList } from "opendcs-api";
 import { useApi } from "../contexts/app/ApiContext";
 import { refListKeys } from "./keys";
+import { REFERENCE_DATA_CACHE } from "./cachePolicy";
 
 // Ref lists are a per-org map (e.g. SiteNameType, TransportMediumType). Loaded
 // once per org and shared across every consumer via the shared QueryClient
@@ -14,6 +15,6 @@ export const useRefListsQuery = () => {
     queryKey: refListKeys.list(api.org),
     queryFn: () => refListApi.getRefLists(api.org),
     // Reference lists rarely change within a session; keep them in cache long.
-    staleTime: 60 * 60_000,
+    ...REFERENCE_DATA_CACHE,
   });
 };

--- a/javascript/opendcs-web-ui-react/src/queries/units.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/units.ts
@@ -7,6 +7,7 @@ import {
 } from "opendcs-api";
 import { useApi } from "../contexts/app/ApiContext";
 import { unitKeys } from "./keys";
+import { REFERENCE_DATA_CACHE } from "./cachePolicy";
 
 const useUnitsApi = () => {
   const api = useApi();
@@ -22,7 +23,7 @@ export const useUnitListQuery = () => {
   return useQuery<Record<number, ApiUnit>>({
     queryKey: unitKeys.list(org),
     queryFn: () => unitsApi.getUnitList(org),
-    staleTime: 60 * 60_000,
+    ...REFERENCE_DATA_CACHE,
   });
 };
 
@@ -31,6 +32,6 @@ export const useUnitConversionsQuery = () => {
   return useQuery<ApiUnitConverter[]>({
     queryKey: unitKeys.conversions(org),
     queryFn: () => unitsApi.getUnitConvList(org),
-    staleTime: 60 * 60_000,
+    ...REFERENCE_DATA_CACHE,
   });
 };

--- a/javascript/opendcs-web-ui-react/src/queries/version.ts
+++ b/javascript/opendcs-web-ui-react/src/queries/version.ts
@@ -17,4 +17,6 @@ export const useVersionQuery = () =>
     queryKey: versionKeys.all(),
     queryFn: fetchVersion,
     staleTime: Infinity,
+    // Never evict: the deployed build can't change without a page reload.
+    gcTime: Infinity,
   });


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #2052. 

<!-- if you are referencing a specific issue a problem description is not required -->
Describe the problem you are trying to solve.

## Solution

Describe your solution.

* `PlatformDaoImpl.sql.stg` will order the site-name rows by preferred-type-first. This makes both the `sitenames` map order and the server-computed `name` field stable.
* `REFERENCE_DATA_CACHE` sets `gcTime >= staleTime` and is applied to the reference-data queries.
* `AppDataTable` has a column render fix so "edit" cells pick up the reference data that will arrive after the row is opened.

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

* Added integration test 
* On the platforms page, reloaded repeatedly on a site with a lot of name types and confirmed the Site column no longer changes name type between loads. 
* Presentation Groups -> edit a group -> edit an element: Units renders as a
   `<select>` with the full unit list 

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
